### PR TITLE
test(grid-connection): Gap-4 What-If scenario support (failing tests)

### DIFF
--- a/tests/grid-connection-whatif.test.js
+++ b/tests/grid-connection-whatif.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+/**
+ * Failing test for Gap-4: Grid-Validation What-If scenario support.
+ *
+ * This test documents the expected parameter shape for future
+ * What-If grid connection validation. It currently fails because
+ * `scenarioAdditions` is not yet accepted by the validate action.
+ */
+
+const GridConnectionService = require('../services/grid-connection.service');
+
+describe('grid-connection What-If (Gap-4)', () => {
+  test('validate action accepts scenarioAdditions parameter', () => {
+    const validateAction = GridConnectionService.actions.validate;
+    expect(validateAction).toBeDefined();
+    expect(validateAction.params).toBeDefined();
+
+    // Expected: validate should accept hypothetical installations
+    // that are added to the capacity calculation as a What-If scenario.
+    expect(validateAction.params.scenarioAdditions).toBeDefined();
+    expect(validateAction.params.scenarioAdditions.type).toBe('array');
+  });
+
+  test('validate action accepts scenarioCapacityMW parameter', () => {
+    const validateAction = GridConnectionService.actions.validate;
+    expect(validateAction.params.scenarioCapacityMW).toBeDefined();
+    expect(validateAction.params.scenarioCapacityMW.type).toBe('number');
+  });
+
+  test('validation report includes scenario findings when scenario provided', () => {
+    // This test will pass once What-If support is implemented.
+    // For now it documents the expected response shape.
+    const validateAction = GridConnectionService.actions.validate;
+    expect(validateAction).toBeDefined();
+
+    // The openapi docs should mention scenario support
+    if (validateAction.openapi?.requestBody?.content) {
+      const schema =
+        validateAction.openapi.requestBody.content['application/json']?.schema;
+      if (schema && schema.properties) {
+        expect(schema.properties.scenarioAdditions).toBeDefined();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Gap-4: Grid-Validation What-If Scenario Support (ARCHITECTURE_GAP)

### Problem
`grid-connection.validate` prueft nur den aktuellen Zustand. Ein zukuenftiges 10-MW-Asset laesst sich nicht als Szenario eingeben. Die Pruefung "Was passiert, wenn das RZ dazukommt?" ist nicht nativ unterstuetzt.

### Dieser PR
3 failing Unit-Tests, die dokumentieren, welche Parameter und Response-Shape fuer What-If noetig waeren:

1. `validate` sollte `scenarioAdditions` (Array von hypothetischen Installationen) akzeptieren
2. `validate` sollte `scenarioCapacityMW` (aggregierte Zusatzkapazitaet) akzeptieren
3. OpenAPI-Schema sollte diese Properties dokumentieren

### Testnachweis (rot)
```bash
npx jest tests/grid-connection-whatif.test.js --runInBand --forceExit
# Tests: 3 failed, 3 total
```

### Empfohlene Implementierung
- `scenarioAdditions` in `validate.params` aufnehmen
- In `stepCapacity`: `scenarioAdditions` zur `installations`-Liste hinzufuegen oder separat als `scenarioInstalledKW` berechnen
- `scenarioCapacityMW` als Shortcut fuer schnelle Kapazitaetsaenderungen
- Neue Finding-Codes: `SCENARIO_CAPACITY_EXCEEDED`, `SCENARIO_HEADROOM_NEGATIVE`
- Entscheidungs-Erweiterung: `GO_CONDITIONAL_SCENARIO`

### Geaenderte Dateien
- `tests/grid-connection-whatif.test.js` (neu)
