### PR TITLE
Add Open WebUI local smoke harness

### DIFF
--- a/integrations/open-webui/README.md
+++ b/integrations/open-webui/README.md
@@ -1,0 +1,63 @@
+# Cernion Open WebUI Integration
+
+This directory contains local verification helpers for the Open WebUI path. The smoke harness
+checks the Cernion chat-provider bridge and the OpenAPI toolserver contract without requiring
+secrets, expiring Sidecar sessions, real process mutations, webhooks or tenant data.
+
+## Local Smoke Test
+
+Run the self-contained smoke test with safe in-process mocks:
+
+```bash
+node integrations/open-webui/smoke-test.js
+```
+
+Expected output:
+
+```text
+[open-webui-smoke] bridge health, models, and chat completion shape passed
+[open-webui-smoke] toolserver health, OpenAPI, and read-only tool shape passed
+```
+
+The default mock path validates:
+
+- bridge `GET /health`
+- bridge `GET /v1/models`
+- bridge `POST /v1/chat/completions` OpenAI-compatible response shape
+- toolserver `GET /health`
+- toolserver `GET /openapi.json`
+- one read-only tool request at `POST /tools/read-only-status`
+
+To run the same checks against locally started services, pass explicit base URLs and disable mocks:
+
+```bash
+OPEN_WEBUI_SMOKE_USE_MOCKS=0 \
+OPEN_WEBUI_BRIDGE_BASE_URL=http://127.0.0.1:3900 \
+OPEN_WEBUI_TOOLSERVER_BASE_URL=http://127.0.0.1:3910 \
+node integrations/open-webui/smoke-test.js
+```
+
+Optional overrides:
+
+- `OPEN_WEBUI_SMOKE_MODEL`: model id sent to `/v1/chat/completions`
+- `OPEN_WEBUI_SMOKE_CHAT_BODY`: full JSON chat completion request body
+- `OPEN_WEBUI_TOOL_REQUEST_PATH`: read-only tool path, default `/tools/read-only-status`
+- `OPEN_WEBUI_TOOL_REQUEST_METHOD`: read-only tool method, default `POST`
+- `OPEN_WEBUI_TOOL_REQUEST_BODY`: full JSON read-only tool request body
+
+Failure messages include the broken layer name, such as `bridge-health`,
+`bridge-models-shape`, `bridge-chat-shape`, `toolserver-health`, `toolserver-openapi`,
+`toolserver-read-only-tool-shape`, `backend reachability`, or `smoke-config`.
+
+## Verification
+
+Focused checks:
+
+```bash
+node --test integrations/open-webui/*.test.js
+node integrations/open-webui/smoke-test.js
+```
+
+The harness is intentionally read-only. It must not call MaKo, billing, settlement, tariff,
+device-control, HITL, production deployment, external messaging, webhooks or mutating tenant
+operations.

