### PR TITLE
feat(dashboard-api): extend Energy Sharing readiness evidence

### DIFF
--- a/llm.txt
+++ b/llm.txt
@@ -251,7 +251,7 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: b9fa91c95a1f029620fb0513b4453677cb2b61b64ca87549fe353262287ab1a8
-- openapi-export.json: 73118cbcae83b98d2507de0192b7c1cd7014f740cb12908e43988f9056549404
+- openapi-export.json: e74ed7852f124d354436f5f7d08d14be2204c35203f94ddd1be17a9a6fb1fc8f
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 994
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 74f5299510240b78c13a617c4aff564ca3af4d8666c8c65bf841f38792a778c0
+- llm_txt_sha256: d34139304a654dfa73a9f14d2768c0c0c089962481c92d82e8822bdec3a4e6bf

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -16110,6 +16110,18 @@
                     "positiveFollowUps": {
                       "type": "array"
                     },
+                    "extendedEvidenceItems": {
+                      "type": "array"
+                    },
+                    "extendedMissingEvidence": {
+                      "type": "array"
+                    },
+                    "extendedPositiveFollowUps": {
+                      "type": "array"
+                    },
+                    "portfolioEvidenceScore": {
+                      "type": "number"
+                    },
                     "sourceActions": {
                       "type": "object"
                     },
@@ -16135,7 +16147,7 @@
             }
           }
         },
-        "description": "Classifies Energy-Sharing candidates as learning pilot, simulation-ready, billing-near-ready or blocked by missing evidence. The endpoint is read-only and does not run allocation, settlement/A96 export, MaKo dispatch, billing, tariff mutation, HITL, external connector, customer communication or Personal Agent execution.",
+        "description": "Classifies Energy-Sharing candidates as learning pilot, simulation-ready, billing-near-ready or blocked by missing evidence. The endpoint is read-only and does not run allocation, settlement/A96 export, MaKo dispatch, billing, tariff mutation, HITL, external connector, customer communication or Personal Agent execution. It also projects extended portfolio evidence (generation/consumption MaLo, supplier/direct-marketer, balance group, metering concept, iMSys, 15-minute values, residual-supply contract, participation window, eligibility, exception rate and economics threshold) as review-only gaps that do not affect the core gate classification.",
         "parameters": [
           {
             "name": "communityId",
@@ -16251,6 +16263,118 @@
           },
           {
             "name": "sourceArtifacts",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "generationMaloEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "consumptionMaloEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "supplierEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "directMarketerEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "balanceGroupEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "meteringConceptEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "imsysStatus",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "quarterHourValuesReadiness",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "residualSupplyContractEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "participationStartDate",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "participationEndDate",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "eligibilityEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "exceptionRateEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "economicsThresholdRef",
             "in": "query",
             "required": false,
             "schema": {
@@ -70743,6 +70867,18 @@
                     "positiveFollowUps": {
                       "type": "array"
                     },
+                    "extendedEvidenceItems": {
+                      "type": "array"
+                    },
+                    "extendedMissingEvidence": {
+                      "type": "array"
+                    },
+                    "extendedPositiveFollowUps": {
+                      "type": "array"
+                    },
+                    "portfolioEvidenceScore": {
+                      "type": "number"
+                    },
                     "sourceActions": {
                       "type": "object"
                     },
@@ -70768,7 +70904,7 @@
             }
           }
         },
