### PR TITLE
feat(dashboard-api): add FCA/fNAV lifecycle evidence projection

### DIFF
--- a/llm.txt
+++ b/llm.txt
@@ -251,7 +251,7 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: b9fa91c95a1f029620fb0513b4453677cb2b61b64ca87549fe353262287ab1a8
-- openapi-export.json: 73118cbcae83b98d2507de0192b7c1cd7014f740cb12908e43988f9056549404
+- openapi-export.json: 8ce89c71dd61e2e0fbb957e8ed3a4f0dfae1e985057764f75a33b1b77caf5dc5
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 994
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 74f5299510240b78c13a617c4aff564ca3af4d8666c8c65bf841f38792a778c0
+- llm_txt_sha256: 525a85873fcddc118b708bd3fe96da8d49abb64e357c4ddd595506f80b488282

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -23962,6 +23962,9 @@
                     "dossierEvidence": {
                       "type": "object"
                     },
+                    "lifecycleEvidence": {
+                      "type": "object"
+                    },
                     "safety": {
                       "type": "string"
                     },
@@ -23975,7 +23978,7 @@
             }
           }
         },
-        "description": "Projects fNAV fast-track request, network-signal, metering/control, commercial, contract, legal and owner evidence into a dossier-safe gate status. The endpoint is read-only and never creates contracts, HITL items, MaKo, billing, settlement, tariff, control, SMGW/CLS or external actions.",
+        "description": "Projects fNAV fast-track request, network-signal, metering/control, commercial, contract, legal and owner evidence into a dossier-safe gate status. The endpoint is read-only and never creates contracts, HITL items, MaKo, billing, settlement, tariff, control, SMGW/CLS or external actions. It additionally projects caller-supplied FCA/fNAV lifecycle evidence (connection request, capacity offer, restriction profile, contract, at most one operating-event snapshot, curtailment/measurement evidence, and Redispatch/compensation evidence markers) as review-only, non-consequential display fields.",
         "parameters": [
           {
             "name": "gateId",
@@ -24136,6 +24139,146 @@
           {
             "in": "query",
             "name": "sourceRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "connectionRequestRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "gridConnectionPoint",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "capacityOfferRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "capacityOfferVersion",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "capacityOfferDate",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "restrictionProfileRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "restrictionProfileVersion",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "contractRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "contractVersion",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "contractReviewStatus",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "operatingEventRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "operatingEventType",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "operatingEventTimestamp",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "curtailmentMeasurementEvidenceRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "redispatchRelevanceRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "redispatchStatusRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "compensationStatusRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "evidenceOwner",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "nextReviewGate",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "evidenceSourceTimestamp",
             "schema": {
               "type": "string"
             }
@@ -72657,6 +72800,9 @@
                     "dossierEvidence": {
                       "type": "object"
                     },
+                    "lifecycleEvidence": {
+                      "type": "object"
+                    },
                     "safety": {
                       "type": "string"
                     },
@@ -72670,7 +72816,7 @@
             }
           }
         },
