### PR TITLE
docs: refresh Cernion README GTM positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Cernion Energy Tools
 
 > API-first Agentic Energy Operations Layer for Stadtwerke, DSOs and energy-service teams.
-> Cernion combines deterministic energy-domain microservices, governed agent orchestration,
-> evidence dossiers and curated integration surfaces for Microsoft Copilot, OpenClaw and
-> conventional REST clients.
+> Cernion combines deterministic energy-domain services, curated capability routing,
+> evidence dossiers, VDMI role logic, HITL boundaries and read-only integration surfaces
+> for REST, Sidecar, Microsoft Copilot, n8n, OpenWebUI and OpenClaw.
 
 [![Maintenance CI](https://github.com/energychain/cernion-energy-tools/actions/workflows/maintenance-ci.yml/badge.svg?branch=main)](https://github.com/energychain/cernion-energy-tools/actions/workflows/maintenance-ci.yml)
 [![CodeQL](https://github.com/energychain/cernion-energy-tools/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/energychain/cernion-energy-tools/actions/workflows/codeql.yml)
@@ -18,13 +18,26 @@ agentic process orchestration.
 
 It is not just a chat frontend for energy APIs. The current platform contains:
 
-- **108 Moleculer services** in `services/`
-- **619 OpenAPI paths** in `openapi-export.json`
-- **243 JavaScript test files** under `tests/`
-- **curated Copilot and Sidecar interfaces** that expose only governed subsets of the backend
+- **137 Moleculer services** in `services/`
+- **1003 OpenAPI paths** in `openapi-export.json`
+- **297 JavaScript test files** under `tests/`
+- **curated Copilot, Sidecar, OpenWebUI, n8n and OpenClaw integration surfaces** that expose only governed subsets of the backend
 - **agentic runtime components** for routing, receipts, dossiers, HITL, evidence, revalidation and observability
 
-Current package version: **`0.60.8`**
+Current package/OpenAPI version: **`0.67.8`**
+
+### Public positioning
+
+Cernion does not let the chat decide. The platform structures the objective, available
+data, service chain, evidence, gaps, risk and the next safe gate. The result is not a
+black-box answer, but a dossier-ready status or decision-readiness view for Stadtwerke,
+distribution-system operators and energy-service teams.
+
+Cernion Energy Tools is not an automatic contract decision, grid-connection commitment,
+device-control system, MaKo execution system, billing/settlement system or tariff-mutation
+machine. Suitable integration scopes are `ask`, `plan`, `evidence`, `capability lookup`
+and `read-only status`. Write-like or consequential steps stay in `draft`, `prepare` or
+`pending confirmation` states and require HITL.
 
 The public website explains Cernion as an energy-intelligence and decision platform for
 Stadtwerke: MaStR analysis, grid planning, §14a, Redispatch, Energy Sharing, customer-service


### PR DESCRIPTION
## Summary
- Align README opening and positioning text with the approved Cernion GTM core.
- Clarify that Cernion structures goals, evidence, gaps, risk and safe HITL gates rather than letting a chat decide.
- Refresh repository metrics and package/OpenAPI version from current local sources.

## Verification
- Verified `package.json` version: `0.67.8`.
- Verified `openapi-export.json` `info.version`: `0.67.8`.
- Counted `services/*.service.js`: `137`.
- Counted `openapi-export.json` paths: `1003`.
- Counted `tests/**/*.test.js`: `297`.
- `git diff --check -- README.md` passed.
- Ad-hoc README verification passed for required GTM strings and stale-value removal.

## Safety boundary
- Documentation-only README diff.
- No live publication, deployment or restart performed.
- GitHub branch/PR creation was performed only after HITL approval on kanban task `t_ff8bf2bb` (`approved creating`).
