### PR TITLE
chore(deps): bump axios from 1.18.0 to 1.18.1 (dep-only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@turf/boolean-point-in-polygon": "^7.3.5",
         "@turf/helpers": "^7.3.4",
         "ajv": "^8.20.0",
-        "axios": "^1.18.0",
+        "axios": "^1.18.1",
         "better-sqlite3": "^12.11.1",
         "dotenv": "^17.4.2",
         "german-zip-codes": "^1.0.2",
@@ -4270,9 +4270,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
-      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@turf/boolean-point-in-polygon": "^7.3.5",
     "@turf/helpers": "^7.3.4",
     "ajv": "^8.20.0",
-    "axios": "^1.18.0",
+    "axios": "^1.18.1",
     "better-sqlite3": "^12.11.1",
     "dotenv": "^17.4.2",
     "german-zip-codes": "^1.0.2",


### PR DESCRIPTION
## Summary

Replaces PR #314 with a dependency-only version.

- Bumps `axios` from 1.18.0 to 1.18.1 — security/patch release
- Only `package.json` and `package-lock.json` are changed
- Drops the 101-file formatting commit that caused SonarCloud duplication (9.2%) and reliability D failures in PR #314

## Why PR #314 is superseded

PR #314 (`ae87968`) contained a second commit `chore: format codebase for quality gate` that rewrote 101 files. SonarCloud flagged 1,222/13,342 new duplicated lines, with main contributors:
- `src/evidence-registry.js` (+668 dup lines)
- `src/capability-catalog.js` (+384 dup lines)
- `services/community.service.js` (+105 dup lines)

Plus two reliability findings (`javascript:S5842`, `javascript:S2871`). PR #314 also has merge conflicts with main (`mergeStateStatus=DIRTY`).

This replacement PR is conflict-free and contains no source-code changes.

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)