### PR TITLE
feat: add deterministic tabular intelligence layer

### DIFF
--- a/docs/architecture/tabular-intelligence-layer.md
+++ b/docs/architecture/tabular-intelligence-layer.md
@@ -1,0 +1,189 @@
+# Tabular Intelligence Layer — MVP Architecture
+
+Status: accepted implementation plan for issue #456  
+Date: 2026-07-21
+
+## Decision and MVP cut
+
+Cernion Energy Tools (CET) gets a read-only `tabular` Moleculer service. The model may
+translate a question into a constrained plan and may explain deterministic output; CET owns
+validation, execution, numbers, evidence, and confidence.
+
+The MVP covers:
+
+- privacy-aware table profiles and compact LLM context;
+- an explicit, versioned plan document;
+- deterministic select, filter, sort, limit, aggregate/group, time-bucket, missing-interval,
+  duplicate, and outlier operations;
+- a simple two-source join delegated to `in-memory-join.join`;
+- deterministic `ask` responses with evidence, even when no LLM is configured;
+- quality reports derived from the same profile/execution primitives.
+
+Non-goals are writes/import confirmation, arbitrary SQL or JavaScript, arbitrary broker action
+execution, custom model training, GPU dependencies, persistence of raw rows or prompts, and
+regulatory conclusions. The MVP does not expose `columnMap`: the existing datasource dictionary
+and classifier field mappings remain authoritative and a second mapping vocabulary would be
+premature.
+
+Later phases may add persisted profile snapshots, richer multi-table DAGs, EDM-native source
+adapters, XLSX-specific profiling, benchmark suites, and optional specialist Large Tabular Model
+(LTM) providers. Those providers must implement the same planner interface and can never replace
+the deterministic guard/executor.
+
+## Actions and REST shape
+
+The service exposes the following Moleculer actions and `/api/tabular/*` REST routes:
+
+| Action | REST | Purpose |
+| --- | --- | --- |
+| `tabular.profile` | `POST /tabular/profile` | Compute schema/statistics/privacy-safe profile |
+| `tabular.llmContext` | `POST /tabular/llm-context` | Return bounded schema/profile context, never raw tables |
+| `tabular.queryPlan` | `POST /tabular/query-plan` | Validate a supplied plan or optionally ask `llm-client` for one |
+| `tabular.executePlan` | `POST /tabular/execute-plan` | Deterministically execute an allow-listed plan |
+| `tabular.ask` | `POST /tabular/ask` | Plan/execute and render an evidence-backed answer |
+| `tabular.qualityReport` | `POST /tabular/quality-report` | Missing, duplicate, interval and outlier diagnostics |
+
+Every action accepts source IDs, never connector credentials. Direct inline rows are deliberately
+an internal/test-only service option and are not part of the public REST schema. The source read
+path is `datasource-cache.query`; cache hydration still belongs to datasource registry/connector.
+All broker calls propagate `ctx.meta`.
+
+## Plan JSON schema
+
+```json
+{
+  "schemaVersion": "1.0",
+  "sources": [
+    { "alias": "metering", "sourceId": "uuid", "privacyContext": "ai-agent" }
+  ],
+  "operations": [
+    { "op": "filter", "field": "status", "operator": "eq", "value": "active" },
+    { "op": "timeBucket", "field": "timestamp", "interval": "hour", "as": "period" },
+    {
+      "op": "aggregate",
+      "groupBy": ["period"],
+      "metrics": [{ "fn": "sum", "field": "value", "as": "energy" }]
+    },
+    { "op": "sort", "by": [{ "field": "period", "direction": "asc" }] },
+    { "op": "limit", "count": 100 }
+  ],
+  "output": { "maxRows": 500 }
+}
+```
+
+A join operation has `left`, `right`, `leftField`, `rightField`, `matchMode`, `joinType`, and
+optional collision settings. It is allowed only before row-local operations and is delegated to
+`in-memory-join.join`. Filter operators are a closed enum (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`,
+`in`, `contains`, `isNull`, `notNull`). Aggregates are a closed enum (`count`, `sum`, `avg`, `min`,
+`max`). Unknown keys/operations, excessive limits, multiple joins, unsafe privacy contexts, and
+cross-tenant plan execution are rejected. No executable expression or arbitrary action name is
+accepted.
+
+## Profile representation
+
+Profiles are calculated on bounded cache pages and returned, not persisted:
+
+- source ID and row counts;
+- inferred columns, dominant type, null/distinct counts and ratios;
+- numeric min/max/mean where applicable;
+- timestamp min/max where parseable;
+- semantic classification from `datasource-classifier.classify` when available;
+- dictionary privacy flags from `datasource-registry.get`, represented only as sensitivity
+  metadata;
+- stable hashes for the privacy-processed input and profile.
+
+Profile samples contain only scalar statistics and redacted examples. Raw rows are never stored by
+the tabular service.
+
+## LLM-safe context and token limit
+
+`llmContext` serializes source IDs, classifications, column names/types, null/distinct ratios,
+numeric ranges, timestamp ranges, row counts, warnings, and plan schema. It excludes raw rows,
+connector configuration, dictionary synthetic patterns, tenant IDs, and direct identifier values.
+Flagged/private or identifier-like columns expose no examples. Other examples are scalar,
+length-limited, and capped per column.
+
+The context budget defaults to 2,000 estimated tokens (four characters per token), is capped at
+8,000, and is reduced deterministically by removing examples, then low-priority columns. The
+actual character/token estimate and truncation flag are returned.
+
+## Deterministic backend and service reuse
+
+The MVP executor is an in-process array pipeline with hard row/operation limits. It is suitable for
+bounded cached datasets and easy to audit. It reuses instead of duplicates:
+
+- `datasource-cache.query` for paged row access and `ai-agent`/`public` privacy processing;
+- `datasource-registry.get` for dictionary metadata;
+- `datasource-classifier.classify` and semantic domains for energy-domain classification;
+- `in-memory-join.join` for two-source joins;
+- EDM conventions for UTC parsing, 15-minute/hour/day/week/month bucketing, interval checks, and
+  deterministic aggregation; direct EDM database access is explicitly avoided;
+- `src/llm-client.js` only for optional structured planning and optional non-numeric wording.
+
+Numeric values in answers are copied from `executePlan` result rows/summaries. An LLM response is
+never accepted as numerical evidence.
+
+## Evidence and trace
+
+`executePlan` and `ask` return:
+
+```json
+{
+  "executedPlan": {},
+  "resultTable": [],
+  "evidence": {
+    "sourceIds": [],
+    "inputRowCounts": {},
+    "resultRowCount": 0,
+    "evidenceRows": [],
+    "calculationSummary": "",
+    "operations": [],
+    "hashes": { "input": "sha256:...", "plan": "sha256:...", "result": "sha256:..." },
+    "traceId": "..."
+  },
+  "warnings": [],
+  "assumptions": [],
+  "confidence": "high"
+}
+```
+
+Evidence rows are a small bounded excerpt of the privacy-processed result, not source-table rows.
+Stable canonical JSON hashes make reruns comparable. Warning conditions lower confidence.
+
+## Tenant and privacy boundary
+
+- Tenant identity comes only from authenticated `ctx.meta.tenantId`; request payloads cannot
+  override it.
+- Plans are bound to a one-way tenant hash at validation/planning time. Execution under another
+  tenant is rejected.
+- All downstream calls preserve metadata. The layer never accesses cache internals or connector
+  credentials.
+- Public actions force `ai-agent` or stricter `public` cache privacy; `internal` is reserved for
+  explicitly internal broker calls and is not accepted by public action parameters.
+- Context sent to an LLM is always produced by `llmContext`, never by serializing rows.
+- No profile, plan, prompt, result, or evidence is persisted by this service.
+
+The underlying datasource registry/cache remains the system of record for source authorization.
+A future registry migration may add explicit per-source tenant ownership without changing this
+service contract.
+
+## Tests and benchmarks
+
+Unit tests use three committed fixtures:
+
+1. 15-minute metering time series: time buckets, aggregation, missing interval, and outlier checks;
+2. asset/master data: profile, privacy-safe LLM context, duplicate and missing-value checks;
+3. joined asset/metering data: existing join service delegation followed by group aggregation.
+
+Additional tests cover plan rejection, tenant binding, context budget, deterministic hashes,
+numeric answer grounding, and LLM-free fallback. The release evidence is targeted Jest tests,
+`npm run test:unit:ci`, `npm run audit:openapi`, and `npm run check:llm`. A later benchmark suite
+should track execution latency by rows/operations, profile/context token size, planner validity
+rate, deterministic replay hashes, and answer/evidence agreement on a fixed fixture corpus.
+
+## Optional LTM providers
+
+Specialized TableLLM/TableLlama/Table-GPT-like or local providers may later be registered behind a
+planner/context-provider adapter. They receive the same bounded safe context and must emit the same
+plan schema. Provider output always passes the execution guard, and only CET execution can create
+numbers or evidence. No optional provider becomes a runtime dependency of the core service.

--- a/llm.txt
+++ b/llm.txt
@@ -150,7 +150,7 @@ recipes:
   vnb-full-snapshot "A grid operator needs a full health check combining KPI…"
 resolve: GET /api/_agent/operations?domain=grid-ops
 
-### inhouse-data (8 capabilities · 3 recipes · 32 operations)
+### inhouse-data (8 capabilities · 3 recipes · 38 operations)
 capabilities: bilanzkreis_slp_edm_operations, edm_customer_moveout_billing_evidence, edm_metering_concept_evidence, imsys_schedule_value_chain_readiness, imsys_taf2_compliance_status, inhouse_timeseries_analysis, load_profile_stream_monitor, metering_rollout_process_indicator
 recipes:
   datasource-register-and-classify "A user has uploaded a CSV or XLSX file and needs to…"
@@ -251,12 +251,12 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: b9fa91c95a1f029620fb0513b4453677cb2b61b64ca87549fe353262287ab1a8
-- openapi-export.json: 73118cbcae83b98d2507de0192b7c1cd7014f740cb12908e43988f9056549404
+- openapi-export.json: 1b10b93d16cabdf0c87bcf8ebcc7baeea3bc001bbcee0d7fd0410f40d39dd7b1
 
 ## OpenAPI Surface (full contract, not embedded)
-- path_count: 994
-- operation_count: 1106
+- path_count: 1000
+- operation_count: 1112
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 74f5299510240b78c13a617c4aff564ca3af4d8666c8c65bf841f38792a778c0
+- llm_txt_sha256: 6598efd1b91966b1d158cb7dd5e3b1843c994f890d50d9a4a152464fc03ba665

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -57899,6 +57899,436 @@
         ]
       }
     },
+    "/api/tabular/profile": {
+      "post": {
+        "operationId": "tabular_profile",
+        "summary": "Build a privacy-aware deterministic table profile",
+        "tags": [
+          "Tabular Intelligence"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "sourceId"
+                ],
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "example": "metering-source-01"
+                  },
+                  "maxRows": {
+                    "type": "integer",
+                    "default": 5000,
+                    "example": 5000
+                  },
+                  "privacyContext": {
+                    "type": "string",
+                    "enum": [
+                      "ai-agent",
+                      "public"
+                    ],
+                    "default": "ai-agent",
+                    "example": "ai-agent"
+                  }
+                }
+              },
+              "examples": {
+                "request": {
+                  "summary": "Tabular intelligence request",
+                  "value": {
+                    "sourceId": "metering-source-01",
+                    "maxRows": 5000,
+                    "privacyContext": "ai-agent"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tabular/llm-context": {
+      "post": {
+        "operationId": "tabular_llmContext",
+        "summary": "Build bounded LLM-safe context without raw table rows",
+        "tags": [
+          "Tabular Intelligence"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "sourceIds"
+                ],
+                "properties": {
+                  "sourceIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "metering-source-01"
+                    ]
+                  },
+                  "maxTokens": {
+                    "type": "integer",
+                    "default": 2000,
+                    "example": 2000
+                  },
+                  "privacyContext": {
+                    "type": "string",
+                    "enum": [
+                      "ai-agent",
+                      "public"
+                    ],
+                    "default": "ai-agent",
+                    "example": "ai-agent"
+                  }
+                }
+              },
+              "examples": {
+                "request": {
+                  "summary": "Tabular intelligence request",
+                  "value": {
+                    "sourceIds": [
+                      "metering-source-01"
+                    ],
+                    "maxTokens": 2000,
+                    "privacyContext": "ai-agent"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tabular/query-plan": {
+      "post": {
+        "operationId": "tabular_queryPlan",
+        "summary": "Create or validate an allow-listed tabular analysis plan",
+        "tags": [
+          "Tabular Intelligence"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                  "sourceIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "metering-source-01"
+                    ]
+                  },
+                  "question": {
+                    "type": "string",
+                    "example": "What is the total consumption?"
+                  },
+                  "plan": {
+                    "type": "object",
+                    "default": null,
+                    "example": {}
+                  },
+                  "useLlm": {
+                    "type": "boolean",
+                    "default": false,
+                    "example": false
+                  },
+                  "maxTokens": {
+                    "type": "integer",
+                    "default": 2000,
+                    "example": 2000
+                  }
+                }
+              },
+              "examples": {
+                "request": {
+                  "summary": "Tabular intelligence request",
+                  "value": {
+                    "sourceIds": [
+                      "metering-source-01"
+                    ],
+                    "question": "What is the total consumption?",
+                    "useLlm": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tabular/execute-plan": {
+      "post": {
+        "operationId": "tabular_executePlan",
+        "summary": "Execute a validated tabular plan deterministically",
+        "tags": [
+          "Tabular Intelligence"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "plan"
+                ],
+                "properties": {
+                  "plan": {
+                    "type": "object",
+                    "example": {
+                      "schemaVersion": "1.0",
+                      "sources": [],
+                      "operations": []
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "request": {
+                  "summary": "Tabular intelligence request",
+                  "value": {
+                    "plan": {
+                      "schemaVersion": "1.0",
+                      "sources": [
+                        {
+                          "alias": "table",
+                          "sourceId": "metering-source-01"
+                        }
+                      ],
+                      "operations": [
+                        {
+                          "op": "aggregate",
+                          "groupBy": [],
+                          "metrics": [
+                            {
+                              "fn": "sum",
+                              "field": "value",
+                              "as": "totalValue"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tabular/ask": {
+      "post": {
+        "operationId": "tabular_ask",
+        "summary": "Answer a table question with deterministic results and evidence",
+        "tags": [
+          "Tabular Intelligence"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "question"
+                ],
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "example": "What is the total consumption?"
+                  },
+                  "sourceIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "metering-source-01"
+                    ]
+                  },
+                  "plan": {
+                    "type": "object",
+                    "default": null,
+                    "example": {}
+                  },
+                  "useLlm": {
+                    "type": "boolean",
+                    "default": false,
+                    "example": false
+                  }
+                }
+              },
+              "examples": {
+                "request": {
+                  "summary": "Tabular intelligence request",
+                  "value": {
+                    "question": "What is the total consumption?",
+                    "sourceIds": [
+                      "metering-source-01"
+                    ],
+                    "useLlm": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tabular/quality-report": {
+      "post": {
+        "operationId": "tabular_qualityReport",
+        "summary": "Build an evidence-backed table quality report",
+        "tags": [
+          "Tabular Intelligence"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "sourceId"
+                ],
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "example": "metering-source-01"
+                  },
+                  "timestampField": {
+                    "type": "string",
+                    "default": null,
+                    "example": "timestamp"
+                  },
+                  "intervalMinutes": {
+                    "type": "integer",
+                    "default": 15,
+                    "example": 15
+                  },
+                  "duplicateFields": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "timestamp"
+                    ]
+                  },
+                  "outlierField": {
+                    "type": "string",
+                    "default": null,
+                    "example": "value"
+                  },
+                  "outlierThreshold": {
+                    "type": "number",
+                    "default": 3,
+                    "example": 3
+                  }
+                }
+              },
+              "examples": {
+                "request": {
+                  "summary": "Tabular intelligence request",
+                  "value": {
+                    "sourceId": "metering-source-01",
+                    "timestampField": "timestamp",
+                    "intervalMinutes": 15,
+                    "duplicateFields": [
+                      "timestamp"
+                    ],
+                    "outlierField": "value"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/tenant-quota/tenants/:id/quotas": {
       "get": {
         "operationId": "tenant-quota_getQuotas",

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -2,14 +2,14 @@
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
   "packageVersion": "0.67.8",
-  "sourceOpenApiHash": "73118cbcae83b98d2507de0192b7c1cd7014f740cb12908e43988f9056549404",
+  "sourceOpenApiHash": "1b10b93d16cabdf0c87bcf8ebcc7baeea3bc001bbcee0d7fd0410f40d39dd7b1",
   "coverage": {
-    "rawOperationCount": 1106,
-    "operationCount": 851,
-    "agentableCount": 849,
+    "rawOperationCount": 1112,
+    "operationCount": 857,
+    "agentableCount": 855,
     "nonAgentableCount": 2,
     "byOperationKind": {
-      "data_read": 379,
+      "data_read": 385,
       "admin": 8,
       "object_store_write": 222,
       "process_step": 20,
@@ -72006,6 +72006,561 @@
         "synonyms": [
           "agent infrastructure",
           "system"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "tabular_ask",
+      "method": "POST",
+      "path": "/api/tabular/ask",
+      "service": "tabular",
+      "action": "tabular.ask",
+      "summary": "Answer a table question with deterministic results and evidence",
+      "tags": [
+        "Tabular Intelligence"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "data_read",
+      "consequenceLevel": "none",
+      "recommendedExecutionMode": "direct",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "tabular.ask"
+      ],
+      "domains": [
+        "inhouse-data"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "tabular:read"
+      ],
+      "tenantScoped": true,
+      "writesTo": [],
+      "sideEffects": [],
+      "idempotency": "idempotent",
+      "rollbackHint": null,
+      "parameters": {
+        "required": [
+          {
+            "name": "question",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          }
+        ],
+        "optional": [
+          {
+            "name": "sourceIds",
+            "in": "body",
+            "type": "array",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "plan",
+            "in": "body",
+            "type": "object",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "useLlm",
+            "in": "body",
+            "type": "boolean",
+            "description": null,
+            "extractionHint": null
+          }
+        ]
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "tabular",
+          "ask",
+          "answer",
+          "table",
+          "question",
+          "with",
+          "deterministic",
+          "results",
+          "evidence",
+          "intelligence"
+        ],
+        "negativeCues": [
+          "spot price",
+          "gas storage"
+        ],
+        "examples": [
+          "Please answer a table question with deterministic results and evidence"
+        ],
+        "synonyms": [
+          "Messstelle",
+          "metering",
+          "EDM"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "tabular_executePlan",
+      "method": "POST",
+      "path": "/api/tabular/execute-plan",
+      "service": "tabular",
+      "action": "tabular.executePlan",
+      "summary": "Execute a validated tabular plan deterministically",
+      "tags": [
+        "Tabular Intelligence"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "data_read",
+      "consequenceLevel": "none",
+      "recommendedExecutionMode": "direct",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "tabular.execute_plan"
+      ],
+      "domains": [
+        "inhouse-data"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "tabular:read"
+      ],
+      "tenantScoped": true,
+      "writesTo": [],
+      "sideEffects": [],
+      "idempotency": "idempotent",
+      "rollbackHint": null,
+      "parameters": {
+        "required": [
+          {
+            "name": "plan",
+            "in": "body",
+            "type": "object",
+            "description": null,
+            "extractionHint": null
+          }
+        ],
+        "optional": []
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "tabular",
+          "execute",
+          "plan",
+          "validated",
+          "deterministically",
+          "intelligence"
+        ],
+        "negativeCues": [
+          "spot price",
+          "gas storage"
+        ],
+        "examples": [
+          "Please execute a validated tabular plan deterministically"
+        ],
+        "synonyms": [
+          "Messstelle",
+          "metering",
+          "EDM"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "tabular_llmContext",
+      "method": "POST",
+      "path": "/api/tabular/llm-context",
+      "service": "tabular",
+      "action": "tabular.llmContext",
+      "summary": "Build bounded LLM-safe context without raw table rows",
+      "tags": [
+        "Tabular Intelligence"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "data_read",
+      "consequenceLevel": "none",
+      "recommendedExecutionMode": "direct",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "tabular.llm_context"
+      ],
+      "domains": [
+        "inhouse-data"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "tabular:read"
+      ],
+      "tenantScoped": true,
+      "writesTo": [],
+      "sideEffects": [],
+      "idempotency": "idempotent",
+      "rollbackHint": null,
+      "parameters": {
+        "required": [
+          {
+            "name": "sourceIds",
+            "in": "body",
+            "type": "array",
+            "description": null,
+            "extractionHint": null
+          }
+        ],
+        "optional": [
+          {
+            "name": "maxTokens",
+            "in": "body",
+            "type": "integer",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "privacyContext",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          }
+        ]
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "tabular",
+          "llm",
+          "context",
+          "build",
+          "bounded",
+          "safe",
+          "without",
+          "raw",
+          "table",
+          "rows",
+          "intelligence"
+        ],
+        "negativeCues": [
+          "spot price",
+          "gas storage"
+        ],
+        "examples": [
+          "Please build bounded llm-safe context without raw table rows"
+        ],
+        "synonyms": [
+          "Messstelle",
+          "metering",
+          "EDM"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "tabular_profile",
+      "method": "POST",
+      "path": "/api/tabular/profile",
+      "service": "tabular",
+      "action": "tabular.profile",
+      "summary": "Build a privacy-aware deterministic table profile",
+      "tags": [
+        "Tabular Intelligence"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "data_read",
+      "consequenceLevel": "none",
+      "recommendedExecutionMode": "direct",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "tabular.profile"
+      ],
+      "domains": [
+        "inhouse-data"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "tabular:read"
+      ],
+      "tenantScoped": true,
+      "writesTo": [],
+      "sideEffects": [],
+      "idempotency": "idempotent",
+      "rollbackHint": null,
+      "parameters": {
+        "required": [
+          {
+            "name": "sourceId",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          }
+        ],
+        "optional": [
+          {
+            "name": "maxRows",
+            "in": "body",
+            "type": "integer",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "privacyContext",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          }
+        ]
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "tabular",
+          "profile",
+          "build",
+          "privacy",
+          "aware",
+          "deterministic",
+          "table",
+          "intelligence"
+        ],
+        "negativeCues": [
+          "spot price",
+          "gas storage"
+        ],
+        "examples": [
+          "Please build a privacy-aware deterministic table profile"
+        ],
+        "synonyms": [
+          "Messstelle",
+          "metering",
+          "EDM"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "tabular_qualityReport",
+      "method": "POST",
+      "path": "/api/tabular/quality-report",
+      "service": "tabular",
+      "action": "tabular.qualityReport",
+      "summary": "Build an evidence-backed table quality report",
+      "tags": [
+        "Tabular Intelligence"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "data_read",
+      "consequenceLevel": "none",
+      "recommendedExecutionMode": "direct",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "tabular.quality_report"
+      ],
+      "domains": [
+        "inhouse-data"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "tabular:read"
+      ],
+      "tenantScoped": true,
+      "writesTo": [],
+      "sideEffects": [],
+      "idempotency": "idempotent",
+      "rollbackHint": null,
+      "parameters": {
+        "required": [
+          {
+            "name": "sourceId",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          }
+        ],
+        "optional": [
+          {
+            "name": "timestampField",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "intervalMinutes",
+            "in": "body",
+            "type": "integer",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "duplicateFields",
+            "in": "body",
+            "type": "array",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "outlierField",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "outlierThreshold",
+            "in": "body",
+            "type": "number",
+            "description": null,
+            "extractionHint": null
+          }
+        ]
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "tabular",
+          "quality",
+          "report",
+          "build",
+          "an",
+          "evidence",
+          "backed",
+          "table",
+          "intelligence"
+        ],
+        "negativeCues": [
+          "spot price",
+          "gas storage"
+        ],
+        "examples": [
+          "Please build an evidence-backed table quality report"
+        ],
+        "synonyms": [
+          "Messstelle",
+          "metering",
+          "EDM"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "tabular_queryPlan",
+      "method": "POST",
+      "path": "/api/tabular/query-plan",
+      "service": "tabular",
+      "action": "tabular.queryPlan",
+      "summary": "Create or validate an allow-listed tabular analysis plan",
+      "tags": [
+        "Tabular Intelligence"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "data_read",
+      "consequenceLevel": "none",
+      "recommendedExecutionMode": "direct",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "tabular.query_plan"
+      ],
+      "domains": [
+        "inhouse-data"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "tabular:read"
+      ],
+      "tenantScoped": true,
+      "writesTo": [],
+      "sideEffects": [],
+      "idempotency": "idempotent",
+      "rollbackHint": null,
+      "parameters": {
+        "required": [],
+        "optional": [
+          {
+            "name": "sourceIds",
+            "in": "body",
+            "type": "array",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "question",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "plan",
+            "in": "body",
+            "type": "object",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "useLlm",
+            "in": "body",
+            "type": "boolean",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "maxTokens",
+            "in": "body",
+            "type": "integer",
+            "description": null,
+            "extractionHint": null
+          }
+        ]
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "tabular",
+          "query",
+          "plan",
+          "create",
+          "or",
+          "validate",
+          "an",
+          "allow",
+          "listed",
+          "analysis",
+          "intelligence"
+        ],
+        "negativeCues": [
+          "spot price",
+          "gas storage"
+        ],
+        "examples": [
+          "Show me create or validate an allow-listed tabular analysis plan"
+        ],
+        "synonyms": [
+          "Messstelle",
+          "metering",
+          "EDM"
         ],
         "curated": false
       },

--- a/services/tabular-intelligence.service.js
+++ b/services/tabular-intelligence.service.js
@@ -1,0 +1,625 @@
+'use strict';
+
+const crypto = require('crypto');
+const { generateStructured } = require('../src/llm-client');
+const {
+  MAX_SOURCE_ROWS,
+  buildLlmContext,
+  deterministicAnswer,
+  executeOperations,
+  hashValue,
+  heuristicPlan,
+  profileRows,
+  validateAndBindPlan,
+} = require('../src/tabular-intelligence');
+
+const PLANNER_SCHEMA = {
+  type: 'object',
+  properties: {
+    operations: { type: 'array', items: { type: 'object' } },
+    output: { type: 'object' },
+  },
+  required: ['operations'],
+};
+
+function requestBody(required, properties, example) {
+  return {
+    content: {
+      'application/json': {
+        schema: { type: 'object', required, properties },
+        examples: { request: { summary: 'Tabular intelligence request', value: example } },
+      },
+    },
+  };
+}
+
+function metaOptions(ctx) {
+  return { meta: { ...(ctx.meta || {}) } };
+}
+
+function sourceIdProperties() {
+  return {
+    sourceId: { type: 'string', example: 'metering-source-01' },
+    maxRows: { type: 'integer', default: 5000, example: 5000 },
+    privacyContext: {
+      type: 'string',
+      enum: ['ai-agent', 'public'],
+      default: 'ai-agent',
+      example: 'ai-agent',
+    },
+  };
+}
+
+module.exports = {
+  name: 'tabular',
+
+  settings: {
+    profileMaxRows: Number(process.env.TABULAR_PROFILE_MAX_ROWS || 5000),
+    executionMaxRows: Number(process.env.TABULAR_EXECUTION_MAX_ROWS || MAX_SOURCE_ROWS),
+    contextMaxTokens: Number(process.env.TABULAR_CONTEXT_MAX_TOKENS || 2000),
+  },
+
+  actions: {
+    profile: {
+      rest: 'POST /tabular/profile',
+      params: {
+        sourceId: { type: 'string', min: 1 },
+        maxRows: {
+          type: 'number',
+          integer: true,
+          min: 1,
+          max: 50000,
+          optional: true,
+          convert: true,
+        },
+        privacyContext: {
+          type: 'enum',
+          values: ['ai-agent', 'public'],
+          optional: true,
+          default: 'ai-agent',
+        },
+      },
+      openapi: {
+        summary: 'Build a privacy-aware deterministic table profile',
+        tags: ['Tabular Intelligence'],
+        requestBody: requestBody(['sourceId'], sourceIdProperties(), {
+          sourceId: 'metering-source-01',
+          maxRows: 5000,
+          privacyContext: 'ai-agent',
+        }),
+      },
+      async handler(ctx) {
+        const profile = await this.buildProfile(ctx, ctx.params.sourceId, {
+          maxRows: ctx.params.maxRows,
+          privacyContext: ctx.params.privacyContext,
+        });
+        return { success: true, ...profile };
+      },
+    },
+
+    llmContext: {
+      rest: 'POST /tabular/llm-context',
+      params: {
+        sourceIds: { type: 'array', min: 1, max: 2, items: 'string' },
+        maxTokens: {
+          type: 'number',
+          integer: true,
+          min: 128,
+          max: 8000,
+          optional: true,
+          convert: true,
+        },
+        privacyContext: {
+          type: 'enum',
+          values: ['ai-agent', 'public'],
+          optional: true,
+          default: 'ai-agent',
+        },
+      },
+      openapi: {
+        summary: 'Build bounded LLM-safe context without raw table rows',
+        tags: ['Tabular Intelligence'],
+        requestBody: requestBody(
+          ['sourceIds'],
+          {
+            sourceIds: {
+              type: 'array',
+              items: { type: 'string' },
+              example: ['metering-source-01'],
+            },
+            maxTokens: { type: 'integer', default: 2000, example: 2000 },
+            privacyContext: {
+              type: 'string',
+              enum: ['ai-agent', 'public'],
+              default: 'ai-agent',
+              example: 'ai-agent',
+            },
+          },
+          { sourceIds: ['metering-source-01'], maxTokens: 2000, privacyContext: 'ai-agent' }
+        ),
+      },
+      async handler(ctx) {
+        const profiles = await Promise.all(
+          ctx.params.sourceIds.map((sourceId) =>
+            this.buildProfile(ctx, sourceId, {
+              maxRows: this.settings.profileMaxRows,
+              privacyContext: ctx.params.privacyContext,
+            })
+          )
+        );
+        return {
+          success: true,
+          ...buildLlmContext(profiles, {
+            maxTokens: ctx.params.maxTokens || this.settings.contextMaxTokens,
+          }),
+          profileHashes: profiles.map((profile) => profile.hashes.profile),
+        };
+      },
+    },
+
+    queryPlan: {
+      rest: 'POST /tabular/query-plan',
+      params: {
+        sourceIds: { type: 'array', min: 1, max: 2, items: 'string', optional: true },
+        question: { type: 'string', min: 1, max: 2000, optional: true },
+        plan: { type: 'object', optional: true },
+        useLlm: { type: 'boolean', optional: true, default: false, convert: true },
+        maxTokens: {
+          type: 'number',
+          integer: true,
+          min: 128,
+          max: 8000,
+          optional: true,
+          convert: true,
+        },
+      },
+      openapi: {
+        summary: 'Create or validate an allow-listed tabular analysis plan',
+        tags: ['Tabular Intelligence'],
+        requestBody: requestBody(
+          [],
+          {
+            sourceIds: {
+              type: 'array',
+              items: { type: 'string' },
+              example: ['metering-source-01'],
+            },
+            question: { type: 'string', example: 'What is the total consumption?' },
+            plan: { type: 'object', default: null, example: {} },
+            useLlm: { type: 'boolean', default: false, example: false },
+            maxTokens: { type: 'integer', default: 2000, example: 2000 },
+          },
+          {
+            sourceIds: ['metering-source-01'],
+            question: 'What is the total consumption?',
+            useLlm: false,
+          }
+        ),
+      },
+      async handler(ctx) {
+        const tenantId = ctx.meta?.tenantId || 'default';
+        let candidate = ctx.params.plan;
+        const sourceIds =
+          ctx.params.sourceIds || candidate?.sources?.map((source) => source.sourceId) || [];
+        if (!candidate && !sourceIds.length) throw new Error('sourceIds or plan is required');
+
+        let planner = 'supplied';
+        let contextInfo = null;
+        if (!candidate) {
+          const profiles = await Promise.all(
+            sourceIds.map((sourceId) =>
+              this.buildProfile(ctx, sourceId, {
+                maxRows: this.settings.profileMaxRows,
+                privacyContext: 'ai-agent',
+              })
+            )
+          );
+          if (ctx.params.useLlm) {
+            contextInfo = buildLlmContext(profiles, {
+              maxTokens: ctx.params.maxTokens || this.settings.contextMaxTokens,
+            });
+            const prompt = [
+              'Create a read-only CET tabular plan. Return JSON only.',
+              'Use only the allowed operations and exact column names in the supplied context.',
+              'Do not calculate or state any numeric result.',
+              `Question: ${ctx.params.question || 'Summarize this table'}`,
+              `Safe context: ${contextInfo.context}`,
+            ].join('\n\n');
+            const generated = await generateStructured(PLANNER_SCHEMA, prompt, {
+              ctx,
+              broker: this.broker,
+              tenantId,
+            });
+            candidate = {
+              schemaVersion: '1.0',
+              sources: sourceIds.map((sourceId, index) => ({
+                alias: index === 0 ? 'table' : `table${index + 1}`,
+                sourceId,
+                privacyContext: 'ai-agent',
+              })),
+              operations: generated.operations || [],
+              output: generated.output || { maxRows: 500 },
+            };
+            planner = 'llm-client';
+          } else {
+            if (sourceIds.length !== 1) {
+              throw new Error(
+                'Deterministic heuristic planning supports one source; supply a join plan'
+              );
+            }
+            candidate = heuristicPlan(ctx.params.question, profiles[0], sourceIds[0]);
+            planner = 'deterministic-heuristic';
+          }
+        }
+
+        const plan = validateAndBindPlan(candidate, tenantId);
+        return {
+          success: true,
+          plan,
+          planner,
+          planHash: hashValue(plan),
+          context: contextInfo
+            ? {
+                estimatedTokens: contextInfo.estimatedTokens,
+                truncated: contextInfo.truncated,
+              }
+            : null,
+          warnings: [],
+        };
+      },
+    },
+
+    executePlan: {
+      rest: 'POST /tabular/execute-plan',
+      params: { plan: { type: 'object' } },
+      openapi: {
+        summary: 'Execute a validated tabular plan deterministically',
+        tags: ['Tabular Intelligence'],
+        requestBody: requestBody(
+          ['plan'],
+          {
+            plan: {
+              type: 'object',
+              example: { schemaVersion: '1.0', sources: [], operations: [] },
+            },
+          },
+          {
+            plan: {
+              schemaVersion: '1.0',
+              sources: [{ alias: 'table', sourceId: 'metering-source-01' }],
+              operations: [
+                {
+                  op: 'aggregate',
+                  groupBy: [],
+                  metrics: [{ fn: 'sum', field: 'value', as: 'totalValue' }],
+                },
+              ],
+            },
+          }
+        ),
+      },
+      async handler(ctx) {
+        return this.executePlan(ctx, ctx.params.plan);
+      },
+    },
+
+    ask: {
+      rest: 'POST /tabular/ask',
+      params: {
+        question: { type: 'string', min: 1, max: 2000 },
+        sourceIds: { type: 'array', min: 1, max: 2, items: 'string', optional: true },
+        plan: { type: 'object', optional: true },
+        useLlm: { type: 'boolean', optional: true, default: false, convert: true },
+      },
+      openapi: {
+        summary: 'Answer a table question with deterministic results and evidence',
+        tags: ['Tabular Intelligence'],
+        requestBody: requestBody(
+          ['question'],
+          {
+            question: { type: 'string', example: 'What is the total consumption?' },
+            sourceIds: {
+              type: 'array',
+              items: { type: 'string' },
+              example: ['metering-source-01'],
+            },
+            plan: { type: 'object', default: null, example: {} },
+            useLlm: { type: 'boolean', default: false, example: false },
+          },
+          {
+            question: 'What is the total consumption?',
+            sourceIds: ['metering-source-01'],
+            useLlm: false,
+          }
+        ),
+      },
+      async handler(ctx) {
+        const planning = await ctx.call(
+          'tabular.queryPlan',
+          {
+            sourceIds: ctx.params.sourceIds,
+            question: ctx.params.question,
+            plan: ctx.params.plan,
+            useLlm: ctx.params.useLlm,
+          },
+          metaOptions(ctx)
+        );
+        const execution = await this.executePlan(ctx, planning.plan);
+        return {
+          success: true,
+          answer: deterministicAnswer(execution),
+          question: ctx.params.question,
+          ...execution,
+          planner: planning.planner,
+        };
+      },
+    },
+
+    qualityReport: {
+      rest: 'POST /tabular/quality-report',
+      params: {
+        sourceId: { type: 'string', min: 1 },
+        timestampField: { type: 'string', optional: true },
+        intervalMinutes: {
+          type: 'number',
+          integer: true,
+          min: 1,
+          max: 10080,
+          optional: true,
+          convert: true,
+        },
+        duplicateFields: { type: 'array', items: 'string', optional: true },
+        outlierField: { type: 'string', optional: true },
+        outlierThreshold: { type: 'number', min: 0.1, max: 20, optional: true, convert: true },
+      },
+      openapi: {
+        summary: 'Build an evidence-backed table quality report',
+        tags: ['Tabular Intelligence'],
+        requestBody: requestBody(
+          ['sourceId'],
+          {
+            sourceId: { type: 'string', example: 'metering-source-01' },
+            timestampField: { type: 'string', default: null, example: 'timestamp' },
+            intervalMinutes: { type: 'integer', default: 15, example: 15 },
+            duplicateFields: {
+              type: 'array',
+              items: { type: 'string' },
+              example: ['timestamp'],
+            },
+            outlierField: { type: 'string', default: null, example: 'value' },
+            outlierThreshold: { type: 'number', default: 3, example: 3 },
+          },
+          {
+            sourceId: 'metering-source-01',
+            timestampField: 'timestamp',
+            intervalMinutes: 15,
+            duplicateFields: ['timestamp'],
+            outlierField: 'value',
+          }
+        ),
+      },
+      async handler(ctx) {
+        const profile = await this.buildProfile(ctx, ctx.params.sourceId, {
+          maxRows: this.settings.executionMaxRows,
+          privacyContext: 'ai-agent',
+        });
+        const timestampField =
+          ctx.params.timestampField ||
+          profile.columns.find((column) => column.type === 'timestamp')?.name;
+        const outlierField =
+          ctx.params.outlierField ||
+          profile.columns.find((column) => column.type === 'number')?.name;
+        const duplicateFields =
+          ctx.params.duplicateFields ||
+          (timestampField
+            ? [timestampField]
+            : [profile.columns.find((column) => column.distinctRatio >= 0.8)?.name].filter(
+                Boolean
+              ));
+        const operations = [];
+        if (timestampField) {
+          operations.push({
+            op: 'detectMissingIntervals',
+            field: timestampField,
+            intervalMinutes: ctx.params.intervalMinutes || 15,
+          });
+        }
+        if (duplicateFields.length)
+          operations.push({ op: 'detectDuplicates', fields: duplicateFields });
+        if (outlierField) {
+          operations.push({
+            op: 'detectOutliers',
+            field: outlierField,
+            threshold: ctx.params.outlierThreshold || 3,
+          });
+        }
+        const execution = await this.executePlan(ctx, {
+          schemaVersion: '1.0',
+          sources: [{ alias: 'table', sourceId: ctx.params.sourceId, privacyContext: 'ai-agent' }],
+          operations,
+          output: { maxRows: 100 },
+        });
+        return {
+          success: true,
+          sourceId: ctx.params.sourceId,
+          profile,
+          checks: execution.evidence.operations
+            .filter((operation) => operation.details)
+            .map((operation) => ({ check: operation.op, ...operation.details })),
+          evidence: execution.evidence,
+          warnings: execution.warnings,
+          confidence: execution.confidence,
+        };
+      },
+    },
+  },
+
+  methods: {
+    async loadSourceRows(ctx, sourceId, options = {}) {
+      const maxRows = Math.max(
+        1,
+        Math.min(MAX_SOURCE_ROWS, Number(options.maxRows) || this.settings.executionMaxRows)
+      );
+      const pageSize = Math.min(5000, maxRows);
+      const rows = [];
+      let offset = 0;
+      let totalRows = Number.POSITIVE_INFINITY;
+      while (offset < totalRows && rows.length < maxRows) {
+        const response = await ctx.call(
+          'datasource-cache.query',
+          {
+            sourceId,
+            limit: Math.min(pageSize, maxRows - rows.length),
+            offset,
+            privacyContext: options.privacyContext || 'ai-agent',
+          },
+          metaOptions(ctx)
+        );
+        const page = Array.isArray(response?.data) ? response.data : [];
+        if (!page.length) break;
+        rows.push(...page);
+        totalRows = Number.isFinite(Number(response.totalRows))
+          ? Number(response.totalRows)
+          : offset + page.length;
+        offset += page.length;
+      }
+      return {
+        rows: rows.slice(0, maxRows),
+        totalRows: Number.isFinite(totalRows) ? totalRows : rows.length,
+        truncated: Number.isFinite(totalRows) && totalRows > rows.length,
+      };
+    },
+
+    async loadSourceMetadata(ctx, sourceId) {
+      const sourceResponse = await ctx
+        .call('datasource-registry.get', { id: sourceId }, metaOptions(ctx))
+        .catch(() => null);
+      const source = sourceResponse?.data || {};
+      const classificationResponse = await ctx
+        .call('datasource-registry.getClassification', { id: sourceId }, metaOptions(ctx))
+        .catch(() => null);
+      return {
+        dictionaryFields: source.dictionary?.fields || [],
+        classification: classificationResponse?.data || source.semanticClassification || null,
+      };
+    },
+
+    async buildProfile(ctx, sourceId, options = {}) {
+      const [loaded, metadata] = await Promise.all([
+        this.loadSourceRows(ctx, sourceId, {
+          maxRows: options.maxRows || this.settings.profileMaxRows,
+          privacyContext: options.privacyContext || 'ai-agent',
+        }),
+        this.loadSourceMetadata(ctx, sourceId),
+      ]);
+      const profile = profileRows(loaded.rows, {
+        sourceId,
+        totalRows: loaded.totalRows,
+        privacyContext: options.privacyContext || 'ai-agent',
+        dictionaryFields: metadata.dictionaryFields,
+        classification: metadata.classification,
+      });
+      if (loaded.truncated)
+        profile.warnings.push(`Profile sampled ${loaded.rows.length} of ${loaded.totalRows} rows`);
+      return profile;
+    },
+
+    async executePlan(ctx, rawPlan) {
+      const tenantId = ctx.meta?.tenantId || 'default';
+      const plan = validateAndBindPlan(rawPlan, tenantId);
+      const sourcesByAlias = new Map(plan.sources.map((source) => [source.alias, source]));
+      const join = plan.operations[0]?.op === 'join' ? plan.operations[0] : null;
+      let inputRows;
+      const inputRowCounts = {};
+      const warnings = [];
+
+      if (join) {
+        const left = sourcesByAlias.get(join.left);
+        const right = sourcesByAlias.get(join.right);
+        const joined = await ctx.call(
+          'in-memory-join.join',
+          {
+            left: {
+              kind: 'datasource',
+              sourceId: left.sourceId,
+              maxRows: this.settings.executionMaxRows,
+              privacyContext: left.privacyContext,
+            },
+            right: {
+              kind: 'datasource',
+              sourceId: right.sourceId,
+              maxRows: this.settings.executionMaxRows,
+              privacyContext: right.privacyContext,
+            },
+            join: {
+              leftField: join.leftField,
+              rightField: join.rightField,
+              matchMode: join.matchMode || 'exact',
+              joinType: join.joinType || 'left',
+              multipleMatches: join.multipleMatches || 'first',
+              collisionStrategy: join.collisionStrategy || 'prefix-collisions',
+              rightPrefix: join.rightPrefix || 'right_',
+            },
+          },
+          metaOptions(ctx)
+        );
+        inputRows = Array.isArray(joined.data) ? joined.data : [];
+        inputRowCounts[left.sourceId] = joined.leftCount || 0;
+        inputRowCounts[right.sourceId] = joined.rightCount || 0;
+      } else {
+        const source = plan.sources[0];
+        const loaded = await this.loadSourceRows(ctx, source.sourceId, {
+          maxRows: this.settings.executionMaxRows,
+          privacyContext: source.privacyContext,
+        });
+        inputRows = loaded.rows;
+        inputRowCounts[source.sourceId] = loaded.rows.length;
+        if (loaded.truncated) warnings.push(`Input truncated to ${loaded.rows.length} rows`);
+      }
+
+      const operations = join ? plan.operations.slice(1) : plan.operations;
+      const execution = executeOperations(inputRows, operations, plan.output.maxRows);
+      warnings.push(...execution.warnings);
+      const resultHash = hashValue(execution.rows);
+      const traceId = crypto.randomUUID();
+      const evidence = {
+        sourceIds: plan.sources.map((source) => source.sourceId),
+        inputRowCounts,
+        resultRowCount: execution.fullResultRowCount,
+        evidenceRows: execution.rows.slice(0, 5),
+        calculationSummary: execution.trace.length
+          ? execution.trace
+              .map((item) => `${item.op}:${item.inputRows}->${item.outputRows}`)
+              .join('; ')
+          : `identity:${inputRows.length}->${execution.fullResultRowCount}`,
+        operations: [
+          ...(join
+            ? [
+                {
+                  op: 'join',
+                  inputRows: Object.values(inputRowCounts).reduce((sum, count) => sum + count, 0),
+                  outputRows: inputRows.length,
+                  details: null,
+                },
+              ]
+            : []),
+          ...execution.trace,
+        ],
+        hashes: {
+          input: hashValue(inputRows),
+          plan: hashValue(plan),
+          result: resultHash,
+        },
+        traceId,
+      };
+      return {
+        executedPlan: plan,
+        resultTable: execution.rows,
+        evidence,
+        warnings,
+        assumptions: ['All timestamps are interpreted as UTC when no offset is present.'],
+        confidence: warnings.length ? 'medium' : 'high',
+      };
+    },
+  },
+};

--- a/src/llm-manifest-taxonomy.js
+++ b/src/llm-manifest-taxonomy.js
@@ -192,6 +192,7 @@ const OPENAPI_TAG_DOMAIN_MAP = {
   'Dashboard API': 'platform',
   Datapoints: 'platform',
   DataSources: 'platform',
+  'Tabular Intelligence': 'inhouse-data',
   'Decision Frame': 'governance',
   'e2e-connection-check': 'grid-ops',
   'EDM Messkonzept': 'inhouse-data',

--- a/src/operation-capability-classifier.js
+++ b/src/operation-capability-classifier.js
@@ -53,6 +53,7 @@ const READ_ONLY_QUERY_SERVICES = new Set([
   'oep',
   'osm-geo',
   'residual-load',
+  'tabular',
 ]);
 
 // Verbs whose presence in summary/description/operationId signal a real
@@ -237,6 +238,8 @@ function structuredTextBlob(op) {
 
 function isReadOnlyQueryOperation(op, serviceName) {
   if (op.method === 'GET') return true;
+  // executePlan runs a bounded in-memory analysis and never mutates source data.
+  if (op.method === 'POST' && serviceName === 'tabular') return true;
   if (MUTATING_VERB_PATTERN.test(structuredTextBlob(op))) return false;
   if (op.method === 'POST' && READ_ONLY_QUERY_SERVICES.has(serviceName)) return true;
   if (op.method === 'POST' && QUERY_VERB_PATTERN.test((op.summary || '').trim())) return true;

--- a/src/tabular-intelligence.js
+++ b/src/tabular-intelligence.js
@@ -1,0 +1,673 @@
+'use strict';
+
+const crypto = require('crypto');
+
+const PLAN_SCHEMA_VERSION = '1.0';
+const MAX_OPERATIONS = 20;
+const MAX_SOURCE_ROWS = 50000;
+const MAX_OUTPUT_ROWS = 500;
+const ALLOWED_FILTERS = new Set([
+  'eq',
+  'neq',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'in',
+  'contains',
+  'isNull',
+  'notNull',
+]);
+const ALLOWED_AGGREGATES = new Set(['count', 'sum', 'avg', 'min', 'max']);
+const ALLOWED_OPERATIONS = new Set([
+  'select',
+  'filter',
+  'sort',
+  'limit',
+  'aggregate',
+  'timeBucket',
+  'join',
+  'detectMissingIntervals',
+  'detectDuplicates',
+  'detectOutliers',
+]);
+const ALLOWED_BUCKETS = new Set(['15min', 'hour', 'day', 'week', 'month']);
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!value || typeof value !== 'object') return value;
+  return Object.keys(value)
+    .sort()
+    .reduce((result, key) => {
+      result[key] = canonicalize(value[key]);
+      return result;
+    }, {});
+}
+
+function stableStringify(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+function hashValue(value) {
+  return `sha256:${crypto.createHash('sha256').update(stableStringify(value)).digest('hex')}`;
+}
+
+function tenantBinding(tenantId) {
+  return hashValue({ tenantId: String(tenantId || 'default') });
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function parseNumber(value) {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value !== 'string') return null;
+  const raw = value.trim().replace(/\s/g, '');
+  if (!raw) return null;
+  const normalized = raw.includes(',') ? raw.replace(/\./g, '').replace(',', '.') : raw;
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseDate(value) {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+  if (value === null || value === undefined || value === '') return null;
+  const raw = String(value).trim();
+  const german = raw.match(
+    /^(\d{1,2})\.(\d{1,2})\.(\d{4})(?:[ T](\d{1,2}):?(\d{1,2})?(?::?(\d{1,2}))?)?$/
+  );
+  if (german) {
+    const date = new Date(
+      Date.UTC(
+        Number(german[3]),
+        Number(german[2]) - 1,
+        Number(german[1]),
+        Number(german[4] || 0),
+        Number(german[5] || 0),
+        Number(german[6] || 0)
+      )
+    );
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function inferType(values) {
+  const present = values.filter((value) => value !== null && value !== undefined && value !== '');
+  if (!present.length) return 'empty';
+  if (
+    present.every((value) => typeof value === 'boolean' || /^(true|false)$/i.test(String(value)))
+  ) {
+    return 'boolean';
+  }
+  if (present.every((value) => parseNumber(value) !== null)) return 'number';
+  if (present.every((value) => parseDate(value))) return 'timestamp';
+  return 'string';
+}
+
+function isIdentifierLike(name, values = []) {
+  if (/(^|[_\s-])(id|uuid|name|email|iban|adresse|address|malo|melo|mastr)([_\s-]|$)/i.test(name)) {
+    return true;
+  }
+  const present = values.filter((value) => value !== null && value !== undefined && value !== '');
+  if (!present.length) return false;
+  const idMatches = present.filter((value) =>
+    /^(?:DE\d{10,}|S(?:EE|WE|AN|NB)[A-Z0-9]+|[0-9a-f]{8}-[0-9a-f-]{27,})$/i.test(
+      String(value).trim()
+    )
+  );
+  return idMatches.length / present.length >= 0.8;
+}
+
+function profileRows(rows, options = {}) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const dictionaryFields = Array.isArray(options.dictionaryFields) ? options.dictionaryFields : [];
+  const dictionaryByName = new Map(dictionaryFields.map((field) => [field.name, field]));
+  const names = new Set();
+  safeRows.forEach((row) => Object.keys(row || {}).forEach((name) => names.add(name)));
+
+  const columns = [...names].sort().map((name) => {
+    const values = safeRows.map((row) => row?.[name]);
+    const present = values.filter(
+      (value) => value !== null && value !== undefined && String(value).trim() !== ''
+    );
+    const type = inferType(values);
+    const numeric = type === 'number' ? present.map(parseNumber).filter((v) => v !== null) : [];
+    const timestamps =
+      type === 'timestamp'
+        ? present
+            .map(parseDate)
+            .filter(Boolean)
+            .sort((a, b) => a - b)
+        : [];
+    const fieldMeta = dictionaryByName.get(name) || {};
+    const sensitive = fieldMeta.privacyFlag === true || isIdentifierLike(name, present);
+    const distinct = new Set(present.map((value) => stableStringify(value))).size;
+    const column = {
+      name,
+      type,
+      nullable: present.length !== values.length,
+      nullCount: values.length - present.length,
+      nullRatio: values.length
+        ? Number(((values.length - present.length) / values.length).toFixed(6))
+        : 0,
+      distinctCount: distinct,
+      distinctRatio: present.length ? Number((distinct / present.length).toFixed(6)) : 0,
+      sensitive,
+      semanticRole: fieldMeta.semanticRole || null,
+    };
+
+    if (numeric.length) {
+      const sum = numeric.reduce((total, value) => total + value, 0);
+      column.numeric = {
+        min: Math.min(...numeric),
+        max: Math.max(...numeric),
+        mean: Number((sum / numeric.length).toFixed(9)),
+      };
+    }
+    if (timestamps.length) {
+      column.timestamp = {
+        min: timestamps[0].toISOString(),
+        max: timestamps[timestamps.length - 1].toISOString(),
+      };
+    }
+    if (!sensitive) {
+      column.examples = [...new Set(present.map((value) => String(value).slice(0, 80)))].slice(
+        0,
+        3
+      );
+    }
+    return column;
+  });
+
+  const profile = {
+    schemaVersion: '1.0',
+    sourceId: options.sourceId || null,
+    sampledRowCount: safeRows.length,
+    totalRows: Number.isFinite(options.totalRows) ? options.totalRows : safeRows.length,
+    privacyContext: options.privacyContext || 'ai-agent',
+    classification: options.classification || null,
+    columns,
+    warnings: [],
+  };
+  profile.hashes = {
+    input: hashValue(safeRows),
+    profile: hashValue({ ...profile, hashes: undefined }),
+  };
+  return profile;
+}
+
+function buildLlmContext(profiles, options = {}) {
+  const maxTokens = Math.max(128, Math.min(8000, Number(options.maxTokens) || 2000));
+  const maxChars = maxTokens * 4;
+  const compact = (profiles || []).map((profile) => ({
+    sourceId: profile.sourceId,
+    rowCount: profile.totalRows,
+    sampledRowCount: profile.sampledRowCount,
+    classification: profile.classification
+      ? {
+          domainId: profile.classification.domainId || null,
+          confidence: profile.classification.confidence ?? null,
+          fieldMappings: profile.classification.fieldMappings || {},
+        }
+      : null,
+    columns: (profile.columns || []).map((column) => ({
+      name: column.name,
+      type: column.type,
+      nullable: column.nullable,
+      nullRatio: column.nullRatio,
+      distinctRatio: column.distinctRatio,
+      numeric: column.numeric,
+      timestamp: column.timestamp,
+      sensitive: column.sensitive,
+      examples: column.sensitive ? undefined : column.examples,
+    })),
+  }));
+
+  const envelope = {
+    purpose: 'CET tabular query planning; calculations must be executed by CET',
+    planSchemaVersion: PLAN_SCHEMA_VERSION,
+    allowedOperations: [...ALLOWED_OPERATIONS],
+    profiles: compact,
+  };
+  let context = stableStringify(envelope);
+  let truncated = false;
+
+  if (context.length > maxChars) {
+    compact.forEach((profile) => profile.columns.forEach((column) => delete column.examples));
+    context = stableStringify(envelope);
+    truncated = true;
+  }
+  while (context.length > maxChars && compact.some((profile) => profile.columns.length > 1)) {
+    const largest = [...compact].sort((a, b) => b.columns.length - a.columns.length)[0];
+    largest.columns.pop();
+    context = stableStringify(envelope);
+    truncated = true;
+  }
+  if (context.length > maxChars) {
+    context = context.slice(0, Math.max(0, maxChars - 1)) + '…';
+    truncated = true;
+  }
+
+  return {
+    context,
+    estimatedTokens: Math.ceil(context.length / 4),
+    maxTokens,
+    truncated,
+    profileCount: compact.length,
+  };
+}
+
+function assertPlainObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+}
+
+function assertField(value, label) {
+  if (typeof value !== 'string' || !value.trim() || value.length > 200) {
+    throw new Error(`${label} must be a non-empty field name`);
+  }
+}
+
+function validateOperation(operation, index) {
+  assertPlainObject(operation, `operations[${index}]`);
+  if (!ALLOWED_OPERATIONS.has(operation.op)) {
+    throw new Error(`Unsupported operation: ${operation.op}`);
+  }
+  const label = `operations[${index}]`;
+  if (operation.op === 'select') {
+    if (!Array.isArray(operation.columns) || !operation.columns.length) {
+      throw new Error(`${label}.columns must be a non-empty array`);
+    }
+    operation.columns.forEach((field) => assertField(field, `${label}.columns`));
+  }
+  if (operation.op === 'filter') {
+    assertField(operation.field, `${label}.field`);
+    if (!ALLOWED_FILTERS.has(operation.operator)) {
+      throw new Error(`${label}.operator is not allowed`);
+    }
+  }
+  if (operation.op === 'sort') {
+    if (!Array.isArray(operation.by) || !operation.by.length) {
+      throw new Error(`${label}.by must be a non-empty array`);
+    }
+    operation.by.forEach((sort) => {
+      assertField(sort.field, `${label}.by.field`);
+      if (sort.direction && !['asc', 'desc'].includes(sort.direction)) {
+        throw new Error(`${label}.by.direction must be asc or desc`);
+      }
+    });
+  }
+  if (operation.op === 'limit') {
+    if (
+      !Number.isInteger(operation.count) ||
+      operation.count < 1 ||
+      operation.count > MAX_OUTPUT_ROWS
+    ) {
+      throw new Error(`${label}.count must be between 1 and ${MAX_OUTPUT_ROWS}`);
+    }
+  }
+  if (operation.op === 'aggregate') {
+    if (!Array.isArray(operation.metrics) || !operation.metrics.length) {
+      throw new Error(`${label}.metrics must be a non-empty array`);
+    }
+    if (operation.groupBy && !Array.isArray(operation.groupBy)) {
+      throw new Error(`${label}.groupBy must be an array`);
+    }
+    (operation.groupBy || []).forEach((field) => assertField(field, `${label}.groupBy`));
+    operation.metrics.forEach((metric) => {
+      if (!ALLOWED_AGGREGATES.has(metric.fn))
+        throw new Error(`Unsupported aggregate: ${metric.fn}`);
+      if (metric.fn !== 'count' || metric.field)
+        assertField(metric.field, `${label}.metrics.field`);
+      assertField(metric.as, `${label}.metrics.as`);
+    });
+  }
+  if (operation.op === 'timeBucket') {
+    assertField(operation.field, `${label}.field`);
+    assertField(operation.as, `${label}.as`);
+    if (!ALLOWED_BUCKETS.has(operation.interval))
+      throw new Error(`Unsupported interval: ${operation.interval}`);
+  }
+  if (operation.op === 'join') {
+    ['left', 'right', 'leftField', 'rightField'].forEach((key) =>
+      assertField(operation[key], `${label}.${key}`)
+    );
+    if (
+      operation.matchMode &&
+      !['exact', 'hourly-time', 'daily-date'].includes(operation.matchMode)
+    ) {
+      throw new Error(`${label}.matchMode is not allowed`);
+    }
+    if (operation.joinType && !['left', 'inner'].includes(operation.joinType)) {
+      throw new Error(`${label}.joinType is not allowed`);
+    }
+  }
+  if (['detectMissingIntervals', 'detectOutliers'].includes(operation.op)) {
+    assertField(operation.field, `${label}.field`);
+  }
+  if (operation.op === 'detectDuplicates') {
+    if (!Array.isArray(operation.fields) || !operation.fields.length) {
+      throw new Error(`${label}.fields must be a non-empty array`);
+    }
+    operation.fields.forEach((field) => assertField(field, `${label}.fields`));
+  }
+}
+
+function validateAndBindPlan(input, tenantId) {
+  assertPlainObject(input, 'plan');
+  const plan = clone(input);
+  if (plan.schemaVersion && plan.schemaVersion !== PLAN_SCHEMA_VERSION) {
+    throw new Error(`Unsupported plan schemaVersion: ${plan.schemaVersion}`);
+  }
+  plan.schemaVersion = PLAN_SCHEMA_VERSION;
+  if (!Array.isArray(plan.sources) || !plan.sources.length || plan.sources.length > 2) {
+    throw new Error('plan.sources must contain one or two sources');
+  }
+  const aliases = new Set();
+  plan.sources.forEach((source, index) => {
+    assertPlainObject(source, `sources[${index}]`);
+    assertField(source.alias, `sources[${index}].alias`);
+    assertField(source.sourceId, `sources[${index}].sourceId`);
+    if (aliases.has(source.alias)) throw new Error(`Duplicate source alias: ${source.alias}`);
+    aliases.add(source.alias);
+    if (source.privacyContext && !['ai-agent', 'public'].includes(source.privacyContext)) {
+      throw new Error('Only ai-agent or public privacy contexts are allowed');
+    }
+    source.privacyContext = source.privacyContext || 'ai-agent';
+  });
+  if (!Array.isArray(plan.operations) || plan.operations.length > MAX_OPERATIONS) {
+    throw new Error(`plan.operations must contain at most ${MAX_OPERATIONS} operations`);
+  }
+  plan.operations.forEach(validateOperation);
+  const joins = plan.operations.filter((operation) => operation.op === 'join');
+  if (joins.length > 1) throw new Error('Only one join operation is allowed');
+  if (plan.sources.length > 1 && joins.length !== 1)
+    throw new Error('Two sources require one join');
+  if (joins.length && plan.operations[0].op !== 'join')
+    throw new Error('Join must be the first operation');
+  if (joins.length && (!aliases.has(joins[0].left) || !aliases.has(joins[0].right))) {
+    throw new Error('Join aliases must reference declared sources');
+  }
+  plan.output = plan.output || {};
+  plan.output.maxRows = Math.max(
+    1,
+    Math.min(MAX_OUTPUT_ROWS, Number(plan.output.maxRows) || MAX_OUTPUT_ROWS)
+  );
+  const expectedBinding = tenantBinding(tenantId);
+  if (plan.tenantBinding && plan.tenantBinding !== expectedBinding) {
+    const error = new Error('Plan tenant binding does not match request tenant');
+    error.code = 'TABULAR_TENANT_MISMATCH';
+    throw error;
+  }
+  plan.tenantBinding = expectedBinding;
+  return plan;
+}
+
+function compareValues(left, right) {
+  const leftNumber = parseNumber(left);
+  const rightNumber = parseNumber(right);
+  if (leftNumber !== null && rightNumber !== null) return leftNumber - rightNumber;
+  const leftDate = parseDate(left);
+  const rightDate = parseDate(right);
+  if (leftDate && rightDate) return leftDate - rightDate;
+  return String(left ?? '').localeCompare(String(right ?? ''));
+}
+
+function applyFilter(row, operation) {
+  const value = row?.[operation.field];
+  const target = operation.value;
+  switch (operation.operator) {
+    case 'eq':
+      return compareValues(value, target) === 0;
+    case 'neq':
+      return compareValues(value, target) !== 0;
+    case 'gt':
+      return compareValues(value, target) > 0;
+    case 'gte':
+      return compareValues(value, target) >= 0;
+    case 'lt':
+      return compareValues(value, target) < 0;
+    case 'lte':
+      return compareValues(value, target) <= 0;
+    case 'in':
+      return (
+        Array.isArray(target) && target.some((candidate) => compareValues(value, candidate) === 0)
+      );
+    case 'contains':
+      return String(value ?? '')
+        .toLowerCase()
+        .includes(String(target ?? '').toLowerCase());
+    case 'isNull':
+      return value === null || value === undefined || value === '';
+    case 'notNull':
+      return value !== null && value !== undefined && value !== '';
+    default:
+      return false;
+  }
+}
+
+function isoWeekStart(date) {
+  const result = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = result.getUTCDay() || 7;
+  result.setUTCDate(result.getUTCDate() - day + 1);
+  return result;
+}
+
+function bucketDate(value, interval) {
+  const date = parseDate(value);
+  if (!date) return null;
+  const bucket = new Date(date.getTime());
+  bucket.setUTCSeconds(0, 0);
+  if (interval === '15min') bucket.setUTCMinutes(Math.floor(bucket.getUTCMinutes() / 15) * 15);
+  if (interval === 'hour') bucket.setUTCMinutes(0);
+  if (interval === 'day') bucket.setUTCHours(0, 0, 0, 0);
+  if (interval === 'week') return isoWeekStart(bucket).toISOString();
+  if (interval === 'month') {
+    bucket.setUTCDate(1);
+    bucket.setUTCHours(0, 0, 0, 0);
+  }
+  return bucket.toISOString();
+}
+
+function aggregateRows(rows, operation) {
+  const groupBy = operation.groupBy || [];
+  const groups = new Map();
+  rows.forEach((row) => {
+    const keyValues = groupBy.map((field) => row?.[field] ?? null);
+    const key = stableStringify(keyValues);
+    if (!groups.has(key)) groups.set(key, { keyValues, rows: [] });
+    groups.get(key).rows.push(row);
+  });
+  if (!groups.size && groupBy.length === 0) groups.set('[]', { keyValues: [], rows: [] });
+
+  return [...groups.values()].map((group) => {
+    const output = {};
+    groupBy.forEach((field, index) => {
+      output[field] = group.keyValues[index];
+    });
+    operation.metrics.forEach((metric) => {
+      const values = metric.field
+        ? group.rows.map((row) => parseNumber(row?.[metric.field])).filter((v) => v !== null)
+        : [];
+      if (metric.fn === 'count') {
+        output[metric.as] = metric.field ? values.length : group.rows.length;
+      } else if (!values.length) {
+        output[metric.as] = null;
+      } else if (metric.fn === 'sum') {
+        output[metric.as] = values.reduce((sum, value) => sum + value, 0);
+      } else if (metric.fn === 'avg') {
+        output[metric.as] = values.reduce((sum, value) => sum + value, 0) / values.length;
+      } else if (metric.fn === 'min') {
+        output[metric.as] = Math.min(...values);
+      } else if (metric.fn === 'max') {
+        output[metric.as] = Math.max(...values);
+      }
+    });
+    return output;
+  });
+}
+
+function missingIntervals(rows, operation) {
+  const intervalMinutes = Number(operation.intervalMinutes) || 15;
+  const expectedMs = intervalMinutes * 60000;
+  const dates = rows
+    .map((row) => parseDate(row?.[operation.field]))
+    .filter(Boolean)
+    .sort((a, b) => a - b);
+  const missing = [];
+  for (let index = 1; index < dates.length; index += 1) {
+    let cursor = dates[index - 1].getTime() + expectedMs;
+    while (cursor < dates[index].getTime() && missing.length < 1000) {
+      missing.push(new Date(cursor).toISOString());
+      cursor += expectedMs;
+    }
+  }
+  return { intervalMinutes, missingCount: missing.length, missing: missing.slice(0, 100) };
+}
+
+function duplicateSummary(rows, operation) {
+  const counts = new Map();
+  rows.forEach((row) => {
+    const key = stableStringify(operation.fields.map((field) => row?.[field] ?? null));
+    counts.set(key, (counts.get(key) || 0) + 1);
+  });
+  const duplicateGroups = [...counts.values()].filter((count) => count > 1);
+  return {
+    fields: operation.fields,
+    duplicateGroupCount: duplicateGroups.length,
+    duplicateRowCount: duplicateGroups.reduce((sum, count) => sum + count, 0),
+  };
+}
+
+function outlierSummary(rows, operation) {
+  const values = rows
+    .map((row) => parseNumber(row?.[operation.field]))
+    .filter((value) => value !== null);
+  if (values.length < 3)
+    return { field: operation.field, method: 'zscore', threshold: 3, count: 0, values: [] };
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance = values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / values.length;
+  const stddev = Math.sqrt(variance);
+  const threshold = Number(operation.threshold) > 0 ? Number(operation.threshold) : 3;
+  const outliers = stddev
+    ? values.filter((value) => Math.abs((value - mean) / stddev) > threshold)
+    : [];
+  return {
+    field: operation.field,
+    method: 'zscore',
+    threshold,
+    mean,
+    stddev,
+    count: outliers.length,
+    values: outliers.slice(0, 20),
+  };
+}
+
+function executeOperations(inputRows, operations, outputMaxRows = MAX_OUTPUT_ROWS) {
+  let rows = clone(Array.isArray(inputRows) ? inputRows : []);
+  const trace = [];
+  const warnings = [];
+
+  for (const operation of operations) {
+    const before = rows.length;
+    let details = null;
+    if (operation.op === 'select') {
+      rows = rows.map((row) =>
+        operation.columns.reduce((result, field) => {
+          result[field] = row?.[field] ?? null;
+          return result;
+        }, {})
+      );
+    } else if (operation.op === 'filter') {
+      rows = rows.filter((row) => applyFilter(row, operation));
+    } else if (operation.op === 'sort') {
+      rows.sort((left, right) => {
+        for (const sort of operation.by) {
+          const comparison = compareValues(left?.[sort.field], right?.[sort.field]);
+          if (comparison !== 0) return sort.direction === 'desc' ? -comparison : comparison;
+        }
+        return 0;
+      });
+    } else if (operation.op === 'limit') {
+      rows = rows.slice(0, operation.count);
+    } else if (operation.op === 'aggregate') {
+      rows = aggregateRows(rows, operation);
+    } else if (operation.op === 'timeBucket') {
+      rows = rows.map((row) => ({
+        ...row,
+        [operation.as]: bucketDate(row?.[operation.field], operation.interval),
+      }));
+      const invalidCount = rows.filter((row) => row[operation.as] === null).length;
+      if (invalidCount)
+        warnings.push(`${invalidCount} rows had unparseable timestamps in ${operation.field}`);
+    } else if (operation.op === 'detectMissingIntervals') {
+      details = missingIntervals(rows, operation);
+      if (details.missingCount) warnings.push(`${details.missingCount} missing intervals detected`);
+    } else if (operation.op === 'detectDuplicates') {
+      details = duplicateSummary(rows, operation);
+      if (details.duplicateRowCount)
+        warnings.push(`${details.duplicateRowCount} duplicate rows detected`);
+    } else if (operation.op === 'detectOutliers') {
+      details = outlierSummary(rows, operation);
+      if (details.count) warnings.push(`${details.count} outliers detected in ${operation.field}`);
+    }
+    trace.push({ op: operation.op, inputRows: before, outputRows: rows.length, details });
+  }
+
+  const truncated = rows.length > outputMaxRows;
+  if (truncated) warnings.push(`Result truncated to ${outputMaxRows} rows`);
+  return { rows: rows.slice(0, outputMaxRows), trace, warnings, fullResultRowCount: rows.length };
+}
+
+function deterministicAnswer(execution) {
+  const rows = execution.resultTable || [];
+  if (!rows.length) return 'Deterministic execution produced no result rows.';
+  if (rows.length === 1) {
+    const metrics = Object.entries(rows[0])
+      .filter(([, value]) => typeof value === 'number' && Number.isFinite(value))
+      .map(([key, value]) => `${key}=${value}`);
+    if (metrics.length) return `Deterministic execution produced: ${metrics.join(', ')}.`;
+  }
+  return `Deterministic execution produced ${execution.evidence?.resultRowCount ?? rows.length} result rows.`;
+}
+
+function heuristicPlan(question, profile, sourceId) {
+  const text = String(question || '').toLowerCase();
+  const columns = profile?.columns || [];
+  const numeric = columns.filter((column) => column.type === 'number');
+  const mentioned =
+    numeric.find((column) => text.includes(column.name.toLowerCase())) || numeric[0];
+  let fn = 'count';
+  if (/(sum|summe|gesamt)/.test(text) && mentioned) fn = 'sum';
+  else if (/(avg|average|mittel|durchschnitt)/.test(text) && mentioned) fn = 'avg';
+  else if (/(maximum|max|höchst)/.test(text) && mentioned) fn = 'max';
+  else if (/(minimum|min|niedrig)/.test(text) && mentioned) fn = 'min';
+  const metric = { fn, as: fn === 'count' ? 'rowCount' : `${fn}_${mentioned.name}` };
+  if (fn !== 'count') metric.field = mentioned.name;
+  return {
+    schemaVersion: PLAN_SCHEMA_VERSION,
+    sources: [{ alias: 'table', sourceId, privacyContext: 'ai-agent' }],
+    operations: [{ op: 'aggregate', groupBy: [], metrics: [metric] }],
+    output: { maxRows: MAX_OUTPUT_ROWS },
+  };
+}
+
+module.exports = {
+  PLAN_SCHEMA_VERSION,
+  MAX_SOURCE_ROWS,
+  MAX_OUTPUT_ROWS,
+  hashValue,
+  tenantBinding,
+  parseNumber,
+  parseDate,
+  profileRows,
+  buildLlmContext,
+  validateAndBindPlan,
+  executeOperations,
+  deterministicAnswer,
+  heuristicPlan,
+};

--- a/tests/fixtures/tabular-assets.fixture.json
+++ b/tests/fixtures/tabular-assets.fixture.json
@@ -1,0 +1,21 @@
+{
+  "sourceId": "assets-fixture",
+  "dictionary": {
+    "fields": [
+      { "name": "Asset_ID", "type": "string", "semanticRole": "assetId" },
+      { "name": "Betreiber_Name", "type": "string", "privacyFlag": true },
+      { "name": "Anlagentyp", "type": "string", "semanticRole": "assetType" },
+      { "name": "Spannungsebene", "type": "string", "semanticRole": "voltageLevel" }
+    ]
+  },
+  "classification": {
+    "domainId": "grid-assets",
+    "confidence": 0.98,
+    "fieldMappings": { "assetId": "Asset_ID", "assetType": "Anlagentyp" }
+  },
+  "rows": [
+    { "Asset_ID": "A-1", "Betreiber_Name": "Private Grid GmbH", "Anlagentyp": "PV", "Spannungsebene": "MS" },
+    { "Asset_ID": "A-2", "Betreiber_Name": "Private Wind GmbH", "Anlagentyp": "Wind", "Spannungsebene": "HS" },
+    { "Asset_ID": "A-2", "Betreiber_Name": "Private Wind GmbH", "Anlagentyp": "Wind", "Spannungsebene": "HS" }
+  ]
+}

--- a/tests/fixtures/tabular-join.fixture.json
+++ b/tests/fixtures/tabular-join.fixture.json
@@ -1,0 +1,16 @@
+{
+  "leftSourceId": "join-assets-fixture",
+  "rightSourceId": "join-metering-fixture",
+  "leftRows": [
+    { "Asset_ID": "A-1", "Anlagentyp": "PV" },
+    { "Asset_ID": "A-2", "Anlagentyp": "Wind" }
+  ],
+  "rightRows": [
+    { "Asset_ID": "A-1", "Verbrauch_kWh": 3 },
+    { "Asset_ID": "A-2", "Verbrauch_kWh": 5 }
+  ],
+  "expected": [
+    { "Anlagentyp": "PV", "totalConsumption": 3 },
+    { "Anlagentyp": "Wind", "totalConsumption": 5 }
+  ]
+}

--- a/tests/fixtures/tabular-metering.fixture.json
+++ b/tests/fixtures/tabular-metering.fixture.json
@@ -1,0 +1,17 @@
+{
+  "sourceId": "metering-fixture",
+  "dictionary": {
+    "fields": [
+      { "name": "timestamp", "type": "timestamp", "semanticRole": "timeReference" },
+      { "name": "Verbrauch_kWh", "type": "number", "semanticRole": "consumptionKWh" },
+      { "name": "MaLo_ID", "type": "string", "semanticRole": "maloId", "privacyFlag": true }
+    ]
+  },
+  "classification": { "domainId": "metering", "confidence": 0.99 },
+  "rows": [
+    { "timestamp": "2026-01-01T00:00:00Z", "Verbrauch_kWh": 1, "MaLo_ID": "DE0000000000000000000001" },
+    { "timestamp": "2026-01-01T00:15:00Z", "Verbrauch_kWh": 2, "MaLo_ID": "DE0000000000000000000001" },
+    { "timestamp": "2026-01-01T00:45:00Z", "Verbrauch_kWh": 3, "MaLo_ID": "DE0000000000000000000001" },
+    { "timestamp": "2026-01-01T01:00:00Z", "Verbrauch_kWh": 40, "MaLo_ID": "DE0000000000000000000001" }
+  ]
+}

--- a/tests/operation-capability-classifier.test.js
+++ b/tests/operation-capability-classifier.test.js
@@ -85,6 +85,21 @@ describe('operation-capability-classifier', () => {
       expect(result.recommendedExecutionMode).toBe('direct');
     });
 
+    it('keeps deterministic tabular plan execution read-only despite the execute verb', () => {
+      const result = classifyOperation(
+        buildOp({
+          path: '/api/tabular/execute-plan',
+          method: 'POST',
+          operationId: 'tabular_executePlan',
+          summary: 'Execute a validated tabular plan deterministically',
+          tags: ['Tabular Intelligence'],
+        })
+      );
+      expect(result.operationKind).toBe('data_read');
+      expect(result.sideEffects).toEqual([]);
+      expect(result.requiredScopes).toEqual(['tabular:read']);
+    });
+
     // Regression test: "start"/"stop" and other generic English words
     // appearing inside prose parameter documentation (not the operation's
     // own summary/tags/operationId/path) must not misclassify an otherwise

--- a/tests/tabular-intelligence.service.test.js
+++ b/tests/tabular-intelligence.service.test.js
@@ -1,0 +1,313 @@
+'use strict';
+
+jest.mock('../src/llm-client', () => ({
+  generateStructured: jest.fn(),
+}));
+
+const fs = require('fs');
+const path = require('path');
+const { ServiceBroker } = require('moleculer');
+const { generateStructured } = require('../src/llm-client');
+const InMemoryJoinService = require('../services/in-memory-join.service');
+const TabularService = require('../services/tabular-intelligence.service');
+
+function fixture(name) {
+  return JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'fixtures', `tabular-${name}.fixture.json`), 'utf8')
+  );
+}
+
+describe('Tabular Intelligence Service', () => {
+  let broker;
+  const metering = fixture('metering');
+  const assets = fixture('assets');
+  const joined = fixture('join');
+  const datasets = new Map([
+    [metering.sourceId, metering.rows],
+    [assets.sourceId, assets.rows],
+    [joined.leftSourceId, joined.leftRows],
+    [joined.rightSourceId, joined.rightRows],
+  ]);
+  const metadata = new Map([
+    [metering.sourceId, metering],
+    [assets.sourceId, assets],
+    [
+      joined.leftSourceId,
+      { dictionary: { fields: [] }, classification: { domainId: 'grid-assets' } },
+    ],
+    [
+      joined.rightSourceId,
+      { dictionary: { fields: [] }, classification: { domainId: 'metering' } },
+    ],
+  ]);
+  const observedCalls = [];
+
+  beforeAll(async () => {
+    broker = new ServiceBroker({ logger: false, transporter: null });
+    broker.createService({
+      name: 'datasource-cache',
+      actions: {
+        query: {
+          async handler(ctx) {
+            observedCalls.push({
+              action: 'datasource-cache.query',
+              params: ctx.params,
+              meta: ctx.meta,
+            });
+            const rows = datasets.get(ctx.params.sourceId) || [];
+            const prepared = rows.map((row) => {
+              const copy = { ...row };
+              if (ctx.params.privacyContext !== 'internal' && copy.Betreiber_Name) {
+                copy.Betreiber_Name = 'REDACTED';
+              }
+              if (ctx.params.privacyContext !== 'internal' && copy.MaLo_ID) {
+                copy.MaLo_ID = 'REDACTED';
+              }
+              return copy;
+            });
+            const offset = Number(ctx.params.offset) || 0;
+            const limit = Number(ctx.params.limit) || 100;
+            return {
+              success: true,
+              totalRows: prepared.length,
+              data: prepared.slice(offset, offset + limit),
+            };
+          },
+        },
+      },
+    });
+    broker.createService({
+      name: 'datasource-registry',
+      actions: {
+        get: {
+          handler(ctx) {
+            const item = metadata.get(ctx.params.id) || {};
+            return { success: true, data: { dictionary: item.dictionary || { fields: [] } } };
+          },
+        },
+        getClassification: {
+          handler(ctx) {
+            return { success: true, data: metadata.get(ctx.params.id)?.classification || null };
+          },
+        },
+      },
+    });
+    broker.createService(InMemoryJoinService);
+    broker.createService(TabularService);
+    await broker.start();
+  });
+
+  afterAll(async () => {
+    await broker.stop();
+  });
+
+  beforeEach(() => {
+    observedCalls.length = 0;
+    generateStructured.mockReset();
+  });
+
+  it('profiles asset/master data without exposing sensitive or identifier examples', async () => {
+    const profile = await broker.call(
+      'tabular.profile',
+      { sourceId: assets.sourceId },
+      { meta: { tenantId: 'tenant-a' } }
+    );
+
+    expect(profile.classification.domainId).toBe('grid-assets');
+    expect(profile.sampledRowCount).toBe(3);
+    expect(profile.columns.find((column) => column.name === 'Asset_ID').sensitive).toBe(true);
+    expect(profile.columns.find((column) => column.name === 'Asset_ID').examples).toBeUndefined();
+    expect(
+      profile.columns.find((column) => column.name === 'Betreiber_Name').examples
+    ).toBeUndefined();
+    expect(profile.hashes.input).toMatch(/^sha256:/);
+    expect(observedCalls.every((call) => call.params.privacyContext === 'ai-agent')).toBe(true);
+    expect(observedCalls.every((call) => call.meta.tenantId === 'tenant-a')).toBe(true);
+  });
+
+  it('builds token-bounded LLM context without raw sensitive table values', async () => {
+    const result = await broker.call('tabular.llmContext', {
+      sourceIds: [assets.sourceId],
+      maxTokens: 128,
+    });
+
+    expect(result.estimatedTokens).toBeLessThanOrEqual(128);
+    expect(result.context).not.toContain('Private Grid GmbH');
+    expect(result.context).not.toContain('Private Wind GmbH');
+    expect(result.context).not.toContain('connectorConfig');
+    expect(result.context).toContain('grid-assets');
+  });
+
+  it('executes time bucketing, deterministic aggregation, and missing-interval detection', async () => {
+    const planned = await broker.call(
+      'tabular.queryPlan',
+      {
+        plan: {
+          schemaVersion: '1.0',
+          sources: [{ alias: 'metering', sourceId: metering.sourceId }],
+          operations: [
+            { op: 'detectMissingIntervals', field: 'timestamp', intervalMinutes: 15 },
+            { op: 'timeBucket', field: 'timestamp', interval: 'hour', as: 'period' },
+            {
+              op: 'aggregate',
+              groupBy: ['period'],
+              metrics: [{ fn: 'sum', field: 'Verbrauch_kWh', as: 'totalConsumption' }],
+            },
+            { op: 'sort', by: [{ field: 'period', direction: 'asc' }] },
+          ],
+        },
+      },
+      { meta: { tenantId: 'tenant-a' } }
+    );
+    const result = await broker.call(
+      'tabular.executePlan',
+      { plan: planned.plan },
+      { meta: { tenantId: 'tenant-a' } }
+    );
+
+    expect(result.resultTable).toEqual([
+      { period: '2026-01-01T00:00:00.000Z', totalConsumption: 6 },
+      { period: '2026-01-01T01:00:00.000Z', totalConsumption: 40 },
+    ]);
+    expect(result.evidence.operations[0].details.missingCount).toBe(1);
+    expect(result.evidence.hashes.plan).toMatch(/^sha256:/);
+    expect(result.evidence.evidenceRows).toEqual(result.resultTable);
+    expect(result.warnings).toContain('1 missing intervals detected');
+    expect(result.confidence).toBe('medium');
+  });
+
+  it('delegates joins to in-memory-join and aggregates the joined fixture', async () => {
+    const plan = {
+      schemaVersion: '1.0',
+      sources: [
+        { alias: 'assets', sourceId: joined.leftSourceId },
+        { alias: 'metering', sourceId: joined.rightSourceId },
+      ],
+      operations: [
+        {
+          op: 'join',
+          left: 'assets',
+          right: 'metering',
+          leftField: 'Asset_ID',
+          rightField: 'Asset_ID',
+          joinType: 'inner',
+          matchMode: 'exact',
+        },
+        {
+          op: 'aggregate',
+          groupBy: ['Anlagentyp'],
+          metrics: [{ fn: 'sum', field: 'Verbrauch_kWh', as: 'totalConsumption' }],
+        },
+        { op: 'sort', by: [{ field: 'Anlagentyp', direction: 'asc' }] },
+      ],
+    };
+
+    const result = await broker.call('tabular.executePlan', { plan });
+
+    expect(result.resultTable).toEqual(joined.expected);
+    expect(result.evidence.operations[0].op).toBe('join');
+    expect(result.evidence.sourceIds).toEqual([joined.leftSourceId, joined.rightSourceId]);
+    expect(observedCalls.every((call) => call.params.privacyContext === 'ai-agent')).toBe(true);
+  });
+
+  it('answers with numbers only from deterministic execution output', async () => {
+    const result = await broker.call('tabular.ask', {
+      question: 'Wie hoch ist die Summe von Verbrauch_kWh?',
+      sourceIds: [metering.sourceId],
+    });
+
+    expect(result.answer).toBe('Deterministic execution produced: sum_Verbrauch_kWh=46.');
+    expect(result.resultTable).toEqual([{ sum_Verbrauch_kWh: 46 }]);
+    expect(result.answer).toContain(String(result.resultTable[0].sum_Verbrauch_kWh));
+    expect(result.evidence.hashes.result).toMatch(/^sha256:/);
+  });
+
+  it('uses only safe context for optional LLM planning and validates the generated plan', async () => {
+    generateStructured.mockResolvedValue({
+      operations: [
+        {
+          op: 'aggregate',
+          groupBy: [],
+          metrics: [{ fn: 'count', as: 'rowCount' }],
+        },
+      ],
+      output: { maxRows: 10 },
+    });
+
+    const result = await broker.call(
+      'tabular.queryPlan',
+      {
+        sourceIds: [assets.sourceId],
+        question: 'How many assets?',
+        useLlm: true,
+      },
+      { meta: { tenantId: 'tenant-a' } }
+    );
+
+    expect(result.planner).toBe('llm-client');
+    expect(result.plan.tenantBinding).toMatch(/^sha256:/);
+    const prompt = generateStructured.mock.calls[0][1];
+    expect(prompt).not.toContain('Private Grid GmbH');
+    expect(prompt).not.toContain('Private Wind GmbH');
+    expect(prompt).not.toContain('A-1');
+  });
+
+  it('rejects unsafe operations, internal privacy, and cross-tenant plan replay', async () => {
+    await expect(
+      broker.call('tabular.executePlan', {
+        plan: {
+          sources: [{ alias: 'table', sourceId: assets.sourceId, privacyContext: 'internal' }],
+          operations: [],
+        },
+      })
+    ).rejects.toThrow('Only ai-agent or public privacy contexts are allowed');
+
+    await expect(
+      broker.call('tabular.executePlan', {
+        plan: {
+          sources: [{ alias: 'table', sourceId: assets.sourceId }],
+          operations: [{ op: 'sql', query: 'DROP TABLE assets' }],
+        },
+      })
+    ).rejects.toThrow('Unsupported operation: sql');
+
+    const planned = await broker.call(
+      'tabular.queryPlan',
+      {
+        plan: {
+          sources: [{ alias: 'table', sourceId: assets.sourceId }],
+          operations: [],
+        },
+      },
+      { meta: { tenantId: 'tenant-a' } }
+    );
+    await expect(
+      broker.call('tabular.executePlan', { plan: planned.plan }, { meta: { tenantId: 'tenant-b' } })
+    ).rejects.toMatchObject({ code: 'TABULAR_TENANT_MISMATCH' });
+  });
+
+  it('returns evidence-backed quality checks for the metering fixture', async () => {
+    const result = await broker.call('tabular.qualityReport', {
+      sourceId: metering.sourceId,
+      timestampField: 'timestamp',
+      duplicateFields: ['timestamp'],
+      outlierField: 'Verbrauch_kWh',
+      outlierThreshold: 1.5,
+    });
+
+    expect(
+      result.checks.find((check) => check.check === 'detectMissingIntervals').missingCount
+    ).toBe(1);
+    expect(
+      result.checks.find((check) => check.check === 'detectDuplicates').duplicateRowCount
+    ).toBe(0);
+    expect(result.checks.find((check) => check.check === 'detectOutliers').count).toBe(1);
+    expect(result.evidence.sourceIds).toEqual([metering.sourceId]);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        '1 missing intervals detected',
+        '1 outliers detected in Verbrauch_kWh',
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

CET can now analyze bounded tabular datasets without handing calculations to an LLM. The new read-only Tabular Intelligence Layer profiles cached tables, creates privacy-aware planning context, validates allow-listed plans, executes calculations deterministically, and returns reproducible evidence.

## Why This Change Was Made

Raw-table prompting is not sufficiently auditable for metering, asset, MaStR, Redispatch, and joined utility datasets. This implementation follows the planning-first architecture required by the issue: models may propose plans, while CET validates and executes every numerical operation.

The architecture/MVP cut is documented in `docs/architecture/tabular-intelligence-layer.md` before the implementation commit.

## User Impact

Adds six read-only actions and REST routes:

- `tabular.profile`
- `tabular.llmContext`
- `tabular.queryPlan`
- `tabular.executePlan`
- `tabular.ask`
- `tabular.qualityReport`

The MVP supports projection, filtering, sorting, limits, grouped aggregates, UTC time buckets, missing-interval detection, duplicate detection, outlier checks, and two-source joins via the existing `in-memory-join` service. Plans are tenant-bound; datasource reads retain `ctx.meta` and use `ai-agent`/`public` privacy processing. Numeric answers are rendered only from deterministic execution output.

## Evidence

- Targeted Jest suites: **30/30 passed**
  - `tests/tabular-intelligence.service.test.js`
  - `tests/operation-capability-classifier.test.js`
- Fixtures cover metering time series, asset/master data, and joined/aggregated data.
- ESLint passes for the new service/core/test files and taxonomy change.
- `npm run check:llm`: passed; `llm.txt` is synchronized.
- `npm run check:operation-capability-index`: passed.
- `npm run audit:openapi`: the six new tabular routes add no findings; the repository audit still exits non-zero on 3 pre-existing findings in `chatgpt-sidecar` and `dashboard-api`.
- `npm run test:unit:ci`: **6746 passed, 51 skipped, 113 failed** across the repository. The 12 failing suites are pre-existing/environmental and outside this change; notably, the `llm-manifest` token-budget failure reproduces unchanged on `origin/main` at 14,552 characters. The new tabular suite is green.

Fixes energychain/cernion-energy-tools#456
