### PR TITLE
fix(znp): listProjects + requireProjectTenant tenant isolation for legacy data (Gap-07 follow-up)

### DIFF
--- a/services/znp.service.js
+++ b/services/znp.service.js
@@ -1690,7 +1690,8 @@ module.exports = {
         const tenantId = getTenantId(ctx);
         const projects = [];
         for (const [projectId, project] of this.activeGraphs.entries()) {
-          if (project.tenantId && project.tenantId !== tenantId) continue;
+          const effectiveTenant = project.tenantId || 'default';
+          if (effectiveTenant !== tenantId) continue;
           projects.push({
             projectId,
             name: project.name,
@@ -1957,7 +1958,8 @@ module.exports = {
     },
 
     requireProjectTenant(project, tenantId, projectId) {
-      if (!project.tenantId || project.tenantId === tenantId) {
+      const effectiveTenant = project.tenantId || 'default';
+      if (effectiveTenant === tenantId) {
         return;
       }
 

--- a/tests/znp.tenant.test.js
+++ b/tests/znp.tenant.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const { ServiceBroker } = require('moleculer');
+const ZnpService = require('../services/znp.service');
+
+describe('znp tenant isolation', () => {
+  let broker;
+
+  beforeAll(async () => {
+    broker = new ServiceBroker({ logger: false });
+    broker.createService({
+      ...ZnpService,
+      settings: {
+        ...ZnpService.settings,
+        dbPath: path.join(os.tmpdir(), `cernion-znp-test-${Date.now()}`),
+      },
+    });
+    await broker.start();
+  });
+
+  afterAll(async () => {
+    if (broker) await broker.stop();
+  });
+
+  it('should only list projects belonging to the caller tenant', async () => {
+    // Create project for tenant-alpha
+    const alpha = await broker.call('znp.createProject', {
+      bbox: { south: 50, north: 51, west: 7, east: 8 },
+      name: 'Alpha-Projekt',
+    }, { meta: { tenantId: 'tenant-alpha' } });
+
+    expect(alpha.projectId).toBeTruthy();
+
+    // Create project for tenant-beta
+    const beta = await broker.call('znp.createProject', {
+      bbox: { south: 52, north: 53, west: 9, east: 10 },
+      name: 'Beta-Projekt',
+    }, { meta: { tenantId: 'tenant-beta' } });
+
+    expect(beta.projectId).toBeTruthy();
+
+    // List as alpha — should only see Alpha
+    const listAlpha = await broker.call('znp.listProjects', {}, { meta: { tenantId: 'tenant-alpha' } });
+    expect(listAlpha.projects.map((p) => p.name)).toEqual(['Alpha-Projekt']);
+
+    // List as beta — should only see Beta
+    const listBeta = await broker.call('znp.listProjects', {}, { meta: { tenantId: 'tenant-beta' } });
+    expect(listBeta.projects.map((p) => p.name)).toEqual(['Beta-Projekt']);
+
+    // List as default — should see neither (they belong to alpha/beta)
+    const listDefault = await broker.call('znp.listProjects', {}, { meta: {} });
+    const defaultNames = listDefault.projects.map((p) => p.name);
+    expect(defaultNames).not.toContain('Alpha-Projekt');
+    expect(defaultNames).not.toContain('Beta-Projekt');
+  });
+
+  it('should block getProjectMeta for a foreign tenant', async () => {
+    const created = await broker.call('znp.createProject', {
+      bbox: { south: 50, north: 51, west: 7, east: 8 },
+      name: 'Guard-Projekt',
+    }, { meta: { tenantId: 'owner-tenant' } });
+
+    await expect(
+      broker.call('znp.getProjectMeta', { projectId: created.projectId }, { meta: { tenantId: 'intruder-tenant' } })
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('should block deleteProject for a foreign tenant', async () => {
+    const created = await broker.call('znp.createProject', {
+      bbox: { south: 50, north: 51, west: 7, east: 8 },
+      name: 'Delete-Guard',
+    }, { meta: { tenantId: 'owner-tenant' } });
+
+    await expect(
+      broker.call('znp.deleteProject', { projectId: created.projectId }, { meta: { tenantId: 'intruder-tenant' } })
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('should isolate legacy projects without tenantId to default tenant only', async () => {
+    // Simulate a legacy project by injecting into activeGraphs directly
+    const svc = broker.getLocalService('znp');
+    const legacyId = 'legacy-project-001';
+    svc.activeGraphs.set(legacyId, {
+      graph: { order: 0, size: 0, forEachNode: () => {}, forEachEdge: () => {} },
+      name: 'Legacy Projekt',
+      bbox: {},
+      createdAt: new Date().toISOString(),
+      tenantId: null, // no tenant — legacy
+      layers: [],
+      layer1GFactorAdjustment: 1.0,
+      layer2CalibrationFactor: 0,
+    });
+
+    // Default tenant should see it
+    const listDefault = await broker.call('znp.listProjects', {}, { meta: { tenantId: 'default' } });
+    expect(listDefault.projects.map((p) => p.name)).toContain('Legacy Projekt');
+
+    // Other tenants must NOT see it
+    const listOther = await broker.call('znp.listProjects', {}, { meta: { tenantId: 'other-tenant' } });
+    expect(listOther.projects.map((p) => p.name)).not.toContain('Legacy Projekt');
+
+    svc.activeGraphs.delete(legacyId);
+  });
+});


### PR DESCRIPTION
## Problem (Gap-07 Follow-Up)

PR #98 fügte dem API-Gateway die Header-Auslesung `x-tenant-id` hinzu, sodass `ctx.meta.tenantId` korrekt gefüllt wird. **Aber:** Der ZNP-Service isolierte Legacy-Daten (und damit auch neu erstellte Projekte ohne Tenant-Kontext) nicht korrekt.

### Die Lücke

In `listProjects` (Zeile 1693):
```js
if (project.tenantId && project.tenantId !== tenantId) continue;
```

Projekte mit `tenantId: null` (Legacy-Daten) oder `tenantId: undefined` wurden von **allen** Tenants gesehen, weil `!project.tenantId` true zurückgab und die `continue`-Anweisung übersprungen wurde.

Dasselbe Muster in `requireProjectTenant` (Zeile 1960):
```js
if (!project.tenantId || project.tenantId === tenantId) { return; }
```
Hier konnte jeder Tenant auf Legacy-Projekte zugreifen, da `!project.tenantId` den Check vorzeitig beendete.

### Live-Beweis (vom Dev-Server, vor dem Fix)

```bash
# list as tenant-alpha → 12 Projekte, alle tenantId: null
# list as tenant-beta  → dieselben 12 Projekte
# list ohne Header     → 16 Projekte (4 davon "default", 12 null)
```

Keine Isolation zwischen Tenants.

## Änderung

Beide Stellen verwenden jetzt einen expliziten Fallback auf `DEFAULT_TENANT`:

```js
const effectiveTenant = project.tenantId || 'default';
if (effectiveTenant !== tenantId) { /* reject / skip */ }
```

- **Legacy-Projekte ohne `tenantId`** → sichtbar **nur für `default`**
- **Neue Projekte mit explizitem Tenant** → sichtbar **nur für diesen Tenant**
- **Kein "open bar" mehr** für null-Daten

## Tests

Neue Testdatei `tests/znp.tenant.test.js` mit 4 Cases:
1. `listProjects` trennt `tenant-alpha` und `tenant-beta`
2. `getProjectMeta` verweigert Fremd-Tenant (404, Security-by-Design)
3. `deleteProject` verweigert Fremd-Tenant (404)
4. Legacy-Projekt (`tenantId: null`) ist nur für `default` sichtbar

## Checkliste

- [x] Code-Änderung minimal (2 Zeilen geändert)
- [x] Unit-Tests hinzugefügt und lokal passing (`npx jest tests/znp.tenant.test.js --runInBand --forceExit`)
- [x] Keine Breaking Changes für korrekt scopegte Requests
- [x] Legacy-Daten-Verhalten dokumentiert (Fall-back to default)

## Restrisiko

Projekte, die über interne PouchDB-Bypasses oder `broker.call` ohne `meta.tenantId` erstellt werden, haben nach wie vor `tenantId = null`. Ein vollständiger Audit aller direkten DB-Schreibwege wäre sinnvoll.

---
**Verwandt:** PR #98 (API-Gateway Header), PR #94 (ZNP tenant isolation — closed unmerged, dies ist der Nachfolger)