-        "description": "Classifies Energy-Sharing candidates as learning pilot, simulation-ready, billing-near-ready or blocked by missing evidence. The endpoint is read-only and does not run allocation, settlement/A96 export, MaKo dispatch, billing, tariff mutation, HITL, external connector, customer communication or Personal Agent execution.",
+        "description": "Classifies Energy-Sharing candidates as learning pilot, simulation-ready, billing-near-ready or blocked by missing evidence. The endpoint is read-only and does not run allocation, settlement/A96 export, MaKo dispatch, billing, tariff mutation, HITL, external connector, customer communication or Personal Agent execution. It also projects extended portfolio evidence (generation/consumption MaLo, supplier/direct-marketer, balance group, metering concept, iMSys, 15-minute values, residual-supply contract, participation window, eligibility, exception rate and economics threshold) as review-only gaps that do not affect the core gate classification.",
         "parameters": [
           {
             "name": "communityId",
@@ -70884,6 +71020,118 @@
           },
           {
             "name": "sourceArtifacts",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "generationMaloEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "consumptionMaloEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "supplierEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "directMarketerEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "balanceGroupEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "meteringConceptEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "imsysStatus",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "quarterHourValuesReadiness",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "residualSupplyContractEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "participationStartDate",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "participationEndDate",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "eligibilityEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "exceptionRateEvidenceRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "economicsThresholdRef",
             "in": "query",
             "required": false,
             "schema": {

--- a/services/dashboard-api.service.js
+++ b/services/dashboard-api.service.js
@@ -20969,6 +20969,9 @@ module.exports = {
           'supplier-connector.call',
           'direct-marketer-connector.call',
           'imsys-connector.sync',
+          'energy-sharing.contract.sign',
+          'tenant.provision',
+          'workflow.execute',
         ],
       };
       const dossierFacts = [

--- a/services/dashboard-api.service.js
+++ b/services/dashboard-api.service.js
@@ -3877,6 +3877,15 @@ module.exports = {
      * candidate as learning/simulation/billing-near readiness from supplied
      * evidence refs and never creates projects, allocations, settlement exports,
      * MaKo messages, HITL tasks, billing artefacts or customer communication.
+     *
+     * Also projects extended multi-site portfolio readiness evidence (issue #446):
+     * generation/consumption MaLo, supplier/direct-marketer, balance group,
+     * metering concept, iMSys status, 15-minute values, residual-supply contract,
+     * participation window, eligibility and exception-rate evidence, and an
+     * economics-threshold reference. These surface as separate
+     * extendedEvidenceItems/extendedMissingEvidence review-only gaps and do not
+     * change gateStatus/simulationStage/readinessScore or the core evidenceItems/
+     * missingEvidence shape.
      */
     energySharingSimulationGateStatus: {
       rest: 'GET /energy-sharing-simulation-gate',
@@ -3907,13 +3916,28 @@ module.exports = {
             { type: 'string', min: 1 },
           ],
         },
+        generationMaloEvidenceRef: { type: 'string', optional: true, min: 1 },
+        consumptionMaloEvidenceRef: { type: 'string', optional: true, min: 1 },
+        supplierEvidenceRef: { type: 'string', optional: true, min: 1 },
+        directMarketerEvidenceRef: { type: 'string', optional: true, min: 1 },
+        balanceGroupEvidenceRef: { type: 'string', optional: true, min: 1 },
+        meteringConceptEvidenceRef: { type: 'string', optional: true, min: 1 },
+        imsysStatus: { type: 'string', optional: true, min: 1 },
+        quarterHourValuesReadiness: { type: 'string', optional: true, min: 1 },
+        residualSupplyContractEvidenceRef: { type: 'string', optional: true, min: 1 },
+        participationStartDate: { type: 'string', optional: true, min: 1 },
+        participationEndDate: { type: 'string', optional: true, min: 1 },
+        eligibilityEvidenceRef: { type: 'string', optional: true, min: 1 },
+        exceptionRateEvidenceRef: { type: 'string', optional: true, min: 1 },
+        economicsThresholdRef: { type: 'string', optional: true, min: 1 },
       },
       openapi: {
         tags: [OPENAPI_TAG],
         summary: 'Energy-Sharing simulation gate - read-only dossier-safe status',
         description:
           'Classifies Energy-Sharing candidates as learning pilot, simulation-ready, billing-near-ready or blocked by missing evidence. ' +
-          'The endpoint is read-only and does not run allocation, settlement/A96 export, MaKo dispatch, billing, tariff mutation, HITL, external connector, customer communication or Personal Agent execution.',
+          'The endpoint is read-only and does not run allocation, settlement/A96 export, MaKo dispatch, billing, tariff mutation, HITL, external connector, customer communication or Personal Agent execution. ' +
+          'It also projects extended portfolio evidence (generation/consumption MaLo, supplier/direct-marketer, balance group, metering concept, iMSys, 15-minute values, residual-supply contract, participation window, eligibility, exception rate and economics threshold) as review-only gaps that do not affect the core gate classification.',
         parameters: [
           { name: 'communityId', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'gridOperatorId', in: 'query', required: false, schema: { type: 'string' } },
@@ -3945,6 +3969,75 @@ module.exports = {
           { name: 'owner', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'escalationContact', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'sourceArtifacts', in: 'query', required: false, schema: { type: 'string' } },
+          {
+            name: 'generationMaloEvidenceRef',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'consumptionMaloEvidenceRef',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
+          { name: 'supplierEvidenceRef', in: 'query', required: false, schema: { type: 'string' } },
+          {
+            name: 'directMarketerEvidenceRef',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'balanceGroupEvidenceRef',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'meteringConceptEvidenceRef',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
+          { name: 'imsysStatus', in: 'query', required: false, schema: { type: 'string' } },
+          {
+            name: 'quarterHourValuesReadiness',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'residualSupplyContractEvidenceRef',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'participationStartDate',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
+          { name: 'participationEndDate', in: 'query', required: false, schema: { type: 'string' } },
+          {
+            name: 'eligibilityEvidenceRef',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'exceptionRateEvidenceRef',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'economicsThresholdRef',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+          },
         ],
         responses: {
           200: {
@@ -3959,6 +4052,10 @@ module.exports = {
                     readinessScore: { type: 'number' },
                     missingEvidence: { type: 'array' },
                     positiveFollowUps: { type: 'array' },
+                    extendedEvidenceItems: { type: 'array' },
+                    extendedMissingEvidence: { type: 'array' },
+                    extendedPositiveFollowUps: { type: 'array' },
+                    portfolioEvidenceScore: { type: 'number' },
                     sourceActions: { type: 'object' },
                     dossierEvidence: { type: 'object' },
                     safety: { type: 'string' },
@@ -3973,7 +4070,24 @@ module.exports = {
       },
       async handler(ctx) {
         const params = { ...ctx.params };
-        const cacheKey = `energy-sharing-simulation-gate:${params.communityId || 'no-community'}:${params.gridOperatorId || 'no-grid'}:${params.participantCount || 'no-participants'}:${params.maloStatus || 'no-malo'}:${params.meteringReadiness || 'no-metering'}:${params.marketRoleReadiness || 'no-market-role'}:${params.dataBasis || 'no-data-basis'}:${params.a96EvidenceRef || 'no-a96'}:${params.settlementEvidenceRef || 'no-settlement'}:${params.contractEvidenceRef || 'no-contract'}:${params.economicsAssumptionRef || 'no-economics'}`;
+        const cacheKey = `energy-sharing-simulation-gate:${params.communityId || 'no-community'}:${params.gridOperatorId || 'no-grid'}:${params.participantCount || 'no-participants'}:${params.maloStatus || 'no-malo'}:${params.meteringReadiness || 'no-metering'}:${params.marketRoleReadiness || 'no-market-role'}:${params.dataBasis || 'no-data-basis'}:${params.a96EvidenceRef || 'no-a96'}:${params.settlementEvidenceRef || 'no-settlement'}:${params.contractEvidenceRef || 'no-contract'}:${params.economicsAssumptionRef || 'no-economics'}:${JSON.stringify(
+          {
+            generationMaloEvidenceRef: params.generationMaloEvidenceRef || null,
+            consumptionMaloEvidenceRef: params.consumptionMaloEvidenceRef || null,
+            supplierEvidenceRef: params.supplierEvidenceRef || null,
+            directMarketerEvidenceRef: params.directMarketerEvidenceRef || null,
+            balanceGroupEvidenceRef: params.balanceGroupEvidenceRef || null,
+            meteringConceptEvidenceRef: params.meteringConceptEvidenceRef || null,
+            imsysStatus: params.imsysStatus || null,
+            quarterHourValuesReadiness: params.quarterHourValuesReadiness || null,
+            residualSupplyContractEvidenceRef: params.residualSupplyContractEvidenceRef || null,
+            participationStartDate: params.participationStartDate || null,
+            participationEndDate: params.participationEndDate || null,
+            eligibilityEvidenceRef: params.eligibilityEvidenceRef || null,
+            exceptionRateEvidenceRef: params.exceptionRateEvidenceRef || null,
+            economicsThresholdRef: params.economicsThresholdRef || null,
+          }
+        )}`;
 
         return this.cacheGetOrFetch(
           cacheKey,
@@ -20553,7 +20667,215 @@ module.exports = {
               ? 'ready'
               : 'missing_evidence',
         },
+        maloPortfolioReadiness: {
+          generationMaloEvidenceRef: params.generationMaloEvidenceRef || null,
+          consumptionMaloEvidenceRef: params.consumptionMaloEvidenceRef || null,
+          status:
+            params.generationMaloEvidenceRef && params.consumptionMaloEvidenceRef
+              ? 'ready'
+              : 'missing_evidence',
+        },
+        supplierModelReadiness: {
+          supplierEvidenceRef: params.supplierEvidenceRef || null,
+          directMarketerEvidenceRef: params.directMarketerEvidenceRef || null,
+          status:
+            params.supplierEvidenceRef || params.directMarketerEvidenceRef
+              ? 'ready'
+              : 'missing_evidence',
+        },
+        balanceGroupEvidenceReadiness: {
+          balanceGroupEvidenceRef: params.balanceGroupEvidenceRef || null,
+          status: params.balanceGroupEvidenceRef ? 'ready' : 'missing_evidence',
+        },
+        meteringConceptReadiness: {
+          meteringConceptEvidenceRef: params.meteringConceptEvidenceRef || null,
+          imsysStatus: params.imsysStatus || null,
+          quarterHourValuesReadiness: params.quarterHourValuesReadiness || null,
+          status:
+            params.meteringConceptEvidenceRef &&
+            isReady(params.imsysStatus) &&
+            isReady(params.quarterHourValuesReadiness)
+              ? 'ready'
+              : 'missing_evidence',
+        },
+        residualSupplyReadiness: {
+          residualSupplyContractEvidenceRef: params.residualSupplyContractEvidenceRef || null,
+          status: params.residualSupplyContractEvidenceRef ? 'ready' : 'missing_evidence',
+        },
+        participationWindowReadiness: {
+          participationStartDate: params.participationStartDate || null,
+          participationEndDate: params.participationEndDate || null,
+          status: params.participationStartDate ? 'ready' : 'missing_evidence',
+        },
+        eligibilityReadiness: {
+          eligibilityEvidenceRef: params.eligibilityEvidenceRef || null,
+          status: params.eligibilityEvidenceRef ? 'ready' : 'missing_evidence',
+        },
+        exceptionRateReadiness: {
+          exceptionRateEvidenceRef: params.exceptionRateEvidenceRef || null,
+          status: params.exceptionRateEvidenceRef ? 'ready' : 'missing_evidence',
+        },
+        economicsThresholdReadiness: {
+          economicsThresholdRef: params.economicsThresholdRef || null,
+          status: params.economicsThresholdRef ? 'ready' : 'missing_evidence',
+        },
       };
+
+      // Extended portfolio evidence (issue #446): generation/consumption MaLo,
+      // supplier/direct-marketer, balance group, metering concept, iMSys,
+      // 15-minute values, residual-supply contract, participation window,
+      // eligibility, exception rate and economics threshold. These are
+      // review-only gaps kept separate from evidenceSpecs/gateStatus so the
+      // existing four-state classification and evidenceItems/missingEvidence
+      // shape stay backwards compatible for current callers.
+      const extendedEvidenceSpecs = [
+        {
+          id: 'generation_consumption_malo',
+          label: 'Generation and consumption MaLo evidence',
+          value: params.generationMaloEvidenceRef && params.consumptionMaloEvidenceRef,
+          displayValue: [params.generationMaloEvidenceRef, params.consumptionMaloEvidenceRef]
+            .filter(Boolean)
+            .join(' / '),
+          readinessBlock: 'maloPortfolio',
+          sourceClass: 'malo_evidence',
+          enablesDossierAddition:
+            'add generation (Erzeugung) and consumption (Verbrauch) MaLo evidence references to confirm the portfolio scope',
+        },
+        {
+          id: 'supplier_direct_marketer',
+          label: 'Supplier or direct-marketer evidence',
+          value: params.supplierEvidenceRef || params.directMarketerEvidenceRef,
+          displayValue: [params.supplierEvidenceRef, params.directMarketerEvidenceRef]
+            .filter(Boolean)
+            .join(' / '),
+          readinessBlock: 'supplierModel',
+          sourceClass: 'supplier_evidence',
+          enablesDossierAddition:
+            'add supplier or direct-marketer evidence reference to confirm which delivery model applies',
+        },
+        {
+          id: 'balance_group_reference',
+          label: 'Balance-group (Bilanzkreis) evidence reference',
+          value: params.balanceGroupEvidenceRef,
+          displayValue: params.balanceGroupEvidenceRef,
+          readinessBlock: 'balanceGroup',
+          sourceClass: 'balance_group_evidence',
+          enablesDossierAddition:
+            'add a balance-group evidence reference in addition to the market-role readiness flag',
+        },
+        {
+          id: 'metering_concept',
+          label: 'Metering concept (Messkonzept) evidence',
+          value: params.meteringConceptEvidenceRef,
+          displayValue: params.meteringConceptEvidenceRef,
+          readinessBlock: 'meteringConcept',
+          sourceClass: 'metering_concept_evidence',
+          enablesDossierAddition:
+            'add metering-concept evidence documenting how shared quantities are measured and split',
+        },
+        {
+          id: 'imsys_status',
+          label: 'iMSys status',
+          value: isReady(params.imsysStatus),
+          displayValue: params.imsysStatus,
+          readinessBlock: 'meteringConcept',
+          sourceClass: 'imsys_evidence',
+          enablesDossierAddition: 'add iMSys rollout status distinct from generic metering readiness',
+        },
+        {
+          id: 'quarter_hour_values',
+          label: '15-minute value (Viertelstundenwerte) readiness',
+          value: isReady(params.quarterHourValuesReadiness),
+          displayValue: params.quarterHourValuesReadiness,
+          readinessBlock: 'meteringConcept',
+          sourceClass: 'quarter_hour_value_evidence',
+          enablesDossierAddition: 'add 15-minute value availability evidence for the candidate MaLos',
+        },
+        {
+          id: 'residual_supply_contract',
+          label: 'Residual-supply contract (Reststromvertrag) evidence',
+          value: params.residualSupplyContractEvidenceRef,
+          displayValue: params.residualSupplyContractEvidenceRef,
+          readinessBlock: 'residualSupply',
+          sourceClass: 'residual_supply_evidence',
+          enablesDossierAddition:
+            'add residual-supply contract evidence covering the non-shared quantity',
+        },
+        {
+          id: 'participation_window',
+          label: 'Participation start/exit date (Teilnahme-/Austrittsdatum)',
+          value: params.participationStartDate,
+          displayValue: [params.participationStartDate, params.participationEndDate]
+            .filter(Boolean)
+            .join(' - '),
+          readinessBlock: 'participationWindow',
+          sourceClass: 'participation_window_evidence',
+          enablesDossierAddition:
+            'add a participation start date (and exit date if known) for the candidate',
+        },
+        {
+          id: 'eligibility_evidence',
+          label: 'Eligibility (Berechtigung) evidence',
+          value: params.eligibilityEvidenceRef,
+          displayValue: params.eligibilityEvidenceRef,
+          readinessBlock: 'eligibility',
+          sourceClass: 'eligibility_evidence',
+          enablesDossierAddition:
+            'add eligibility evidence confirming the participant/operator is entitled to share energy',
+        },
+        {
+          id: 'exception_rate_evidence',
+          label: 'Exception-rate (Klaerfallquote) evidence',
+          value: params.exceptionRateEvidenceRef,
+          displayValue: params.exceptionRateEvidenceRef,
+          readinessBlock: 'exceptionRate',
+          sourceClass: 'exception_rate_evidence',
+          enablesDossierAddition:
+            'add an exception/clearing-case rate evidence reference for the candidate data basis',
+        },
+        {
+          id: 'economics_threshold',
+          label: 'Economics threshold (Wirtschaftlichkeitsschwellen) reference',
+          value: params.economicsThresholdRef,
+          displayValue: params.economicsThresholdRef,
+          readinessBlock: 'economicsThreshold',
+          sourceClass: 'economics_threshold_evidence',
+          enablesDossierAddition:
+            'add an explicit economics-threshold reference distinct from general economics assumptions',
+        },
+      ];
+
+      const extendedEvidenceItems = extendedEvidenceSpecs
+        .filter((spec) => normalizeStatus(spec.value) === 'ready')
+        .map((spec) => ({
+          id: spec.id,
+          label: spec.label,
+          value: spec.displayValue || spec.value,
+          readinessBlock: spec.readinessBlock,
+          sourceClass: spec.sourceClass,
+          evidenceStatus: 'provided',
+        }));
+      const extendedMissingEvidence = extendedEvidenceSpecs
+        .filter((spec) => normalizeStatus(spec.value) !== 'ready')
+        .map((spec) => ({
+          missingDataPoint: spec.id,
+          label: spec.label,
+          status: normalizeStatus(spec.value),
+          value: spec.displayValue || spec.value || null,
+          readinessBlock: spec.readinessBlock,
+          sourceClass: spec.sourceClass,
+          enablesDossierAddition: spec.enablesDossierAddition,
+        }));
+      const extendedPositiveFollowUps = extendedMissingEvidence.map((item) => ({
+        missingDataPoint: item.missingDataPoint,
+        status: item.status,
+        value: item.value,
+        enablesDossierAddition: item.enablesDossierAddition,
+        category: 'energy_sharing_portfolio_evidence',
+      }));
+      const portfolioEvidenceScore = Number(
+        (extendedEvidenceItems.length / extendedEvidenceSpecs.length).toFixed(2)
+      );
 
       const evidenceItems = evidenceSpecs
         .filter((spec) => normalizeStatus(spec.value) === 'ready')
@@ -20644,6 +20966,9 @@ module.exports = {
           'hitl.create',
           'external.connector.call',
           'personal-agent.execute',
+          'supplier-connector.call',
+          'direct-marketer-connector.call',
+          'imsys-connector.sync',
         ],
       };
       const dossierFacts = [
@@ -20651,6 +20976,8 @@ module.exports = {
         `Simulation Stage: ${simulationStage}`,
         `Provided Energy-Sharing gate evidence: ${evidenceItems.length}/${evidenceSpecs.length}`,
         `Open gaps: ${missingEvidence.length}`,
+        `Provided portfolio evidence: ${extendedEvidenceItems.length}/${extendedEvidenceSpecs.length}`,
+        `Open portfolio evidence gaps: ${extendedMissingEvidence.length}`,
       ];
       if (params.communityId) dossierFacts.push(`Community: ${params.communityId}`);
       if (params.gridOperatorId) dossierFacts.push(`Grid Operator: ${params.gridOperatorId}`);
@@ -20673,6 +21000,10 @@ module.exports = {
         evidenceItems,
         missingEvidence,
         positiveFollowUps,
+        extendedEvidenceItems,
+        extendedMissingEvidence,
+        extendedPositiveFollowUps,
+        portfolioEvidenceScore,
         sourceArtifacts,
         sourceActions,
         validationFindings: missingEvidence,
@@ -20688,6 +21019,10 @@ module.exports = {
           evidenceItems,
           missingEvidence,
           positiveFollowUps,
+          extendedEvidenceItems,
+          extendedMissingEvidence,
+          extendedPositiveFollowUps,
+          portfolioEvidenceScore,
           sourceArtifacts,
           sourceActions: {
             notCalled: sourceActions.notCalled,

--- a/tests/dashboard-api.test.js
+++ b/tests/dashboard-api.test.js
@@ -5301,6 +5301,121 @@ describe('dashboard-api.service', () => {
         );
         expect(result.sourceActions.notCalled).toContain('energy-sharing-allocation.allocate');
       });
+
+      it('keeps the core gate backwards compatible when portfolio evidence (issue #446) is not supplied', async () => {
+        const result = await broker.call('dashboard-api.energySharingSimulationGateStatus', {
+          communityId: 'es-230',
+          gridOperatorId: 'vnb-230',
+          participantCount: '42',
+          participantEvidenceRef: 'participants-v2',
+          maloStatus: 'ready',
+          meteringReadiness: 'ready',
+          marketRoleReadiness: 'ready',
+          dataBasis: 'inhouse-imsys-mscons',
+          a96EvidenceRef: 'a96-ready',
+          settlementEvidenceRef: 'settlement-ready',
+          contractEvidenceRef: 'contracts-ready',
+          economicsAssumptionRef: 'economics-v1',
+          owner: 'energy-sharing-owner',
+          escalationContact: 'billing-lead',
+        });
+
+        expect(result.gateStatus).toBe('billing_near_ready');
+        expect(result.simulationStage).toBe('billing_near_ready');
+        expect(result.missingEvidence).toEqual([]);
+        expect(result.extendedMissingEvidence.map((gap) => gap.missingDataPoint)).toEqual(
+          expect.arrayContaining([
+            'generation_consumption_malo',
+            'supplier_direct_marketer',
+            'balance_group_reference',
+            'metering_concept',
+            'imsys_status',
+            'quarter_hour_values',
+            'residual_supply_contract',
+            'participation_window',
+            'eligibility_evidence',
+            'exception_rate_evidence',
+            'economics_threshold',
+          ])
+        );
+        expect(result.extendedEvidenceItems).toEqual([]);
+        expect(result.portfolioEvidenceScore).toBe(0);
+      });
+
+      it('reports portfolio evidence (generation/consumption MaLo, supplier, balance group, metering concept, iMSys, 15-minute values, residual supply, participation window, eligibility, exception rate, economics threshold) as provided when supplied, without changing the core gate', async () => {
+        const result = await broker.call('dashboard-api.energySharingSimulationGateStatus', {
+          communityId: 'es-231',
+          gridOperatorId: 'vnb-231',
+          participantCount: '7',
+          participantEvidenceRef: 'participants-v3',
+          dataBasis: 'forecast',
+          owner: 'product-owner',
+          escalationContact: 'marktrolle-team',
+          generationMaloEvidenceRef: 'gen-malo-1',
+          consumptionMaloEvidenceRef: 'cons-malo-1',
+          supplierEvidenceRef: 'supplier-1',
+          balanceGroupEvidenceRef: 'bk-1',
+          meteringConceptEvidenceRef: 'messkonzept-1',
+          imsysStatus: 'ready',
+          quarterHourValuesReadiness: 'ready',
+          residualSupplyContractEvidenceRef: 'reststrom-1',
+          participationStartDate: '2026-08-01',
+          eligibilityEvidenceRef: 'berechtigung-1',
+          exceptionRateEvidenceRef: 'klaerfallquote-1',
+          economicsThresholdRef: 'threshold-1',
+        });
+
+        // Core gate classification is unaffected by portfolio evidence.
+        expect(result.gateStatus).toBe('learning_pilot');
+        expect(result.simulationStage).toBe('learning_pilot');
+
+        expect(result.extendedMissingEvidence).toEqual([]);
+        expect(result.portfolioEvidenceScore).toBe(1);
+        expect(result.extendedEvidenceItems.map((item) => item.id)).toEqual(
+          expect.arrayContaining([
+            'generation_consumption_malo',
+            'supplier_direct_marketer',
+            'balance_group_reference',
+            'metering_concept',
+            'imsys_status',
+            'quarter_hour_values',
+            'residual_supply_contract',
+            'participation_window',
+            'eligibility_evidence',
+            'exception_rate_evidence',
+            'economics_threshold',
+          ])
+        );
+        expect(result.extendedPositiveFollowUps).toEqual([]);
+      });
+
+      it('never calls allocation, billing, settlement, MaKo, contract signing, onboarding, workflow or connector actions for portfolio evidence gaps', async () => {
+        const result = await broker.call('dashboard-api.energySharingSimulationGateStatus', {
+          communityId: 'es-232',
+          gridOperatorId: 'vnb-232',
+        });
+
+        expect(result.extendedPositiveFollowUps[0].category).toBe(
+          'energy_sharing_portfolio_evidence'
+        );
+        expect(result.sourceActions.notCalled).toEqual(
+          expect.arrayContaining([
+            'energy-sharing.createProject',
+            'energy-sharing-allocation.allocate',
+            'settlement.exportA96',
+            'mako.dispatch',
+            'billing.release',
+            'tariff.mutate',
+            'hitl.create',
+            'external.connector.call',
+            'personal-agent.execute',
+            'supplier-connector.call',
+            'direct-marketer-connector.call',
+            'imsys-connector.sync',
+          ])
+        );
+        expect(result.safety).toBe('read_only');
+      });
     });
 
     // -- energySharing42cCutoverReadinessStatus -----------------------------

--- a/tests/dashboard-api.test.js
+++ b/tests/dashboard-api.test.js
@@ -5412,6 +5412,9 @@ describe('dashboard-api.service', () => {
             'supplier-connector.call',
             'direct-marketer-connector.call',
             'imsys-connector.sync',
+            'energy-sharing.contract.sign',
+            'tenant.provision',
+            'workflow.execute',
           ])
         );
         expect(result.safety).toBe('read_only');


### PR DESCRIPTION
## Summary

- extend the existing read-only Energy Sharing simulation gate with supplied portfolio evidence for generation/consumption MaLo, supplier/direct marketer, balance group, metering/iMSys/15-minute values, residual supply, participation dates, eligibility, exception rate and economics threshold
- preserve the existing endpoint, capability key, four-state classification and legacy evidence fields
- expose portfolio evidence and review-only gaps separately, with explicit no-call guards
- regenerate LLM/OpenAPI artifacts

## Safety boundary

Read-only projection only. No production hydration, persistence, connector execution, workflow/task creation, allocation, contract signing, onboarding, billing, settlement, MaKo, device control, Personal Agent execution, secrets, wallets or key material.

## Verification

- `npx jest tests/dashboard-api.test.js --runInBand` — 439 passed
- `npx jest tests/api.service.test.js tests/capability-broker.service.test.js tests/dossier-hydration.test.js --runInBand` — 453 passed
- `npm run generate:llm` — passed
- `npm run check:llm` — passed
- `git diff --check` — passed
- GitNexus query/context/impact gate completed; related Energy Sharing and Bilanzkreis surfaces identified, with the oversized dashboard service inspected directly

Relates to #446. The issue should remain open until merge, DevServer deployment and the required synthetic read-only endpoint smoke are proven.