--- a/integrations/open-webui/smoke-test.js
+++ b/integrations/open-webui/smoke-test.js
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+
+const http = require('node:http');
+
+const DEFAULT_MODEL = 'cernion-agent-mvp';
+
+class SmokeFailure extends Error {
+  constructor(layer, message, details) {
+    super(`[${layer}] ${message}`);
+    this.name = 'SmokeFailure';
+    this.layer = layer;
+    this.details = details;
+  }
+}
+
+function joinUrl(baseUrl, path) {
+  const base = String(baseUrl || '').replace(/\/+$/, '');
+  const suffix = String(path || '').startsWith('/') ? path : `/${path}`;
+  return `${base}${suffix}`;
+}
+
+async function fetchJson(layer, url, options = {}) {
+  let response;
+  try {
+    response = await fetch(url, {
+      ...options,
+      headers: {
+        accept: 'application/json',
+        ...(options.body ? { 'content-type': 'application/json' } : {}),
+        ...(options.headers || {}),
+      },
+    });
+  } catch (err) {
+    throw new SmokeFailure(layer, `Backend reachability failed for ${url}: ${err.message}`);
+  }
+
+  const text = await response.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch (err) {
+    throw new SmokeFailure(
+      layer,
+      `Expected JSON from ${url}, got ${response.status}: ${text.slice(0, 160)}`
+    );
+  }
+
+  if (!response.ok) {
+    throw new SmokeFailure(layer, `Expected 2xx from ${url}, got ${response.status}`, body);
+  }
+
+  return body;
+}
+
+function assertObject(layer, value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new SmokeFailure(layer, `${label} must be a JSON object`, value);
+  }
+}
+
+function validateHealth(layer, body) {
+  assertObject(layer, body, 'health response');
+  const status = body.status || body.ok || body.healthy;
+  if (status === false || status === 'error' || status === 'failed' || status === 'unhealthy') {
+    throw new SmokeFailure(layer, 'health response reported an unhealthy status', body);
+  }
+}
+
+function validateModels(body) {
+  assertObject('bridge-models-shape', body, 'models response');
+  if (body.object !== 'list') {
+    throw new SmokeFailure('bridge-models-shape', 'models response must use OpenAI list shape', body);
+  }
+  if (!Array.isArray(body.data) || body.data.length === 0) {
+    throw new SmokeFailure('bridge-models-shape', 'models response must include a non-empty data array', body);
+  }
+  for (const model of body.data) {
+    if (!model || typeof model.id !== 'string' || !model.id.trim()) {
+      throw new SmokeFailure('bridge-models-shape', 'each model must include a string id', model);
+    }
+  }
+}
+
+function validateChatCompletion(body) {
+  assertObject('bridge-chat-shape', body, 'chat completion response');
+  if (body.object !== 'chat.completion') {
+    throw new SmokeFailure('bridge-chat-shape', 'chat completion must use object=chat.completion', body);
+  }
+  if (typeof body.id !== 'string' || !body.id.trim()) {
+    throw new SmokeFailure('bridge-chat-shape', 'chat completion must include a string id', body);
+  }
+  if (!Array.isArray(body.choices) || body.choices.length === 0) {
+    throw new SmokeFailure('bridge-chat-shape', 'chat completion must include choices', body);
+  }
+  const message = body.choices[0]?.message;
+  if (!message || message.role !== 'assistant' || typeof message.content !== 'string') {
+    throw new SmokeFailure('bridge-chat-shape', 'first choice must include assistant message content', body);
+  }
+  assertObject('bridge-chat-shape', body.usage, 'chat completion usage');
+}
+
+function validateOpenApi(body) {
+  assertObject('toolserver-openapi', body, 'OpenAPI response');
+  if (typeof body.openapi !== 'string' || !body.openapi.startsWith('3.')) {
+    throw new SmokeFailure('toolserver-openapi', 'OpenAPI response must declare an OpenAPI 3.x version', body);
+  }
+  assertObject('toolserver-openapi', body.paths, 'OpenAPI paths');
+}
+
+function validateReadOnlyToolResponse(body) {
+  assertObject('toolserver-read-only-tool-shape', body, 'read-only tool response');
+  const declaredReadOnly =
+    body.readOnly === true ||
+    body.safety === 'read_only' ||
+    body.mode === 'read_only' ||
+    body.consequenceLevel === 'none';
+  if (!declaredReadOnly) {
+    throw new SmokeFailure(
+      'toolserver-read-only-tool-shape',
+      'read-only tool response must declare readOnly=true, safety=read_only, mode=read_only, or consequenceLevel=none',
+      body
+    );
+  }
+}
+
+async function checkBridge(baseUrl, options = {}) {
+  const model = options.model || DEFAULT_MODEL;
+  const chatBody = options.chatBody || {
+    model,
+    messages: [
+      {
+        role: 'user',
+        content: 'Open WebUI smoke test: return a short safe readiness response.',
+      },
+    ],
+    stream: false,
+  };
+
+  const health = await fetchJson('bridge-health', joinUrl(baseUrl, '/health'));
+  validateHealth('bridge-health', health);
+
+  const models = await fetchJson('bridge-models-shape', joinUrl(baseUrl, '/v1/models'));
+  validateModels(models);
+
+  const chat = await fetchJson('bridge-chat-shape', joinUrl(baseUrl, '/v1/chat/completions'), {
+    method: 'POST',
+    body: JSON.stringify(chatBody),
+  });
+  validateChatCompletion(chat);
+}
+
+async function checkToolserver(baseUrl, options = {}) {
+  const method = (options.toolMethod || 'POST').toUpperCase();
+  const toolPath = options.toolPath || '/tools/read-only-status';
+  const toolBody = options.toolBody || {
+    tenantId: 'smoke-local',
+    mode: 'read_only',
+  };
+
+  const health = await fetchJson('toolserver-health', joinUrl(baseUrl, '/health'));
+  validateHealth('toolserver-health', health);
+
+  const spec = await fetchJson('toolserver-openapi', joinUrl(baseUrl, '/openapi.json'));
+  validateOpenApi(spec);
+
+  const toolResponse = await fetchJson(
+    'toolserver-read-only-tool-shape',
+    joinUrl(baseUrl, toolPath),
+    {
+      method,
+      body: method === 'GET' ? undefined : JSON.stringify(toolBody),
+    }
+  );
+  validateReadOnlyToolResponse(toolResponse);
+}
+
+function createMockServer(kind) {
+  const server = http.createServer(async (req, res) => {
+    for await (const chunk of req) {
+      void chunk;
+    }
+    const send = (statusCode, body) => {
+      res.writeHead(statusCode, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(body));
+    };
+
+    if (req.method === 'GET' && req.url === '/health') {
+      send(200, { status: 'ok', service: kind });
+      return;
+    }
+
+    if (kind === 'bridge' && req.method === 'GET' && req.url === '/v1/models') {
+      send(200, {
+        object: 'list',
+        data: [{ id: DEFAULT_MODEL, object: 'model', owned_by: 'cernion-local-smoke' }],
+      });
+      return;
+    }
+
+    if (kind === 'bridge' && req.method === 'POST' && req.url === '/v1/chat/completions') {
+      send(200, {
+        id: 'chatcmpl_local_smoke',
+        object: 'chat.completion',
+        created: 1,
+        model: DEFAULT_MODEL,
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'local smoke ready' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+      });
+      return;
+    }
+
+    if (kind === 'toolserver' && req.method === 'GET' && req.url === '/openapi.json') {
+      send(200, {
+        openapi: '3.0.3',
+        info: { title: 'Cernion Open WebUI Local Toolserver', version: '0.0.0-smoke' },
+        paths: {
+          '/tools/read-only-status': {
+            post: {
+              operationId: 'readOnlyStatus',
+              summary: 'Read local smoke status',
+              'x-cernion-safety': 'read_only',
+              responses: { 200: { description: 'read-only status' } },
+            },
+          },
+        },
+      });
+      return;
+    }
+
+    if (kind === 'toolserver' && req.method === 'POST' && req.url === '/tools/read-only-status') {
+      send(200, {
+        status: 'ok',
+        safety: 'read_only',
+        readOnly: true,
+        checkedAt: '1970-01-01T00:00:00.000Z',
+      });
+      return;
+    }
+
+    send(404, { status: 'not_found', method: req.method, path: req.url });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+}
+
+function parseJsonEnv(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new SmokeFailure('smoke-config', `${name} must be valid JSON: ${err.message}`);
+  }
+}
+
+async function runSmoke(config = {}) {
+  const started = [];
+  let bridgeBaseUrl = config.bridgeBaseUrl || process.env.OPEN_WEBUI_BRIDGE_BASE_URL;
+  let toolserverBaseUrl = config.toolserverBaseUrl || process.env.OPEN_WEBUI_TOOLSERVER_BASE_URL;
+  const useMocks = config.useMocks ?? (!bridgeBaseUrl || !toolserverBaseUrl);
+
+  try {
+    if (!bridgeBaseUrl && useMocks) {
+      const mockBridge = await createMockServer('bridge');
+      started.push(mockBridge);
+      bridgeBaseUrl = mockBridge.baseUrl;
+    }
+
+    if (!toolserverBaseUrl && useMocks) {
+      const mockToolserver = await createMockServer('toolserver');
+      started.push(mockToolserver);
+      toolserverBaseUrl = mockToolserver.baseUrl;
+    }
+
+    if (!bridgeBaseUrl) {
+      throw new SmokeFailure(
+        'smoke-config',
+        'OPEN_WEBUI_BRIDGE_BASE_URL is required when mock bridge is disabled'
+      );
+    }
+    if (!toolserverBaseUrl) {
+      throw new SmokeFailure(
+        'smoke-config',
+        'OPEN_WEBUI_TOOLSERVER_BASE_URL is required when mock toolserver is disabled'
+      );
+    }
+
+    console.log(`[open-webui-smoke] bridge: ${bridgeBaseUrl}`);
+    await checkBridge(bridgeBaseUrl, {
+      model: config.model || process.env.OPEN_WEBUI_SMOKE_MODEL || DEFAULT_MODEL,
+      chatBody: config.chatBody || parseJsonEnv('OPEN_WEBUI_SMOKE_CHAT_BODY'),
+    });
+    console.log('[open-webui-smoke] bridge health, models, and chat completion shape passed');
+
+    console.log(`[open-webui-smoke] toolserver: ${toolserverBaseUrl}`);
+    await checkToolserver(toolserverBaseUrl, {
+      toolPath: config.toolPath || process.env.OPEN_WEBUI_TOOL_REQUEST_PATH,
+      toolMethod: config.toolMethod || process.env.OPEN_WEBUI_TOOL_REQUEST_METHOD,
+      toolBody: config.toolBody || parseJsonEnv('OPEN_WEBUI_TOOL_REQUEST_BODY'),
+    });
+    console.log('[open-webui-smoke] toolserver health, OpenAPI, and read-only tool shape passed');
+
+    return { bridgeBaseUrl, toolserverBaseUrl };
+  } finally {
+    await Promise.all(started.map((server) => server.close()));
+  }
+}
+
+if (require.main === module) {
+  const useMocks = process.env.OPEN_WEBUI_SMOKE_USE_MOCKS !== '0';
+  runSmoke({ useMocks }).catch((err) => {
+    if (err instanceof SmokeFailure) {
+      console.error(`[open-webui-smoke] FAILED ${err.message}`);
+      if (err.details) console.error(JSON.stringify(err.details, null, 2));
+    } else {
+      console.error('[open-webui-smoke] FAILED unexpected error');
+      console.error(err.stack || err.message);
+    }
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  SmokeFailure,
+  checkBridge,
+  checkToolserver,
+  createMockServer,
+  runSmoke,
+  validateChatCompletion,
+  validateHealth,
+  validateModels,
+  validateOpenApi,
+  validateReadOnlyToolResponse,
+};

--- a/integrations/open-webui/smoke-test.test.js
+++ b/integrations/open-webui/smoke-test.test.js
@@ -1,0 +1,61 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  SmokeFailure,
+  createMockServer,
+  runSmoke,
+  validateChatCompletion,
+  validateModels,
+  validateOpenApi,
+  validateReadOnlyToolResponse,
+} = require('./smoke-test');
+
+test('local smoke harness passes against safe in-process mocks', async () => {
+  const result = await runSmoke({ useMocks: true });
+
+  assert.match(result.bridgeBaseUrl, /^http:\/\/127\.0\.0\.1:/);
+  assert.match(result.toolserverBaseUrl, /^http:\/\/127\.0\.0\.1:/);
+});
+
+test('bridge shape failures identify OpenAI-compatible provider layer', () => {
+  assert.throws(
+    () => validateModels({ object: 'list', data: [{}] }),
+    (err) => err instanceof SmokeFailure && err.layer === 'bridge-models-shape'
+  );
+
+  assert.throws(
+    () => validateChatCompletion({ object: 'message', choices: [] }),
+    (err) => err instanceof SmokeFailure && err.layer === 'bridge-chat-shape'
+  );
+});
+
+test('toolserver shape failures identify spec and read-only tool layers', () => {
+  assert.throws(
+    () => validateOpenApi({ openapi: '2.0', paths: {} }),
+    (err) => err instanceof SmokeFailure && err.layer === 'toolserver-openapi'
+  );
+
+  assert.throws(
+    () => validateReadOnlyToolResponse({ status: 'ok' }),
+    (err) => err instanceof SmokeFailure && err.layer === 'toolserver-read-only-tool-shape'
+  );
+});
+
+test('external URL mode can target explicit bridge and toolserver bases', async () => {
+  const bridge = await createMockServer('bridge');
+  const toolserver = await createMockServer('toolserver');
+
+  try {
+    const result = await runSmoke({
+      useMocks: false,
+      bridgeBaseUrl: bridge.baseUrl,
+      toolserverBaseUrl: toolserver.baseUrl,
+    });
+
+    assert.equal(result.bridgeBaseUrl, bridge.baseUrl);
+    assert.equal(result.toolserverBaseUrl, toolserver.baseUrl);
+  } finally {
+    await Promise.all([bridge.close(), toolserver.close()]);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "token:create": "node scripts/provision-token.js",
     "verify:agent-shapes": "node scripts/verify-agent-shapes.js",
     "verify:agent-shapes:curl": "bash scripts/verify-agent-shapes-curl.sh",
+    "verify:open-webui": "node integrations/open-webui/smoke-test.js",
     "build": "echo 'No build step required'",
     "blueprint:export": "node scripts/export-blueprints.js"
   },


### PR DESCRIPTION
## Problem

Open WebUI operators need one local command that validates the chat-provider bridge and OpenAPI toolserver path without requiring live expiring Sidecar sessions, secrets, or mutating process actions.

## Change

- Added `integrations/open-webui/smoke-test.js`, a Node-only smoke harness with safe in-process mocks by default and env-configurable real local bridge/toolserver URLs.
- Added focused `node:test` coverage for happy-path mocks, explicit external URL mode, and failure layer naming for bridge and toolserver shape checks.
- Added `integrations/open-webui/README.md` with local mock and real-service commands, expected output, safety boundaries, and overrides.
- Added `npm run verify:open-webui` for the smoke command.

## User Impact

Operators can verify bridge `/health`, `/v1/models`, `/v1/chat/completions`, toolserver `/health`, `/openapi.json`, and one read-only tool request shape locally without tenant/customer data, secrets, webhooks, browser automation, or writes.

## Evidence

```bash
node --test integrations/open-webui/*.test.js
node integrations/open-webui/smoke-test.js
npm run verify:open-webui
git diff --check
```

Fixes energychain/cernion-energy-tools#429
