### PR TITLE
feat(vdmi): add structured actor to audit events

### DIFF
--- a/services/vdmi.service.js
+++ b/services/vdmi.service.js
@@ -1668,9 +1668,16 @@ module.exports = {
       return doc;
     },
 
-    async writeAuditEvent(tenantId, matrixId, action, payload = {}) {
+    async writeAuditEvent(tenantId, matrixId, action, payload = {}, actor = null) {
       const ts = nowIso();
       const id = crypto.randomUUID();
+
+      // Derive actor from explicit param or backward-compat payload fields
+      const resolvedActor = actor || {
+        actorType: payload.actorType || 'user',
+        actorId: payload.actorId || payload.approver || 'system',
+      };
+
       const doc = {
         _id: `${AUDIT_PREFIX}${id}`,
         id,
@@ -1678,6 +1685,7 @@ module.exports = {
         tenantId,
         matrixId,
         action,
+        actor: resolvedActor,
         payload,
         createdAt: ts,
       };


### PR DESCRIPTION
## TF-06 Blackbox Fix

Vorher: Audit-Trail hatte kein Top-Level `actor`-Feld.
Nachher: Jedes Audit-Event enthaelt strukturiertes `actor`-Objekt.

### Aenderungen
- `writeAuditEvent()`: Neuer optionaler `actor`-Parameter
- Backward-compat: Leitet `actor` aus `payload.actorId` / `payload.approver` ab
- Audit-Response (GET /api/vdmi/audit) enthaelt `actor` natuerlich (raw passthrough)

Fachgrund: Paragraph 42c EnWG / BDEW -- Audit muss "Bearbeiter" enthalten.

### Test-Evidence
```
PASS TF-06: Audit-Trail Nachvollziehbarkeit fuer externen Integrator [passed] (OK)
sampleKeys enthaelt "actor", "actorId", "actorType"
```