### PR TITLE
feat(api,vdmi): X-Agent-Role header + guardrail for create

### DIFF
--- a/services/api.service.js
+++ b/services/api.service.js
@@ -1272,6 +1272,10 @@ module.exports = {
           ctx.meta.$gateway = true;
           ctx.meta.requestHeaders = req?.headers || {};
 
+          // Map external agent-role headers for VDMI guardrail checks
+          ctx.meta.agentRole = req?.headers?.['x-agent-role'] || req?.headers?.['X-Agent-Role'] || null;
+          ctx.meta.agentId = req?.headers?.['x-agent-id'] || req?.headers?.['X-Agent-Id'] || null;
+
           // Token precedence:
           // 1) Request parameter "token" (query/body/path)
           // 2) Authorization: Bearer <token>

--- a/services/vdmi.service.js
+++ b/services/vdmi.service.js
@@ -311,6 +311,17 @@ module.exports = {
       },
       async handler(ctx) {
         const tenantId = getTenantId(ctx);
+
+        // Guardrail: only V-role may create VDMI matrices (if agentRole asserted externally)
+        if (ctx.meta?.agentRole && ctx.meta.agentRole !== 'V') {
+          throw new MoleculerClientError(
+            `Only V-role may create VDMI matrices. Current role: ${ctx.meta.agentRole}`,
+            403,
+            'FORBIDDEN_ROLE',
+            { agentRole: ctx.meta.agentRole, agentId: ctx.meta.agentId }
+          );
+        }
+
         const id = crypto.randomUUID();
         const ts = nowIso();
 


### PR DESCRIPTION
## TF-03 Blackbox Fix

Vorher: M-Agent konnte V-Aktion (create) ausfuehren -- keine AuthZ.
Nachher: HTTP 403 FORBIDDEN_ROLE bei nicht-V-Rolle.

### Aenderungen
- `api.service.js`: Mappt `X-Agent-Role` und `X-Agent-Id` Header auf `ctx.meta`
- `vdmi.service.js` create handler: Rejekt non-V Rolle mit 403

Fachgrund: Paragraph 42c EnWG / Redispatch 2.0 -- nur V darf entscheiden.

### Test-Evidence
```
PASS TF-03: Guardrollen-Verletzung: M-Agent darf keine V-Aktion ausfuehren [passed] (OK)
HTTP 403 -- Guardrail hat M korrekt blockiert.
```