-        "description": "Projects fNAV fast-track request, network-signal, metering/control, commercial, contract, legal and owner evidence into a dossier-safe gate status. The endpoint is read-only and never creates contracts, HITL items, MaKo, billing, settlement, tariff, control, SMGW/CLS or external actions.",
+        "description": "Projects fNAV fast-track request, network-signal, metering/control, commercial, contract, legal and owner evidence into a dossier-safe gate status. The endpoint is read-only and never creates contracts, HITL items, MaKo, billing, settlement, tariff, control, SMGW/CLS or external actions. It additionally projects caller-supplied FCA/fNAV lifecycle evidence (connection request, capacity offer, restriction profile, contract, at most one operating-event snapshot, curtailment/measurement evidence, and Redispatch/compensation evidence markers) as review-only, non-consequential display fields.",
         "parameters": [
           {
             "name": "gateId",
@@ -72831,6 +72977,146 @@
           {
             "in": "query",
             "name": "sourceRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "connectionRequestRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "gridConnectionPoint",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "capacityOfferRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "capacityOfferVersion",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "capacityOfferDate",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "restrictionProfileRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "restrictionProfileVersion",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "contractRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "contractVersion",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "contractReviewStatus",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "operatingEventRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "operatingEventType",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "operatingEventTimestamp",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "curtailmentMeasurementEvidenceRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "redispatchRelevanceRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "redispatchStatusRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "compensationStatusRef",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "evidenceOwner",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "nextReviewGate",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "evidenceSourceTimestamp",
             "schema": {
               "type": "string"
             }

--- a/services/dashboard-api.service.js
+++ b/services/dashboard-api.service.js
@@ -39542,7 +39542,7 @@ module.exports = {
       const lifecycleRows = lifecycleRowSpecs.map((spec) => ({
         code: spec.code,
         label: spec.label,
-        values: spec.values,
+        ...spec.values,
         evidenceStatus: lifecycleRowStatus(Object.values(spec.values)),
         enablesDossierAddition: spec.enablesDossierAddition,
       }));
@@ -39555,7 +39555,7 @@ module.exports = {
       const operatingEventRow = {
         code: 'operating_event',
         label: 'Operating Event (optional, at most one snapshot per request)',
-        values: operatingEventValues,
+        ...operatingEventValues,
         evidenceStatus: operatingEventStatus,
         optional: true,
         enablesDossierAddition:

--- a/services/dashboard-api.service.js
+++ b/services/dashboard-api.service.js
@@ -10639,13 +10639,37 @@ module.exports = {
           optional: true,
           rules: [{ type: 'string' }, { type: 'array' }],
         },
+        // -- FCA/fNAV lifecycle evidence (additive, caller-supplied, read-only) --
+        connectionRequestRef: { type: 'string', optional: true, min: 1 },
+        gridConnectionPoint: { type: 'string', optional: true, min: 1 },
+        capacityOfferRef: { type: 'string', optional: true, min: 1 },
+        capacityOfferVersion: { type: 'string', optional: true, min: 1 },
+        capacityOfferDate: { type: 'string', optional: true, min: 1 },
+        restrictionProfileRef: { type: 'string', optional: true, min: 1 },
+        restrictionProfileVersion: { type: 'string', optional: true, min: 1 },
+        contractRef: { type: 'string', optional: true, min: 1 },
+        contractVersion: { type: 'string', optional: true, min: 1 },
+        contractReviewStatus: { type: 'string', optional: true, min: 1 },
+        operatingEventRef: { type: 'string', optional: true, min: 1 },
+        operatingEventType: { type: 'string', optional: true, min: 1 },
+        operatingEventTimestamp: { type: 'string', optional: true, min: 1 },
+        curtailmentMeasurementEvidenceRef: { type: 'string', optional: true, min: 1 },
+        redispatchRelevanceRef: { type: 'string', optional: true, min: 1 },
+        redispatchStatusRef: { type: 'string', optional: true, min: 1 },
+        compensationStatusRef: { type: 'string', optional: true, min: 1 },
+        evidenceOwner: { type: 'string', optional: true, min: 1 },
+        nextReviewGate: { type: 'string', optional: true, min: 1 },
+        evidenceSourceTimestamp: { type: 'string', optional: true, min: 1 },
       },
       openapi: {
         tags: [OPENAPI_TAG],
         summary: 'fNAV fast-track contract gate -- read-only decision readiness',
         description:
           'Projects fNAV fast-track request, network-signal, metering/control, commercial, contract, legal and owner evidence into a dossier-safe gate status. ' +
-          'The endpoint is read-only and never creates contracts, HITL items, MaKo, billing, settlement, tariff, control, SMGW/CLS or external actions.',
+          'The endpoint is read-only and never creates contracts, HITL items, MaKo, billing, settlement, tariff, control, SMGW/CLS or external actions. ' +
+          'It additionally projects caller-supplied FCA/fNAV lifecycle evidence (connection request, capacity offer, restriction profile, contract, ' +
+          'at most one operating-event snapshot, curtailment/measurement evidence, and Redispatch/compensation evidence markers) as review-only, ' +
+          'non-consequential display fields.',
         parameters: [
           { name: 'gateId', in: 'query', required: false, schema: { type: 'string' } },
           { name: 'gridOperatorId', in: 'query', required: false, schema: { type: 'string' } },
@@ -10674,6 +10698,26 @@ module.exports = {
           { in: 'query', name: 'escalationOwner', schema: { type: 'string' } },
           { in: 'query', name: 'vdmiProcessId', schema: { type: 'string' } },
           { in: 'query', name: 'sourceRef', schema: { type: 'string' } },
+          { in: 'query', name: 'connectionRequestRef', schema: { type: 'string' } },
+          { in: 'query', name: 'gridConnectionPoint', schema: { type: 'string' } },
+          { in: 'query', name: 'capacityOfferRef', schema: { type: 'string' } },
+          { in: 'query', name: 'capacityOfferVersion', schema: { type: 'string' } },
+          { in: 'query', name: 'capacityOfferDate', schema: { type: 'string' } },
+          { in: 'query', name: 'restrictionProfileRef', schema: { type: 'string' } },
+          { in: 'query', name: 'restrictionProfileVersion', schema: { type: 'string' } },
+          { in: 'query', name: 'contractRef', schema: { type: 'string' } },
+          { in: 'query', name: 'contractVersion', schema: { type: 'string' } },
+          { in: 'query', name: 'contractReviewStatus', schema: { type: 'string' } },
+          { in: 'query', name: 'operatingEventRef', schema: { type: 'string' } },
+          { in: 'query', name: 'operatingEventType', schema: { type: 'string' } },
+          { in: 'query', name: 'operatingEventTimestamp', schema: { type: 'string' } },
+          { in: 'query', name: 'curtailmentMeasurementEvidenceRef', schema: { type: 'string' } },
+          { in: 'query', name: 'redispatchRelevanceRef', schema: { type: 'string' } },
+          { in: 'query', name: 'redispatchStatusRef', schema: { type: 'string' } },
+          { in: 'query', name: 'compensationStatusRef', schema: { type: 'string' } },
+          { in: 'query', name: 'evidenceOwner', schema: { type: 'string' } },
+          { in: 'query', name: 'nextReviewGate', schema: { type: 'string' } },
+          { in: 'query', name: 'evidenceSourceTimestamp', schema: { type: 'string' } },
         ],
         responses: {
           200: {
@@ -10697,6 +10741,7 @@ module.exports = {
                     positiveFollowUps: { type: 'array' },
                     sourceActions: { type: 'object' },
                     dossierEvidence: { type: 'object' },
+                    lifecycleEvidence: { type: 'object' },
                     safety: { type: 'string' },
                     timestamp: { type: 'string', format: 'date-time' },
                   },
@@ -39405,6 +39450,187 @@ module.exports = {
         `Request Type: ${params.requestType || 'unknown'}`,
         `Open gaps: ${evidenceGaps.length}`,
       ];
+
+      // -- FCA/fNAV lifecycle evidence (additive, caller-supplied, read-only) --
+      // Narrow, non-consequential projection of one supplied FCA/fNAV case across
+      // request, offer, restriction, contract and at most one operating-event
+      // snapshot. Never affects decisionReadiness/status above; scalar and
+      // reference values only, no service calls, persistence or hydration.
+      const hasEvidenceValue = (value) => value !== undefined && value !== null && String(value).trim() !== '';
+      const lifecycleRowStatus = (values) => {
+        const provided = values.filter(hasEvidenceValue).length;
+        if (provided === 0) return 'missing';
+        if (provided === values.length) return 'provided';
+        return 'partial';
+      };
+      const lifecycleRowSpecs = [
+        {
+          code: 'connection_request',
+          label: 'Connection Request',
+          values: {
+            connectionRequestRef: params.connectionRequestRef ?? null,
+            gridConnectionPoint: params.gridConnectionPoint ?? null,
+          },
+          enablesDossierAddition:
+            'add connection request/case reference and grid connection point evidence',
+        },
+        {
+          code: 'capacity_offer',
+          label: 'Capacity Offer',
+          values: {
+            capacityOfferRef: params.capacityOfferRef ?? null,
+            capacityOfferVersion: params.capacityOfferVersion ?? null,
+            capacityOfferDate: params.capacityOfferDate ?? null,
+            firmCapacityKW: params.firmCapacityKW ?? null,
+            flexibleCapacityKW: params.flexibleCapacityKW ?? null,
+          },
+          enablesDossierAddition:
+            'add capacity-offer reference, offer version/date and offered firm/flexible capacity evidence',
+        },
+        {
+          code: 'restriction_profile',
+          label: 'Restriction Profile',
+          values: {
+            restrictionProfileRef: params.restrictionProfileRef ?? null,
+            restrictionProfileVersion: params.restrictionProfileVersion ?? null,
+            curtailmentWindow: params.curtailmentWindow ?? null,
+          },
+          enablesDossierAddition:
+            'add restriction-profile reference/version and curtailment window evidence',
+        },
+        {
+          code: 'contract_lifecycle',
+          label: 'Contract Lifecycle',
+          values: {
+            contractRef: params.contractRef ?? null,
+            contractVersion: params.contractVersion ?? null,
+            contractReviewStatus: params.contractReviewStatus ?? null,
+          },
+          enablesDossierAddition:
+            'add contract reference, contract version and review status evidence',
+        },
+        {
+          code: 'curtailment_measurement_evidence',
+          label: 'Curtailment/Measurement Evidence',
+          values: {
+            curtailmentMeasurementEvidenceRef: params.curtailmentMeasurementEvidenceRef ?? null,
+          },
+          enablesDossierAddition: 'add curtailment/measurement evidence reference',
+        },
+        {
+          code: 'redispatch_compensation_markers',
+          label: 'Redispatch/Compensation Evidence Markers',
+          values: {
+            redispatchRelevanceRef: params.redispatchRelevanceRef ?? null,
+            redispatchStatusRef: params.redispatchStatusRef ?? null,
+            compensationStatusRef: params.compensationStatusRef ?? null,
+          },
+          enablesDossierAddition:
+            'add Redispatch relevance/status and compensation-status evidence markers (markers only, not a classification or calculation)',
+        },
+        {
+          code: 'evidence_governance',
+          label: 'Evidence Governance',
+          values: {
+            evidenceOwner: params.evidenceOwner ?? null,
+            nextReviewGate: params.nextReviewGate ?? null,
+            evidenceSourceTimestamp: params.evidenceSourceTimestamp ?? null,
+          },
+          enablesDossierAddition: 'add evidence owner, next review gate and source timestamp',
+        },
+      ];
+      const lifecycleRows = lifecycleRowSpecs.map((spec) => ({
+        code: spec.code,
+        label: spec.label,
+        values: spec.values,
+        evidenceStatus: lifecycleRowStatus(Object.values(spec.values)),
+        enablesDossierAddition: spec.enablesDossierAddition,
+      }));
+      const operatingEventValues = {
+        operatingEventRef: params.operatingEventRef ?? null,
+        operatingEventType: params.operatingEventType ?? null,
+        operatingEventTimestamp: params.operatingEventTimestamp ?? null,
+      };
+      const operatingEventStatus = lifecycleRowStatus(Object.values(operatingEventValues));
+      const operatingEventRow = {
+        code: 'operating_event',
+        label: 'Operating Event (optional, at most one snapshot per request)',
+        values: operatingEventValues,
+        evidenceStatus: operatingEventStatus,
+        optional: true,
+        enablesDossierAddition:
+          'add the single supplied operating-event reference, type and timestamp',
+      };
+      const lifecycleMissingEvidence = lifecycleRows
+        .filter((row) => row.evidenceStatus !== 'provided')
+        .map((row) => ({
+          missingDataPoint: row.code,
+          status: row.evidenceStatus,
+          enablesDossierAddition: row.enablesDossierAddition,
+        }));
+      // The operating-event snapshot is optional (at most one per request), so a
+      // fully unsupplied snapshot is not a gap -- only a partially supplied one is.
+      if (operatingEventStatus === 'partial') {
+        lifecycleMissingEvidence.push({
+          missingDataPoint: operatingEventRow.code,
+          status: operatingEventStatus,
+          enablesDossierAddition: operatingEventRow.enablesDossierAddition,
+        });
+      }
+      const lifecyclePositiveFollowUps = lifecycleMissingEvidence.map((gap) => ({
+        missingDataPoint: gap.missingDataPoint,
+        status: gap.status,
+        enablesDossierAddition: gap.enablesDossierAddition,
+        category: 'fca_fnav_lifecycle_evidence',
+      }));
+      const lifecycleEvidence = {
+        capabilityKey: 'fnav_fast_track_contract_gate',
+        gateId,
+        rows: [...lifecycleRows, operatingEventRow],
+        operatingEvent: operatingEventRow,
+        evidenceStatus: {
+          provided: lifecycleRows.filter((row) => row.evidenceStatus === 'provided').length,
+          required: lifecycleRows.length,
+        },
+        missingEvidence: lifecycleMissingEvidence,
+        positiveFollowUps: lifecyclePositiveFollowUps,
+        sourceActions: {
+          referenced: [
+            'fnav-commercial-hedging.createContract',
+            'fnav-commercial-hedging.createScenario',
+            'redispatch-expost.stepCurtailmentCorrelation',
+            'grid-connection.stepCapacity',
+            'grid-connection.fnavValidate',
+          ],
+          notCalled: [
+            'contract.approve',
+            'contract.release',
+            'capacity.allocate',
+            'grid-connection.mutate',
+            'grid-connection.approve',
+            'curtailment.dispatch',
+            'device-control.execute',
+            'smgw.connector.call',
+            'cls.control.execute',
+            'redispatch.execute',
+            'redispatch.classify',
+            'compensation.calculate',
+            'settlement.prepareBilling',
+            'mako.dispatch',
+            'a96.dispatch',
+            'workflow.create',
+            'hitl.create',
+            'external.connector.call',
+            'personal-agent.execute',
+          ],
+        },
+        notice:
+          'Evidence markers only: no capacity allocation, connection approval, contract action, ' +
+          'curtailment/dispatch/device control, Redispatch execution/classification, compensation ' +
+          'calculation, settlement, MaKo/A96, workflow/HITL, connector or Personal-Agent execution ' +
+          'is performed by this projection.',
+      };
+
       return {
         capabilityKey: 'fnav_fast_track_contract_gate',
         safety: 'read_only',
@@ -39443,6 +39669,7 @@ module.exports = {
         positiveFollowUps,
         sourceActions,
         sourceDatapoints: signals,
+        lifecycleEvidence,
         dossierEvidence: {
           capabilityKey: 'fnav_fast_track_contract_gate',
           gateId,

--- a/tests/dashboard-api.test.js
+++ b/tests/dashboard-api.test.js
@@ -3345,7 +3345,9 @@ describe('dashboard-api.service', () => {
         });
 
         const { lifecycleEvidence } = result;
-        expect(lifecycleEvidence.evidenceStatus.provided).toBe(lifecycleEvidence.evidenceStatus.required);
+        expect(lifecycleEvidence.evidenceStatus.provided).toBe(
+          lifecycleEvidence.evidenceStatus.required
+        );
         expect(lifecycleEvidence.missingEvidence).toEqual([]);
         expect(lifecycleEvidence.positiveFollowUps).toEqual([]);
         for (const row of lifecycleEvidence.rows) {
@@ -3376,9 +3378,7 @@ describe('dashboard-api.service', () => {
         });
 
         const { lifecycleEvidence } = result;
-        const rowByCode = Object.fromEntries(
-          lifecycleEvidence.rows.map((row) => [row.code, row])
-        );
+        const rowByCode = Object.fromEntries(lifecycleEvidence.rows.map((row) => [row.code, row]));
         expect(rowByCode.connection_request.evidenceStatus).toBe('partial');
         expect(rowByCode.capacity_offer.evidenceStatus).toBe('partial');
         expect(rowByCode.restriction_profile.evidenceStatus).toBe('missing');
@@ -3399,7 +3399,9 @@ describe('dashboard-api.service', () => {
             'evidence_governance',
           ])
         );
-        expect(lifecycleEvidence.positiveFollowUps.length).toBe(lifecycleEvidence.missingEvidence.length);
+        expect(lifecycleEvidence.positiveFollowUps.length).toBe(
+          lifecycleEvidence.missingEvidence.length
+        );
         for (const followUp of lifecycleEvidence.positiveFollowUps) {
           expect(followUp.category).toBe('fca_fnav_lifecycle_evidence');
         }
@@ -3440,7 +3442,9 @@ describe('dashboard-api.service', () => {
           operatingEventTimestamp: '2026-06-15T12:00:00Z',
         });
         expect(fullEvent.lifecycleEvidence.operatingEvent.evidenceStatus).toBe('provided');
-        expect(fullEvent.lifecycleEvidence.rows.filter((row) => row.code === 'operating_event').length).toBe(1);
+        expect(
+          fullEvent.lifecycleEvidence.rows.filter((row) => row.code === 'operating_event').length
+        ).toBe(1);
       });
 
       it('keeps lifecycle evidence rows scalar-safe (dossier-display-only values)', async () => {

--- a/tests/dashboard-api.test.js
+++ b/tests/dashboard-api.test.js
@@ -3456,7 +3456,22 @@ describe('dashboard-api.service', () => {
           operatingEventTimestamp: '2026-06-20T08:00:00Z',
         });
 
-        expectScalarTableRows(result.lifecycleEvidence.rows.map((row) => row.values));
+        expectScalarTableRows(result.lifecycleEvidence.rows);
+        expect(result.lifecycleEvidence.rows).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              code: 'connection_request',
+              connectionRequestRef: 'creq-2203',
+              gridConnectionPoint: 'napp-09.1',
+            }),
+            expect.objectContaining({
+              code: 'operating_event',
+              operatingEventRef: 'evt-503',
+              operatingEventType: 'curtailment_order',
+              operatingEventTimestamp: '2026-06-20T08:00:00Z',
+            }),
+          ])
+        );
       });
 
       it('never calls contract, capacity-allocation, grid-mutation, curtailment/dispatch, Redispatch/compensation/settlement, MaKo/A96, workflow/HITL, connector or Personal-Agent actions', async () => {

--- a/tests/dashboard-api.test.js
+++ b/tests/dashboard-api.test.js
@@ -3288,6 +3288,211 @@ describe('dashboard-api.service', () => {
         expect(result.evidenceStatus.provided).toBe(result.evidenceStatus.required);
         expect(result.dossierEvidence.dossierFacts).toContain('Status: ready_for_fast_track');
       });
+
+      it('is backwards compatible: existing callers without lifecycle params keep all current fields and decisionReadiness', async () => {
+        const result = await broker.call('dashboard-api.fnavFastTrackContractGateStatus', {
+          gateId: 'fnav-ft-legacy',
+          gridOperatorId: 'SNB935578300972',
+          requestType: 'data_center',
+          assetOrLoadType: 'large_load',
+          requestedCapacityKW: 10000,
+          netzsignalPriorityPolicy: 'approved',
+          scheduleObligation: 'confirmed',
+          meteringRequirements: 'confirmed',
+          controlEvidenceRef: 'ctrl-proof-1',
+          contractStatus: 'signed',
+          legalStatus: 'approved',
+          ownerContact: 'vertrieb',
+          commercialImpact: 'ready',
+          marketingBoundaries: 'ready',
+        });
+
+        expect(result.status).toBe('ready_for_fast_track');
+        expect(result.missingEvidence).toEqual([]);
+        expect(result.evidenceStatus.provided).toBe(result.evidenceStatus.required);
+        expect(result.dossierEvidence.dossierFacts).toContain('Status: ready_for_fast_track');
+        // additive field present without changing existing response shape/semantics
+        expect(result.lifecycleEvidence).toBeDefined();
+        expect(result.lifecycleEvidence.capabilityKey).toBe('fnav_fast_track_contract_gate');
+      });
+
+      it('reports complete FCA/fNAV lifecycle evidence when every stage is supplied', async () => {
+        const result = await broker.call('dashboard-api.fnavFastTrackContractGateStatus', {
+          gateId: 'fnav-ft-lifecycle-complete',
+          gridOperatorId: 'SNB935578300972',
+          requestType: 'storage',
+          assetOrLoadType: 'battery',
+          firmCapacityKW: 500,
+          flexibleCapacityKW: 1500,
+          connectionRequestRef: 'creq-2201',
+          gridConnectionPoint: 'napp-08.4',
+          capacityOfferRef: 'coffer-77',
+          capacityOfferVersion: 'v3',
+          capacityOfferDate: '2026-05-01',
+          restrictionProfileRef: 'restr-14',
+          restrictionProfileVersion: 'v2',
+          curtailmentWindow: '18:00-20:00',
+          contractRef: 'contract-91',
+          contractVersion: 'v4',
+          contractReviewStatus: 'under_review',
+          curtailmentMeasurementEvidenceRef: 'meas-3391',
+          redispatchRelevanceRef: 'rd-relevance-1',
+          redispatchStatusRef: 'rd-status-1',
+          compensationStatusRef: 'comp-status-1',
+          evidenceOwner: 'netzplanung',
+          nextReviewGate: 'quarterly-review-q3',
+          evidenceSourceTimestamp: '2026-07-01T09:00:00Z',
+        });
+
+        const { lifecycleEvidence } = result;
+        expect(lifecycleEvidence.evidenceStatus.provided).toBe(lifecycleEvidence.evidenceStatus.required);
+        expect(lifecycleEvidence.missingEvidence).toEqual([]);
+        expect(lifecycleEvidence.positiveFollowUps).toEqual([]);
+        for (const row of lifecycleEvidence.rows) {
+          if (row.code === 'operating_event') continue;
+          expect(row.evidenceStatus).toBe('provided');
+        }
+      });
+
+      it('reports incomplete FCA/fNAV lifecycle evidence with review-only follow-ups when stages are partial or missing', async () => {
+        const result = await broker.call('dashboard-api.fnavFastTrackContractGateStatus', {
+          gateId: 'fnav-ft-lifecycle-incomplete',
+          gridOperatorId: 'SNB935578300972',
+          requestType: 'storage',
+          assetOrLoadType: 'battery',
+          requestedCapacityKW: 2500,
+          netzsignalPriorityPolicy: 'approved',
+          scheduleObligation: 'ready',
+          contractStatus: 'draft',
+          legalStatus: 'approved',
+          ownerContact: 'netzplanung',
+          commercialImpact: 'ready',
+          connectionRequestRef: 'creq-2202',
+          // gridConnectionPoint omitted -> connection_request partial
+          capacityOfferRef: 'coffer-78',
+          // capacityOfferVersion/Date/firm/flexible capacity omitted -> capacity_offer partial
+          // restriction_profile, contract_lifecycle, curtailment_measurement_evidence,
+          // redispatch_compensation_markers, evidence_governance fully omitted -> missing
+        });
+
+        const { lifecycleEvidence } = result;
+        const rowByCode = Object.fromEntries(
+          lifecycleEvidence.rows.map((row) => [row.code, row])
+        );
+        expect(rowByCode.connection_request.evidenceStatus).toBe('partial');
+        expect(rowByCode.capacity_offer.evidenceStatus).toBe('partial');
+        expect(rowByCode.restriction_profile.evidenceStatus).toBe('missing');
+        expect(rowByCode.contract_lifecycle.evidenceStatus).toBe('missing');
+        expect(rowByCode.curtailment_measurement_evidence.evidenceStatus).toBe('missing');
+        expect(rowByCode.redispatch_compensation_markers.evidenceStatus).toBe('missing');
+        expect(rowByCode.evidence_governance.evidenceStatus).toBe('missing');
+
+        const missingCodes = lifecycleEvidence.missingEvidence.map((gap) => gap.missingDataPoint);
+        expect(missingCodes).toEqual(
+          expect.arrayContaining([
+            'connection_request',
+            'capacity_offer',
+            'restriction_profile',
+            'contract_lifecycle',
+            'curtailment_measurement_evidence',
+            'redispatch_compensation_markers',
+            'evidence_governance',
+          ])
+        );
+        expect(lifecycleEvidence.positiveFollowUps.length).toBe(lifecycleEvidence.missingEvidence.length);
+        for (const followUp of lifecycleEvidence.positiveFollowUps) {
+          expect(followUp.category).toBe('fca_fnav_lifecycle_evidence');
+        }
+        // existing gate semantics (decisionReadiness) are unaffected by lifecycle gaps
+        expect(result.status).toBe('needs_control_evidence');
+      });
+
+      it('supports at most one optional operating-event snapshot per request', async () => {
+        const noEvent = await broker.call('dashboard-api.fnavFastTrackContractGateStatus', {
+          gateId: 'fnav-ft-event-none',
+          gridOperatorId: 'SNB935578300972',
+        });
+        expect(noEvent.lifecycleEvidence.operatingEvent.evidenceStatus).toBe('missing');
+        // fully unsupplied optional snapshot is not a gap
+        expect(
+          noEvent.lifecycleEvidence.missingEvidence.some(
+            (gap) => gap.missingDataPoint === 'operating_event'
+          )
+        ).toBe(false);
+
+        const partialEvent = await broker.call('dashboard-api.fnavFastTrackContractGateStatus', {
+          gateId: 'fnav-ft-event-partial',
+          gridOperatorId: 'SNB935578300972',
+          operatingEventRef: 'evt-501',
+        });
+        expect(partialEvent.lifecycleEvidence.operatingEvent.evidenceStatus).toBe('partial');
+        expect(
+          partialEvent.lifecycleEvidence.missingEvidence.some(
+            (gap) => gap.missingDataPoint === 'operating_event'
+          )
+        ).toBe(true);
+
+        const fullEvent = await broker.call('dashboard-api.fnavFastTrackContractGateStatus', {
+          gateId: 'fnav-ft-event-full',
+          gridOperatorId: 'SNB935578300972',
+          operatingEventRef: 'evt-502',
+          operatingEventType: 'curtailment_order',
+          operatingEventTimestamp: '2026-06-15T12:00:00Z',
+        });
+        expect(fullEvent.lifecycleEvidence.operatingEvent.evidenceStatus).toBe('provided');
+        expect(fullEvent.lifecycleEvidence.rows.filter((row) => row.code === 'operating_event').length).toBe(1);
+      });
+
+      it('keeps lifecycle evidence rows scalar-safe (dossier-display-only values)', async () => {
+        const result = await broker.call('dashboard-api.fnavFastTrackContractGateStatus', {
+          gateId: 'fnav-ft-scalar-safe',
+          gridOperatorId: 'SNB935578300972',
+          connectionRequestRef: 'creq-2203',
+          gridConnectionPoint: 'napp-09.1',
+          firmCapacityKW: 250,
+          flexibleCapacityKW: 750,
+          operatingEventRef: 'evt-503',
+          operatingEventType: 'curtailment_order',
+          operatingEventTimestamp: '2026-06-20T08:00:00Z',
+        });
+
+        expectScalarTableRows(result.lifecycleEvidence.rows.map((row) => row.values));
+      });
+
+      it('never calls contract, capacity-allocation, grid-mutation, curtailment/dispatch, Redispatch/compensation/settlement, MaKo/A96, workflow/HITL, connector or Personal-Agent actions', async () => {
+        const result = await broker.call('dashboard-api.fnavFastTrackContractGateStatus', {
+          gateId: 'fnav-ft-nocall',
+          gridOperatorId: 'SNB935578300972',
+          connectionRequestRef: 'creq-2204',
+          contractRef: 'contract-92',
+          redispatchRelevanceRef: 'rd-relevance-2',
+          redispatchStatusRef: 'rd-status-2',
+          compensationStatusRef: 'comp-status-2',
+        });
+
+        expect(result.lifecycleEvidence.sourceActions.notCalled).toEqual(
+          expect.arrayContaining([
+            'contract.approve',
+            'contract.release',
+            'capacity.allocate',
+            'grid-connection.mutate',
+            'grid-connection.approve',
+            'curtailment.dispatch',
+            'device-control.execute',
+            'redispatch.execute',
+            'redispatch.classify',
+            'compensation.calculate',
+            'settlement.prepareBilling',
+            'mako.dispatch',
+            'a96.dispatch',
+            'workflow.create',
+            'hitl.create',
+            'external.connector.call',
+            'personal-agent.execute',
+          ])
+        );
+        expect(result._errors).toEqual([]);
+      });
     });
 
     // -- crossChannelVnbSignalQueueStatus -----------------------------------


### PR DESCRIPTION
## Summary
- extend the existing read-only `fnav_fast_track_contract_gate` with a bounded caller-supplied FCA/fNAV lifecycle evidence projection
- preserve existing decision-readiness semantics and response fields
- add scalar-safe lifecycle stages, optional single operating-event evidence, review-only gaps/follow-ups, and explicit no-call metadata
- regenerate OpenAPI and `llm.txt`

## Safety
Read-only/non-consequential projection only. No persistence, capacity allocation, contract action, grid mutation, curtailment/dispatch, Redispatch/compensation/settlement, MaKo/A96, workflow/HITL, connector, Personal-Agent, credential, wallet, key-material, or production action.

## Verification
- `tests/dashboard-api.test.js`: 442/442 passed
- Claude regression set (`evidence-planner`, `api.service`, `capability-broker`, `dossier-hydration`): 564/564 passed
- `npm run generate:llm`: passed
- `npm run check:llm`: passed
- `git diff --check origin/main...HEAD`: passed
- GitNexus pre-edit context/impact plus final detect-changes: low risk, 0 affected processes

## Remaining gate
No DevServer deployment/smoke before merge because this commit is intentionally on a review branch, not `origin/main`. Issue #447 must remain open until integration and a synthetic read-only DevServer smoke prove lifecycle rows, gaps, and no-call metadata.

Closes no issue; relates to #447.
