### PR TITLE
fix(redispatch-expost): TF-08 VDMI tenant context und Task-Feld-Mapping

### DIFF
--- a/services/redispatch-expost.service.js
+++ b/services/redispatch-expost.service.js
@@ -284,11 +284,11 @@ module.exports = {
             const resolvedGridOperatorId = gridOperatorId || report.gridOperator?.mastrId || null;
             let vdmiMatrix = null;
             if (resolvedGridOperatorId) {
-              const vdmiRes = await ctx.call('vdmi.list', {
-                processType: 'redispatch',
-                limit: 1,
-                tenantId: resolvedGridOperatorId,
-              });
+              const vdmiRes = await ctx.call(
+                'vdmi.list',
+                { processType: 'redispatch', limit: 1 },
+                { meta: { tenantId: resolvedGridOperatorId } }
+              );
               vdmiMatrix = vdmiRes.items?.[0] || null;
             }
 
@@ -306,7 +306,7 @@ module.exports = {
                 verantwortlich: t.verantwortlich,
                 durchfuehrend: t.durchfuehrend,
                 mitwirkend: t.mitwirkend,
-                informiert: t.informiert,
+                informiert: t.information,
               })) || null,
               gridOperator: report.gridOperator,
               period: report.period,


### PR DESCRIPTION
## Problem

Der geschärfte Blackbox-Test TF-08 (Redispatch-Sequenz End-to-End mit VDMI-Konsistenz) schlägt mit ARCHITECTURE_GAP fehl:

- `vdmiMatrixId`: null
- `vdmiTasks`: null

## Ursachen

1. **Falscher Tenant-Transport**: `tenantId` wurde als Parameter an `vdmi.list` übergeben, aber der VDMI-Service liest `tenantId` ausschließlich aus `ctx.meta.tenantId` (via `getTenantId(ctx)`). Dadurch wurde immer der Default-Tenant `default` verwendet und keine gridOperator-spezifische VDMI-Matrix gefunden.

2. **Falsches Task-Feld-Mapping**: Das Mapping verwendete `t.informiert`, aber VDMI-Tasks speichern die I-Rolle im Feld `information`. Dadurch waren alle Tasks leer/falsch.

## Fix

- `ctx.call('vdmi.list', ..., { meta: { tenantId: resolvedGridOperatorId } })`
- `informiert: t.information`

## Test-Status

- Statisch/Unit: Syntax OK, keine Lint-Fehler
- Blackbox-TF-08: Erst nach Deploy verifizierbar (kein Server-Start lokal)