### PR TITLE
Add decision-readiness matrix evidence contract

### DIFF
--- a/llm.txt
+++ b/llm.txt
@@ -251,7 +251,7 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: 1923e5f7853d594b2d0fc2f6f2cee4a9d4ed4c101a0ee20e99bb08d79a0f8a15
-- openapi-export.json: 9a7e8df62daf0c116a972d791cc414859c1dc20b06f9566b6515349b65e55699
+- openapi-export.json: 23d64273d3f2fe93fd9f4f91b363bd3118e65a13b3bb6ae2802c52a7d881934f
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 963
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 5e073b99203ca8d64aea71d054eb4bdb36a0f7cc3a56fe6143ed1ae769c96fce
+- llm_txt_sha256: f3669c0cbcba6c8a25be5a29489dfe4ef818aebcd91c163d975d5d50930cb755

--- a/llm.txt
+++ b/llm.txt
@@ -246,12 +246,12 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: 1af9d00461d2fcf59ee68bf8385572934bdd47d9e91f21dde28689e5c5b89bbd
+- CHANGELOG.md: 34917c6a84a29026060761cda6a5c074c1be6d1561b0a9b5a562a4bfa574d4be
 - README.md: bdfc5d35a65796de3357f3ce717a61998325fa257776cbf17f7077893d0b23e7
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: 1923e5f7853d594b2d0fc2f6f2cee4a9d4ed4c101a0ee20e99bb08d79a0f8a15
-- openapi-export.json: 8bf3f16fbd28f2402d17a6a7714d1077994da7c45688f7f3ef3817080cf1fca8
+- openapi-export.json: 9a7e8df62daf0c116a972d791cc414859c1dc20b06f9566b6515349b65e55699
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 963
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: df9785f82386278fa3e7aee104f8ab0cf27fee3c52c1509e5e78ca1adb3b5b43
+- llm_txt_sha256: 5e073b99203ca8d64aea71d054eb4bdb36a0f7cc3a56fe6143ed1ae769c96fce

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -12482,7 +12482,8 @@
                       "type": "string"
                     },
                     "caseId": {
-                      "type": "string"
+                      "type": "string",
+                      "nullable": true
                     },
                     "safety": {
                       "type": "string"
@@ -65828,7 +65829,8 @@
                       "type": "string"
                     },
                     "caseId": {
-                      "type": "string"
+                      "type": "string",
+                      "nullable": true
                     },
                     "safety": {
                       "type": "string"

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -12481,11 +12481,17 @@
                     "capabilityKey": {
                       "type": "string"
                     },
+                    "caseId": {
+                      "type": "string"
+                    },
                     "safety": {
                       "type": "string"
                     },
                     "status": {
                       "type": "string"
+                    },
+                    "summary": {
+                      "type": "object"
                     },
                     "rows": {
                       "type": "array"
@@ -12500,6 +12506,9 @@
                       "type": "array"
                     },
                     "decisionBoundaries": {
+                      "type": "array"
+                    },
+                    "evidenceFacts": {
                       "type": "array"
                     },
                     "sourceActions": {
@@ -65818,11 +65827,17 @@
                     "capabilityKey": {
                       "type": "string"
                     },
+                    "caseId": {
+                      "type": "string"
+                    },
                     "safety": {
                       "type": "string"
                     },
                     "status": {
                       "type": "string"
+                    },
+                    "summary": {
+                      "type": "object"
                     },
                     "rows": {
                       "type": "array"
@@ -65837,6 +65852,9 @@
                       "type": "array"
                     },
                     "decisionBoundaries": {
+                      "type": "array"
+                    },
+                    "evidenceFacts": {
                       "type": "array"
                     },
                     "sourceActions": {

--- a/services/dashboard-api.service.js
+++ b/services/dashboard-api.service.js
@@ -1798,14 +1798,24 @@ module.exports = {
           { name: 'category', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'budgetStatus', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'financingOption', in: 'query', required: false, schema: { type: 'string' } },
-          { name: 'riskIfNotImplemented', in: 'query', required: false, schema: { type: 'string' } },
+          {
+            name: 'riskIfNotImplemented',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
           { name: 'evidenceSource', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'owner', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'committeeWindow', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'nextDecisionPoint', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'blockers', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'openEvidence', in: 'query', required: false, schema: { type: 'string' } },
-          { name: 'includeSyntheticRows', in: 'query', required: false, schema: { type: 'boolean' } },
+          {
+            name: 'includeSyntheticRows',
+            in: 'query',
+            required: false,
+            schema: { type: 'boolean' },
+          },
         ],
         responses: {
           200: {
@@ -1909,7 +1919,12 @@ module.exports = {
           { name: 'threshold', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'resolutionStatus', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'openEvidence', in: 'query', required: false, schema: { type: 'string' } },
-          { name: 'includeSyntheticRows', in: 'query', required: false, schema: { type: 'boolean' } },
+          {
+            name: 'includeSyntheticRows',
+            in: 'query',
+            required: false,
+            schema: { type: 'boolean' },
+          },
         ],
         responses: {
           200: {
@@ -14717,16 +14732,15 @@ module.exports = {
           enablesDossierAddition: `add blocker resolution evidence: ${blocker}`,
         });
       }
-      const status =
-        classifiedRows.some((row) => row.readiness === 'financing_risk')
-          ? 'financing_risk'
-          : classifiedRows.every((row) => row.readiness === 'decision_ready')
-            ? 'decision_ready'
-            : classifiedRows.some((row) => row.readiness === 'owner_needed')
-              ? 'owner_needed'
-              : missingEvidence.length > 0
-                ? 'evidence_gap'
-                : 'informational';
+      const status = classifiedRows.some((row) => row.readiness === 'financing_risk')
+        ? 'financing_risk'
+        : classifiedRows.every((row) => row.readiness === 'decision_ready')
+          ? 'decision_ready'
+          : classifiedRows.some((row) => row.readiness === 'owner_needed')
+            ? 'owner_needed'
+            : missingEvidence.length > 0
+              ? 'evidence_gap'
+              : 'informational';
       const positiveFollowUps = missingEvidence.map((item) => ({
         missingDataPoint: item.missingDataPoint,
         enablesDossierAddition: item.enablesDossierAddition,
@@ -14734,13 +14748,16 @@ module.exports = {
       }));
       const decisionBoundaries = [
         {
-          boundary: 'Budget and financing fields classify evidence only; they do not approve spend.',
+          boundary:
+            'Budget and financing fields classify evidence only; they do not approve spend.',
         },
         {
-          boundary: 'Committee windows and next decision points are planning facts, not workflow triggers.',
+          boundary:
+            'Committee windows and next decision points are planning facts, not workflow triggers.',
         },
         {
-          boundary: 'No SAP/ERP, procurement, HITL, billing, settlement, tariff, MaKo or device-control action is called.',
+          boundary:
+            'No SAP/ERP, procurement, HITL, billing, settlement, tariff, MaKo or device-control action is called.',
         },
       ];
       const dossierFacts = [
@@ -14897,7 +14914,11 @@ module.exports = {
       }
 
       const classifyRow = (row) => {
-        if (!hasValue(row.sourceSystem) || !hasValue(row.targetSystem) || !hasValue(row.affectedObject)) {
+        if (
+          !hasValue(row.sourceSystem) ||
+          !hasValue(row.targetSystem) ||
+          !hasValue(row.affectedObject)
+        ) {
           return 'evidence_gap';
         }
         if (!hasValue(row.owner)) return 'needs_owner';
@@ -15014,18 +15035,17 @@ module.exports = {
           enablesDossierAddition: `add open variance evidence: ${evidenceGap}`,
         });
       }
-      const status =
-        classifiedRows.some((row) => row.varianceState === 'revenue_risk')
-          ? 'revenue_risk'
-          : classifiedRows.some((row) => row.varianceState === 'asset_scope_risk')
-            ? 'asset_scope_risk'
-            : classifiedRows.every((row) => row.varianceState === 'management_ready')
-              ? 'management_ready'
-              : classifiedRows.some((row) => row.varianceState === 'needs_owner')
-                ? 'needs_owner'
-                : missingEvidence.length > 0
-                  ? 'evidence_gap'
-                  : 'informational';
+      const status = classifiedRows.some((row) => row.varianceState === 'revenue_risk')
+        ? 'revenue_risk'
+        : classifiedRows.some((row) => row.varianceState === 'asset_scope_risk')
+          ? 'asset_scope_risk'
+          : classifiedRows.every((row) => row.varianceState === 'management_ready')
+            ? 'management_ready'
+            : classifiedRows.some((row) => row.varianceState === 'needs_owner')
+              ? 'needs_owner'
+              : missingEvidence.length > 0
+                ? 'evidence_gap'
+                : 'informational';
       const positiveFollowUps = missingEvidence.map((item) => ({
         missingDataPoint: item.missingDataPoint,
         enablesDossierAddition: item.enablesDossierAddition,
@@ -15033,13 +15053,16 @@ module.exports = {
       }));
       const decisionBoundaries = [
         {
-          boundary: 'Variance rows classify caller-supplied evidence only; they do not reconcile or correct source systems.',
+          boundary:
+            'Variance rows classify caller-supplied evidence only; they do not reconcile or correct source systems.',
         },
         {
-          boundary: 'Revenue, budget and asset hints are risk context, not booking, billing, settlement or master-data authority.',
+          boundary:
+            'Revenue, budget and asset hints are risk context, not booking, billing, settlement or master-data authority.',
         },
         {
-          boundary: 'No ERP/SAP/GIS/MDM connector, workflow, HITL, webhook, MaKo, tariff or device-control action is called.',
+          boundary:
+            'No ERP/SAP/GIS/MDM connector, workflow, HITL, webhook, MaKo, tariff or device-control action is called.',
         },
       ];
       const dossierFacts = [
@@ -15074,7 +15097,11 @@ module.exports = {
         dossierFacts,
         sourceActions: {
           inspected: ['dashboard-api.crossSystemVarianceMatrixStatus'],
-          referenced: ['vdmi.dossier', 'evidence-registry.findings', 'variance-register.suppliedFacts'],
+          referenced: [
+            'vdmi.dossier',
+            'evidence-registry.findings',
+            'variance-register.suppliedFacts',
+          ],
           notCalled: [
             'erp.sap.read',
             'erp.sap.write',
@@ -15135,7 +15162,11 @@ module.exports = {
           label: 'Metering operations',
           rx: /messstellenbetrieb|metering|imsys|smart.?meter|msb|melo|malo/i,
           data: ['MaLo/MeLo reference', 'metering-role boundary', 'rollout or measurement status'],
-          evidence: ['source signal reference', 'affected metering process', 'role responsibility proof'],
+          evidence: [
+            'source signal reference',
+            'affected metering process',
+            'role responsibility proof',
+          ],
           tests: ['metering-process impact check', 'role-boundary regression test'],
           gate: 'Metering owner confirms affected process and evidence scope',
         },
@@ -15143,8 +15174,16 @@ module.exports = {
           key: 'flexibility_grid_operations',
           label: 'Flexibility and grid operations',
           rx: /flex|steuerbar|14a|redispatch|netzbetrieb|grid|cls|smgw/i,
-          data: ['asset controllability scope', 'grid-operation decision boundary', 'flexibility process status'],
-          evidence: ['asset/control evidence', 'grid operations handover proof', 'non-execution boundary'],
+          data: [
+            'asset controllability scope',
+            'grid-operation decision boundary',
+            'flexibility process status',
+          ],
+          evidence: [
+            'asset/control evidence',
+            'grid operations handover proof',
+            'non-execution boundary',
+          ],
           tests: ['read-only controllability evidence check', 'no device-control mutation smoke'],
           gate: 'Grid operations owner confirms control boundary remains non-executing',
         },
@@ -15198,7 +15237,10 @@ module.exports = {
       const evidenceRequirements = uniq([
         ...selectedProfiles.flatMap((profile) => profile.evidence),
         params.evidenceHint || null,
-      ]).map((label) => ({ label, status: params.evidenceHint === label ? 'supplied' : 'required' }));
+      ]).map((label) => ({
+        label,
+        status: params.evidenceHint === label ? 'supplied' : 'required',
+      }));
       const testCaseHints = uniq([
         ...selectedProfiles.flatMap((profile) => profile.tests),
         params.testCaseHint || null,
@@ -15340,7 +15382,11 @@ module.exports = {
         dossierFacts,
         sourceActions: {
           inspected: ['dashboard-api.regulatorySignalProcessTranslatorStatus'],
-          referenced: ['vdmi.dossier', 'evidence-registry.findings', 'regulatory-signal.suppliedFacts'],
+          referenced: [
+            'vdmi.dossier',
+            'evidence-registry.findings',
+            'regulatory-signal.suppliedFacts',
+          ],
           notCalled: [
             'legal.interpret',
             'compliance.decide',
@@ -15543,7 +15589,8 @@ module.exports = {
       ];
       if (params.owner) dossierFacts.push(`Owner: ${params.owner}`);
       if (params.reviewStatus) dossierFacts.push(`Review Status: ${params.reviewStatus}`);
-      if (params.nextCommitteeGate) dossierFacts.push(`Next Committee Gate: ${params.nextCommitteeGate}`);
+      if (params.nextCommitteeGate)
+        dossierFacts.push(`Next Committee Gate: ${params.nextCommitteeGate}`);
 
       return {
         costReviewId: `crcs:${Buffer.from(
@@ -27390,8 +27437,7 @@ module.exports = {
           value: params.owner || params.reviewer,
           displayValue: [params.owner, params.reviewer].filter(Boolean).join(' / '),
           sourceClass: 'data_room_accountability',
-          enablesDossierAddition:
-            'adds accountable data-room ownership and review responsibility.',
+          enablesDossierAddition: 'adds accountable data-room ownership and review responsibility.',
         },
         {
           id: 'source_refs',
@@ -27423,23 +27469,24 @@ module.exports = {
           enablesDossierAddition: spec.enablesDossierAddition,
         }));
 
-      const status = !params.roomId || (!params.mandateId && !params.profile)
-        ? 'needs_room_profile'
-        : transformationPaths.length === 0
-          ? 'needs_transformation_path'
-          : scenarioReferences.length === 0
-            ? 'needs_scenario_reference'
-            : !params.evidenceStatus
-              ? 'needs_evidence_register'
-              : !params.decisionStatus
-                ? 'needs_decision_log'
-                : !params.roadmapStatus || !params.reviewDate
-                  ? 'needs_review_snapshot'
-                  : !params.owner && !params.reviewer
-                    ? 'needs_owner_reviewer'
-                    : sourceRefs.length === 0
-                      ? 'needs_source_refs'
-                      : 'ready_for_dataroom_review';
+      const status =
+        !params.roomId || (!params.mandateId && !params.profile)
+          ? 'needs_room_profile'
+          : transformationPaths.length === 0
+            ? 'needs_transformation_path'
+            : scenarioReferences.length === 0
+              ? 'needs_scenario_reference'
+              : !params.evidenceStatus
+                ? 'needs_evidence_register'
+                : !params.decisionStatus
+                  ? 'needs_decision_log'
+                  : !params.roadmapStatus || !params.reviewDate
+                    ? 'needs_review_snapshot'
+                    : !params.owner && !params.reviewer
+                      ? 'needs_owner_reviewer'
+                      : sourceRefs.length === 0
+                        ? 'needs_source_refs'
+                        : 'ready_for_dataroom_review';
 
       const readinessScore = Number((evidenceItems.length / evidenceSpecs.length).toFixed(2));
       const positiveFollowUps = missingEvidence.map((item) => ({
@@ -42199,8 +42246,7 @@ module.exports = {
         {
           id: 'missing_side_source_policy',
           ok: allowedSideSources.length > 0,
-          enablesDossierAddition:
-            'Nebenquellen-Regel kann Uebersteuerung nachvollziehbar machen.',
+          enablesDossierAddition: 'Nebenquellen-Regel kann Uebersteuerung nachvollziehbar machen.',
         },
       ];
       const missingEvidence = gapSpecs
@@ -42371,7 +42417,8 @@ module.exports = {
           id: 'blocking_finding',
           label: 'Absent blocker evidence',
           value: blockerAbsent ? params.blockingFinding : null,
-          enablesDossierAddition: 'distinguish absent blocker from unresolved unknown or active blocker',
+          enablesDossierAddition:
+            'distinguish absent blocker from unresolved unknown or active blocker',
         },
         {
           id: 'next_check_at',

--- a/services/dashboard-api.service.js
+++ b/services/dashboard-api.service.js
@@ -1816,7 +1816,7 @@ module.exports = {
                   type: 'object',
                   properties: {
                     capabilityKey: { type: 'string' },
-                    caseId: { type: 'string' },
+                    caseId: { type: 'string', nullable: true },
                     safety: { type: 'string' },
                     status: { type: 'string' },
                     summary: { type: 'object' },

--- a/services/dashboard-api.service.js
+++ b/services/dashboard-api.service.js
@@ -1816,13 +1816,16 @@ module.exports = {
                   type: 'object',
                   properties: {
                     capabilityKey: { type: 'string' },
+                    caseId: { type: 'string' },
                     safety: { type: 'string' },
                     status: { type: 'string' },
+                    summary: { type: 'object' },
                     rows: { type: 'array' },
                     readinessCounts: { type: 'object' },
                     missingEvidence: { type: 'array' },
                     positiveFollowUps: { type: 'array' },
                     decisionBoundaries: { type: 'array' },
+                    evidenceFacts: { type: 'array' },
                     sourceActions: { type: 'object' },
                     dossierEvidence: { type: 'object' },
                     timestamp: { type: 'string', format: 'date-time' },
@@ -14676,13 +14679,19 @@ module.exports = {
           enablesDossierAddition: 'add next decision-point evidence',
         },
       ];
-      const classifiedRows = rows.map((row, index) => ({
-        ...row,
-        rowId: row.measureId || `row:${index + 1}`,
-        readiness: classifyRow(row),
-        evidenceStatus:
-          !hasValue(row.evidenceSource) || row.openEvidence.length > 0 ? 'incomplete' : 'provided',
-      }));
+      const classifiedRows = rows.map((row, index) => {
+        const rowStatus = classifyRow(row);
+        return {
+          ...row,
+          rowId: row.measureId || `row:${index + 1}`,
+          readiness: rowStatus,
+          status: rowStatus,
+          evidenceStatus:
+            !hasValue(row.evidenceSource) || row.openEvidence.length > 0
+              ? 'incomplete'
+              : 'provided',
+        };
+      });
       const readinessCounts = classifiedRows.reduce((acc, row) => {
         acc[row.readiness] = (acc[row.readiness] || 0) + 1;
         return acc;
@@ -14744,6 +14753,16 @@ module.exports = {
       if (baseRow.owner) dossierFacts.push(`Owner: ${baseRow.owner}`);
       if (baseRow.nextDecisionPoint)
         dossierFacts.push(`Next Decision Point: ${baseRow.nextDecisionPoint}`);
+      const summary = {
+        rowCount: classifiedRows.length,
+        status,
+        readyRows: readinessCounts.decision_ready || 0,
+        gapRows: readinessCounts.evidence_gap || 0,
+        financingRiskRows: readinessCounts.financing_risk || 0,
+        ownerNeededRows: readinessCounts.owner_needed || 0,
+        informationalRows: readinessCounts.informational || 0,
+        missingEvidenceCount: missingEvidence.length,
+      };
 
       return {
         matrixId: `drm:${Buffer.from(
@@ -14752,18 +14771,21 @@ module.exports = {
           .toString('base64url')
           .slice(0, 24)}`,
         capabilityKey: 'decision_readiness_matrix',
-        safety: 'read_only',
+        caseId: params.caseId || null,
+        safety: 'read_only_evidence',
         requestContext: {
           caseId: params.caseId || null,
           includeSyntheticRows: Boolean(params.includeSyntheticRows),
         },
         status,
+        summary,
         rows: classifiedRows,
         readinessCounts,
         missingEvidence,
         positiveFollowUps,
         decisionBoundaries,
         dossierFacts,
+        evidenceFacts: dossierFacts,
         sourceActions: {
           inspected: ['dashboard-api.decisionReadinessMatrixStatus'],
           referenced: ['vdmi.dossier', 'evidence-registry.findings', 'decision-frame.list'],
@@ -14793,12 +14815,32 @@ module.exports = {
         })),
         dossierEvidence: {
           status,
+          summary,
           rows: classifiedRows,
           readinessCounts,
           missingEvidence,
           positiveFollowUps,
           decisionBoundaries,
+          sourceActions: {
+            notCalled: [
+              'budget.approve',
+              'finance.book',
+              'procurement.create',
+              'sap.erp.write',
+              'hitl.create',
+              'workflow.execute',
+              'webhook.emit',
+              'mail.send',
+              'billing.release',
+              'settlement.prepareBilling',
+              'tariff.mutate',
+              'mako.dispatch',
+              'device-control.execute',
+              'external.connector.call',
+            ],
+          },
           dossierFacts,
+          evidenceFacts: dossierFacts,
         },
       };
     },

--- a/src/answer-dossier-hydration-rules.json
+++ b/src/answer-dossier-hydration-rules.json
@@ -624,7 +624,7 @@
       "fields": [
         { "paths": ["status", "dossierEvidence.status"], "label": "Decision Readiness", "maxLen": 80 },
         { "paths": ["rows.0.measureName", "dossierEvidence.rows.0.measureName"], "label": "Measure", "maxLen": 120 },
-        { "paths": ["rows.0.readiness", "dossierEvidence.rows.0.readiness"], "label": "Row Status", "maxLen": 80 },
+        { "paths": ["rows.0.status", "dossierEvidence.rows.0.status", "rows.0.readiness", "dossierEvidence.rows.0.readiness"], "label": "Row Status", "maxLen": 80 },
         { "paths": ["readinessCounts.decision_ready", "dossierEvidence.readinessCounts.decision_ready"], "label": "Ready Rows", "maxLen": 40 },
         { "paths": ["missingEvidence.0.missingDataPoint", "dossierEvidence.missingEvidence.0.missingDataPoint"], "label": "Leading Gap", "maxLen": 100 },
         { "paths": ["positiveFollowUps.0.enablesDossierAddition", "dossierEvidence.positiveFollowUps.0.enablesDossierAddition"], "label": "Follow-up Enables", "maxLen": 160 },

--- a/src/evidence-registry.js
+++ b/src/evidence-registry.js
@@ -6324,14 +6324,14 @@ const EVIDENCE_REGISTRY = Object.freeze({
       {
         id: 'budget_status',
         label: 'Budget status',
-        resolvedBy: ['dashboard-api.decisionReadinessMatrixStatus', 'finance.evidence'],
+        resolvedBy: ['dashboard-api.decisionReadinessMatrixStatus', 'vdmi.dossier'],
         contextKeys: ['budgetStatus'],
         optional: false,
       },
       {
         id: 'financing_option',
         label: 'Financing option / risk evidence',
-        resolvedBy: ['dashboard-api.decisionReadinessMatrixStatus', 'finance.evidence'],
+        resolvedBy: ['dashboard-api.decisionReadinessMatrixStatus', 'vdmi.dossier'],
         contextKeys: ['financingOption'],
         optional: false,
       },

--- a/tests/capability-broker.service.test.js
+++ b/tests/capability-broker.service.test.js
@@ -1820,9 +1820,7 @@ describe('Capability Broker Service', () => {
     });
 
     expect(result.capability).toBe('gas_transformation_dataroom_status');
-    expect(result.recommendedCapabilities[0].capability).toBe(
-      'gas_transformation_dataroom_status'
-    );
+    expect(result.recommendedCapabilities[0].capability).toBe('gas_transformation_dataroom_status');
     const actionNames = result.recommendedPlan.map((step) => step.action);
     expect(actionNames).toContain('dashboard-api.gasTransformationDataroomStatus');
     expect(actionNames).not.toContain('object-store.create');

--- a/tests/capability-broker.service.test.js
+++ b/tests/capability-broker.service.test.js
@@ -932,7 +932,25 @@ describe('Capability Broker Service', () => {
     expect(actionNames).not.toContain('sap.erp.write');
     expect(actionNames).not.toContain('hitl.create');
     expect(actionNames).not.toContain('billing.release');
+    expect(actionNames).not.toContain('settlement.prepareBilling');
+    expect(actionNames).not.toContain('tariff.mutate');
+    expect(actionNames).not.toContain('mako.dispatch');
+    expect(actionNames).not.toContain('device-control.execute');
+    expect(actionNames).not.toContain('external.connector.call');
     expect(actionNames).not.toContain('personal-agent.execute');
+  });
+
+  it('does not steal billing, settlement, tariff, MaKo, legal or regulatory intents', async () => {
+    const prompts = [
+      'Bitte MaKo Abrechnung Settlement Tarifstatus fuer Lieferstellen pruefen.',
+      'Bitte legal regulatory clarification fuer EEG Rechtsfrage und BNetzA Nachweis klaeren.',
+    ];
+
+    for (const task of prompts) {
+      const result = await broker.call('capability-broker.recommend', { task });
+      expect(result.capability).not.toBe('decision_readiness_matrix');
+      expect(result.recommendedCapabilities[0].capability).not.toBe('decision_readiness_matrix');
+    }
   });
 
   it('routes cross-system variance prompts to the read-only VNB variance matrix', async () => {

--- a/tests/dashboard-api.test.js
+++ b/tests/dashboard-api.test.js
@@ -2258,9 +2258,16 @@ describe('dashboard-api.service', () => {
 
         expect(result.status).toBe('evidence_gap');
         expect(result.capabilityKey).toBe('decision_readiness_matrix');
+        expect(result.caseId).toBe('case-379');
+        expect(result.summary).toMatchObject({
+          status: 'evidence_gap',
+          rowCount: 1,
+          missingEvidenceCount: expect.any(Number),
+        });
         expect(result.rows[0]).toMatchObject({
           measureName: 'OPL grid study',
           readiness: 'evidence_gap',
+          status: 'evidence_gap',
         });
         expect(result.missingEvidence.map((gap) => gap.missingDataPoint)).toEqual(
           expect.arrayContaining([
@@ -2277,13 +2284,25 @@ describe('dashboard-api.service', () => {
         expect(result.sourceActions.notCalled).toEqual(
           expect.arrayContaining([
             'budget.approve',
+            'finance.book',
+            'procurement.create',
             'sap.erp.write',
             'hitl.create',
+            'workflow.execute',
+            'mail.send',
             'billing.release',
+            'settlement.prepareBilling',
+            'tariff.mutate',
+            'mako.dispatch',
+            'device-control.execute',
             'external.connector.call',
           ])
         );
-        expect(result.safety).toBe('read_only');
+        expect(result.dossierEvidence.sourceActions.notCalled).toEqual(
+          expect.arrayContaining(['budget.approve', 'settlement.prepareBilling'])
+        );
+        expect(result.evidenceFacts).toEqual(result.dossierFacts);
+        expect(result.safety).toBe('read_only_evidence');
       });
 
       it('returns decision_ready for a fully evidenced measure row', async () => {
@@ -2303,6 +2322,8 @@ describe('dashboard-api.service', () => {
 
         expect(result.status).toBe('decision_ready');
         expect(result.readinessCounts.decision_ready).toBe(1);
+        expect(result.summary.readyRows).toBe(1);
+        expect(result.rows[0].status).toBe('decision_ready');
         expect(result.missingEvidence).toEqual([]);
         expect(result.dossierEvidence.dossierFacts).toContain('Decision-ready rows: 1');
       });
@@ -2322,6 +2343,36 @@ describe('dashboard-api.service', () => {
 
         expect(result.status).toBe('financing_risk');
         expect(result.rows[0].readiness).toBe('financing_risk');
+        expect(result.rows[0].status).toBe('financing_risk');
+        expect(result.summary.financingRiskRows).toBe(1);
+      });
+
+      it('flags a sourced measure without owner as owner_needed', async () => {
+        const result = await broker.call('dashboard-api.decisionReadinessMatrixStatus', {
+          measureName: 'Station reinforcement',
+          category: 'asset_investment',
+          budgetStatus: 'minimum-budget-confirmed',
+          financingOption: 'internal-planning-budget',
+          riskIfNotImplemented: 'capacity-delay',
+          evidenceSource: 'opl:row-380',
+          committeeWindow: '2026-Q4',
+          nextDecisionPoint: 'capex-board',
+        });
+
+        expect(result.status).toBe('owner_needed');
+        expect(result.rows[0].status).toBe('owner_needed');
+        expect(result.readinessCounts.owner_needed).toBe(1);
+      });
+
+      it('keeps rows with only descriptive context informational', async () => {
+        const result = await broker.call('dashboard-api.decisionReadinessMatrixStatus', {
+          caseId: 'case-379',
+          measureName: 'Parking-lot OPL note',
+        });
+
+        expect(result.status).toBe('evidence_gap');
+        expect(result.rows[0].status).toBe('informational');
+        expect(result.readinessCounts.informational).toBe(1);
       });
     });
 

--- a/tests/dashboard-api.test.js
+++ b/tests/dashboard-api.test.js
@@ -2491,9 +2491,7 @@ describe('dashboard-api.service', () => {
             'test_case_hint',
           ])
         );
-        expect(result.positiveFollowUps[0].category).toBe(
-          'regulatory_signal_process_translator'
-        );
+        expect(result.positiveFollowUps[0].category).toBe('regulatory_signal_process_translator');
         expect(result.sourceActions.notCalled).toEqual(
           expect.arrayContaining([
             'legal.interpret',
@@ -4481,9 +4479,7 @@ describe('dashboard-api.service', () => {
         });
 
         expect(stale.status).toBe('stale');
-        expect(stale.staleMarkers.map((marker) => marker.marker)).toContain(
-          'leading_source_stale'
-        );
+        expect(stale.staleMarkers.map((marker) => marker.marker)).toContain('leading_source_stale');
         expect(stale.positiveFollowUps.map((gap) => gap.missingDataPoint)).toContain(
           'stale_leading_source_refresh'
         );

--- a/tests/dossier-hydration.test.js
+++ b/tests/dossier-hydration.test.js
@@ -2430,9 +2430,7 @@ describe('dossier-hydration-registry (unit)', () => {
         },
       });
 
-      expect(formatted).toContain(
-        'Nicht-Eskalation Status: needs_absent_blocker_evidence'
-      );
+      expect(formatted).toContain('Nicht-Eskalation Status: needs_absent_blocker_evidence');
       expect(formatted).toContain('Signal: signal-368');
       expect(formatted).toContain('Quelle: monitor');
       expect(formatted).toContain('Leading Gap: blocking_finding');
@@ -2444,10 +2442,7 @@ describe('dossier-hydration-registry (unit)', () => {
       expect(rule).not.toBeNull();
       expect(isSafetyRejectedAction(rule.action)).toBe(false);
       expect(
-        rule.extractParams(
-          [],
-          'Bitte review=cr-367 owner=controlling gate=invest-board laden'
-        )
+        rule.extractParams([], 'Bitte review=cr-367 owner=controlling gate=invest-board laden')
       ).toEqual({
         reviewId: 'cr-367',
         owner: 'controlling',
@@ -2462,9 +2457,7 @@ describe('dossier-hydration-registry (unit)', () => {
         decisionReadiness: null,
         nextCommitteeGate: 'invest-board',
         missingEvidence: [{ missingDataPoint: 'decision_readiness' }],
-        positiveFollowUps: [
-          { enablesDossierAddition: 'add readiness rationale and blockers' },
-        ],
+        positiveFollowUps: [{ enablesDossierAddition: 'add readiness rationale and blockers' }],
         sourceActions: { notCalled: ['budget.approve'] },
         dossierEvidence: {
           dossierFacts: ['Kostenpruefung Status: needs_decision_readiness'],

--- a/tests/dossier-hydration.test.js
+++ b/tests/dossier-hydration.test.js
@@ -506,7 +506,7 @@ describe('dossier-hydration-registry (unit)', () => {
 
       const formatted = rule.formatEvidence({
         status: 'evidence_gap',
-        rows: [{ measureName: 'grid-study', readiness: 'evidence_gap' }],
+        rows: [{ measureName: 'grid-study', status: 'evidence_gap', readiness: 'evidence_gap' }],
         readinessCounts: { decision_ready: 0 },
         missingEvidence: [{ missingDataPoint: 'budget_status' }],
         positiveFollowUps: [


### PR DESCRIPTION
## Summary
- Tightens the existing decision-readiness matrix API contract for Issue #379 with top-level caseId, safety=read_only_evidence, summary, evidenceFacts, and explicit row status while preserving readiness as a compatibility alias.
- Keeps the slice read-only and dossier-safe for VNB OPL/Budget/Massnahmen rows; budget/financing fields classify evidence only and do not approve, book, procure, or trigger workflows.
- Narrows evidence registry resolver labels for budget/financing facts to dashboard/VDMI dossier evidence instead of finance evidence.
- Updates dossier hydration formatting, generated OpenAPI/LLM artifacts, and focused coverage for dashboard, broker routing, hydration consumption, and API schema.

Fixes energychain/cernion-energy-tools#379

## Affected files
- services/dashboard-api.service.js
- src/evidence-registry.js
- src/answer-dossier-hydration-rules.json
- openapi-export.json
- llm.txt
- tests/dashboard-api.test.js
- tests/capability-broker.service.test.js
- tests/dossier-hydration.test.js

## Test evidence
- GITNEXUS_MAX_FILE_SIZE=1200 gitnexus analyze .
- gitnexus context --repo . --file services/dashboard-api.service.js decisionReadiness (confirmed pre-existing symbol lookup absence before edits)
- gitnexus context --repo . --file src/capability-catalog.js CURATED_CAPABILITIES
- gitnexus impact --repo . --uid File:src/capability-catalog.js
- gitnexus impact --repo . --uid File:src/dossier-hydration-registry.js
- npx jest --runInBand --coverage=false tests/dashboard-api.test.js tests/capability-broker.service.test.js tests/dossier-hydration.test.js tests/api.service.test.js (849 passed)
- npm run generate:llm
- npm run check:llm
- git diff --check
- gitnexus detect-changes --repo . --scope compare --base-ref origin/main (low risk, 0 affected processes)

## No-call guards
The dashboard response and broker tests assert the feature does not call or recommend budget.approve, finance.book, procurement.create, sap.erp.write, hitl.create, workflow.execute, webhook.emit, mail.send, billing.release, settlement.prepareBilling, tariff.mutate, mako.dispatch, device-control.execute, external.connector.call, or personal-agent.execute.

## DevServer smoke decision
Not run. This slice is a read-only Moleculer dashboard/API contract with generated OpenAPI coverage and focused service/API tests. Starting 10.0.0.8:3900 was not necessary after the passing PR commit/test evidence and no UI surface changed.