### PR TITLE
fix(znp): Gap-7 ZNP Tenant-Isolation

### DIFF
--- a/services/znp.service.js
+++ b/services/znp.service.js
@@ -54,6 +54,7 @@ const { fetchBuildingsForBbox, mapAssetsToBuildings } = require('../src/znp-osm-
 const { detectClusters, computeGFactorAdjustment } = require('../src/znp-clustering-heuristics');
 const { generateStructured, SchemaType } = require('../src/llm-client');
 const { normaliseBoolFlag } = require('../src/redispatch-utils');
+const { getTenantId } = require('../src/tenant-context');
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -220,6 +221,7 @@ module.exports = {
       },
       async handler(ctx) {
         const { bbox, name } = ctx.params;
+        const tenantId = getTenantId(ctx);
         const projectId = crypto.randomUUID();
         const createdAt = new Date().toISOString();
         const projectName = name || `ZNP Project ${projectId.slice(0, 8)}`;
@@ -241,6 +243,7 @@ module.exports = {
           bbox,
           name: projectName,
           createdAt,
+          tenantId,
           layers: [],
           layer1GFactorAdjustment: 1.0, // updated by addLayer1 when clustering is computed
           layer2CalibrationFactor: 0,
@@ -253,6 +256,7 @@ module.exports = {
         const metaDoc = {
           _id: `${DOC_PREFIX_META}${projectId}`,
           projectId,
+          tenantId,
           name: projectName,
           bbox,
           createdAt,
@@ -270,13 +274,14 @@ module.exports = {
         // Persist initial graph state (SUB_1 only) to znp:graph: document
         await this.persistGraph(projectId, graph);
 
-        this.logger.info(`[znp] Created project ${projectId} ("${projectName}")`);
+        this.logger.info(`[znp] Created project ${projectId} ("${projectName}") for tenant ${tenantId}`);
 
         return {
           projectId,
           name: projectName,
           bbox,
           createdAt,
+          tenantId,
           graphStats: { nodes: graph.order, edges: graph.size },
         };
       },
@@ -1569,9 +1574,11 @@ module.exports = {
           offset = 0,
           sortByCapacity = 'desc',
         } = ctx.params;
+        const tenantId = getTenantId(ctx);
 
         await this.ensureProjectHydrated(projectId);
         const { graph } = this.getProject(projectId); // throws 404 if not found
+        this.requireProjectTenant(this.getProject(projectId), tenantId, projectId);
 
         // Collect all mastr_asset nodes (Layer 0 only — excludes assumptions, buildings, etc.)
         const allAssets = [];
@@ -1642,14 +1649,17 @@ module.exports = {
       },
       async handler(ctx) {
         const { projectId } = ctx.params;
+        const tenantId = getTenantId(ctx);
         await this.ensureProjectHydrated(projectId);
         const project = this.getProject(projectId); // throws 404 if not found
+        this.requireProjectTenant(project, tenantId, projectId);
 
         return {
           projectId,
           name: project.name,
           bbox: project.bbox,
           createdAt: project.createdAt,
+          tenantId: project.tenantId,
           layers: project.layers,
           graphStats: {
             nodes: project.graph.order,
@@ -1675,14 +1685,17 @@ module.exports = {
           'As of v0.23, graphs are hydrated from PouchDB on service start, so this list ' +
           'is populated even after a server restart.',
       },
-      handler() {
+      handler(ctx) {
+        const tenantId = getTenantId(ctx);
         const projects = [];
         for (const [projectId, project] of this.activeGraphs.entries()) {
+          if (project.tenantId && project.tenantId !== tenantId) continue;
           projects.push({
             projectId,
             name: project.name,
             bbox: project.bbox,
             createdAt: project.createdAt,
+            tenantId: project.tenantId,
             layers: project.layers,
             graphStats: {
               nodes: project.graph.order,
@@ -1727,6 +1740,7 @@ module.exports = {
       },
       async handler(ctx) {
         const { projectId } = ctx.params;
+        const tenantId = getTenantId(ctx);
 
         // Check that project exists (in-memory)
         if (!this.activeGraphs.has(projectId)) {
@@ -1737,6 +1751,9 @@ module.exports = {
             { projectId }
           );
         }
+
+        const project = this.activeGraphs.get(projectId);
+        this.requireProjectTenant(project, tenantId, projectId);
 
         const metaDocId = `${DOC_PREFIX_META}${projectId}`;
         const graphDocId = `${DOC_PREFIX_GRAPH}${projectId}`;
@@ -1886,6 +1903,7 @@ module.exports = {
         bbox: meta.bbox,
         name: meta.name,
         createdAt: meta.createdAt,
+        tenantId: meta.tenantId || null,
         layers: meta.layers || [],
         layer1GFactorAdjustment: meta.layer1GFactorAdjustment || 1.0,
         layer2CalibrationFactor: meta.layer2CalibrationFactor || 0,
@@ -1935,6 +1953,28 @@ module.exports = {
         );
       }
       return project;
+    },
+
+    /**
+     * requireProjectTenant — Enforce tenant isolation for a project.
+     * @param {object} project
+     * @param {string} tenantId
+     * @param {string} projectId
+     */
+    requireProjectTenant(project, tenantId, projectId) {
+      if (!project.tenantId) {
+        // Backward-compat: projects created before tenant isolation have no tenantId.
+        // Treat as unrestricted (legacy data).
+        return;
+      }
+      if (project.tenantId !== tenantId) {
+        throw new MoleculerError(
+          `ZNP project "${projectId}" not found.`,
+          404,
+          'ZNP_PROJECT_NOT_FOUND',
+          { projectId }
+        );
+      }
     },
 
     /**

--- a/tests/znp.service.test.js
+++ b/tests/znp.service.test.js
@@ -1496,4 +1496,51 @@ describe('ZNP Service', () => {
       expect(result.assets.every((a) => a.mastrNummer !== undefined)).toBe(true);
     });
   });
+
+  // ─── Tenant Isolation (Gap-7) ───
+  describe('tenant isolation', () => {
+    it('createProject stores and returns tenantId', async () => {
+      const result = await broker.call(
+        'znp.createProject',
+        { bbox: makeBbox() },
+        { meta: { tenantId: 'tenant-a' } }
+      );
+      expect(result.tenantId).toBe('tenant-a');
+    });
+
+    it('listProjects only returns projects for the calling tenant', async () => {
+      const r1 = await broker.call('znp.createProject', { bbox: makeBbox() }, { meta: { tenantId: 'tenant-a' } });
+      const r2 = await broker.call('znp.createProject', { bbox: makeBbox() }, { meta: { tenantId: 'tenant-b' } });
+
+      const listA = await broker.call('znp.listProjects', {}, { meta: { tenantId: 'tenant-a' } });
+      expect(listA.projects.some((p) => p.projectId === r1.projectId)).toBe(true);
+      expect(listA.projects.some((p) => p.projectId === r2.projectId)).toBe(false);
+
+      const listB = await broker.call('znp.listProjects', {}, { meta: { tenantId: 'tenant-b' } });
+      expect(listB.projects.some((p) => p.projectId === r2.projectId)).toBe(true);
+      expect(listB.projects.some((p) => p.projectId === r1.projectId)).toBe(false);
+    });
+
+    it('getProjectMeta rejects cross-tenant access with 404', async () => {
+      const r = await broker.call('znp.createProject', { bbox: makeBbox() }, { meta: { tenantId: 'tenant-a' } });
+      await expect(
+        broker.call('znp.getProjectMeta', { projectId: r.projectId }, { meta: { tenantId: 'tenant-b' } })
+      ).rejects.toMatchObject({ code: 404, type: 'ZNP_PROJECT_NOT_FOUND' });
+    });
+
+    it('deleteProject rejects cross-tenant access with 404', async () => {
+      const r = await broker.call('znp.createProject', { bbox: makeBbox() }, { meta: { tenantId: 'tenant-a' } });
+      await expect(
+        broker.call('znp.deleteProject', { projectId: r.projectId }, { meta: { tenantId: 'tenant-b' } })
+      ).rejects.toMatchObject({ code: 404, type: 'ZNP_PROJECT_NOT_FOUND' });
+    });
+
+    it('getProjectAssets rejects cross-tenant access with 404', async () => {
+      const r = await broker.call('znp.createProject', { bbox: makeBbox() }, { meta: { tenantId: 'tenant-a' } });
+      await broker.call('znp.addLayer0', { projectId: r.projectId, assets: makeAssets(1) }, { meta: { tenantId: 'tenant-a' } });
+      await expect(
+        broker.call('znp.getProjectAssets', { projectId: r.projectId }, { meta: { tenantId: 'tenant-b' } })
+      ).rejects.toMatchObject({ code: 404, type: 'ZNP_PROJECT_NOT_FOUND' });
+    });
+  });
 });


### PR DESCRIPTION
## Gap-7: ZNP Tenant-Isolation (IMPLEMENTATION_BUG)

### Problem
ZNP speicherte und pruefte `tenantId` in keiner Action. Projekte waren mandantenuebergreifend sichtbar und modifizierbar.

### Aenderungen
- `createProject`: speichert `tenantId` in Meta-Doc und `activeGraphs`
- `hydrateGraph`: laedt `tenantId` aus PouchDB
- `listProjects`: filtert nach aufrufendem Tenant
- `getProjectMeta`, `deleteProject`, `getProjectAssets`: enforced Tenant-Zugriff via `requireProjectTenant`
- `requireProjectTenant`: backward-compat fuer Legacy-Projekte ohne `tenantId`

### Testnachweis
- 5 neue Unit-Tests in `tests/znp.service.test.js`
- Alle 110 ZNP-Tests bestehen (inkl. Regressionstests)

```bash
npx jest tests/znp.service.test.js --runInBand --forceExit
# Test Suites: 1 passed, 1 total
# Tests:       110 passed, 110 total
```

### Restrisiko
`addLayer0`, `calculateGFactor`, `addAssumption` und weitere Mutation-Actions verwenden weiterhin `getProject()` ohne expliziten Tenant-Check. Ein Folge-PR sollte `requireProjectTenant` dort nachziehen.

### Geaenderte Dateien
- `services/znp.service.js`
- `tests/znp.service.test.js`
