### PR TITLE
fix(znp): remove conflicting rest: route from addAssumption

### DIFF
--- a/services/znp.service.js
+++ b/services/znp.service.js
@@ -1306,7 +1306,6 @@ module.exports = {
      * POST /api/znp/projects/:projectId/assumptions
      */
     addAssumption: {
-      rest: 'POST /projects/:projectId/assumptions',
       params: {
         projectId: { type: 'string' },
         text: { type: 'string', min: 10, max: 2000 },


### PR DESCRIPTION
## Problem

The `addAssumption` action had both a `rest:` auto-route block in `znp.service.js` and a manual alias in `api.service.js`. This caused Moleculer-Web to intermittently resolve the path to an invalid service name, resulting in `404 SERVICE_NOT_FOUND` errors during the Troisdorf E2E demo scenario.

## Fix

Remove the `rest:` block from `addAssumption`. The `api.service.js` alias already handles routing correctly. This matches the pattern used by `addLayer0`, `addLayer1`, and `addLayer2`.

## Test Evidence

- Reproduced during Troisdorf E2E demo scenario: POST /api/znp/projects/:id/assumptions returned 404 with service name `znp.projects..assumptions`.
- Other ZNP actions (layer0/layer1/layer2) work because they rely solely on the api.service.js alias.
- Unit tests call `znp.addAssumption` directly via broker — unaffected by this change.

## Changed Files

- `services/znp.service.js` — removed 1 line (`rest:` declaration)

## Residual Risk

None. The OpenAPI documentation block (`openapi:`) remains intact. The endpoint behavior is unchanged for REST API callers.
