### PR TITLE
feat: add public website backlog reports

### DIFF
--- a/docs/PUBLIC_WEBSITE_BACKLOG_AGENT_ROUTING.md
+++ b/docs/PUBLIC_WEBSITE_BACKLOG_AGENT_ROUTING.md
@@ -1,0 +1,226 @@
+# CET Public Website Backlog Agent Routing
+
+Dieses Dokument spezifiziert, wie erzeugte Public-Website-Backlog-Kandidaten in konkrete interne Folgeimpulse fuer Rhajaina, Webmaster und Felix uebersetzt werden. Es ergaenzt `public-website-backlog-candidate-schema.md` und `PUBLIC_WEBSITE_BACKLOG_RUBRIC.md`.
+
+Die Routing-Entscheidung erzeugt nur Aufgabenentwuerfe oder Review-Impulse. Sie sendet keine externen Nachrichten, schreibt keine GitHub-Issues/PRs, publiziert keine Website-Aenderungen und startet keine Deployments.
+
+## 1. Routing-Grundsatz
+
+1. Jeder Kandidat bleibt ein interner Draft, bis ein expliziter HITL-, PR-, Publish- oder Sending-Schritt freigegeben ist.
+2. Rhajaina ist Default-Owner fuer Triage, Claim-Grenzen, Stop-Regeln und unklare Mehrfachzustandigkeit.
+3. Webmaster ist Owner fuer oeffentliche Struktur-, SEO-, FAQ-, Doku- und Website-Draft-Arbeit, solange der Inhalt belegbar und claim-sicher formulierbar ist.
+4. Felix ist Owner fuer B2B-Sales-Narrative, Zielkunden-Segmentierung, Demo-Gespraechsleitfaeden und Follow-up-Entwuerfe ohne externen Versand.
+5. Bei R2/R3-Claim-Risiko, sensitiver Herkunft, fehlendem Beleg oder externer Wirkung wird nicht automatisch geroutet, sondern als Review-/HITL-Impuls markiert.
+
+## 2. Routing-Tabelle
+
+| Bedingung im Kandidaten                                                                                  | Primaerer Folgeimpuls                                      | Sekundaerer Review                                       | Prioritaetssignal                                                       | Naechster sicherer Schritt                                                | Stop-Gate                                                            |
+| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------ |
+| `recommendedFollowUpAgent = rhajaina-claim-review` oder `claimRisk = high`                               | Rhajaina                                                   | Fachowner nach Bedarf                                    | Hoch, wenn Website-/Sales-Nutzen plausibel und nur Claim-Grenzen fehlen | Claim-Grenzen, erlaubte Nicht-Zusagen und Ziel-Owner klaeren              | Keine Website-, Sales- oder GitHub-Aktion vor Freigabe               |
+| `recommendedFollowUpAgent = webmaster` und `claimRisk = low                                              | medium`, `demoReadiness != concept-only                    | blocked-unverified`                                      | Webmaster                                                               | Rhajaina bei R1/R2-Begriffen; Felix bei B2B-CTA                           | Hoch bei stabilem OpenAPI-/CHANGELOG-Beleg plus klarer Zielseite     | Website-/FAQ-/SEO-Draft mit Quellenankern vorbereiten          | Kein PR, Publish, Deployment oder Live-CMS-Write |
+| `recommendedFollowUpAgent = felix-demo-sales` oder Zielrolle `Cernion-Demo/Vertrieb`, Stadtwerk/VNB/B2B  | Felix                                                      | Rhajaina bei Claims; Webmaster bei spaeterem Website-Fit | Hoch bei demo-ready/read-only und konkretem Zielsegment                 | Demo-Narrativ, Gespraechsleitfaden oder Follow-up-Mailentwurf vorbereiten | Kein Versand, keine Preis-/Vertragszusage, kein CRM-Fakt ohne Quelle |
+| Developer-/OSS-Fokus, Zielseite `corrently.io`, API-Rezept- oder Auth-/curl-Luecke                       | Webmaster als Sichtbarkeits-Steward oder DevOps-Doku-Folge | Rhajaina, falls aus Website-Backlog nicht eindeutig      | Mittel; hoch nur bei starker OpenAPI-Relevanz fuer Public Discovery     | Doku-/LLM-Discoverability-Draft oder DevOps-Folgeimpuls formulieren       | Kein GitHub-Issue/PR ohne separate Freigabe                          |
+| `demoReadiness = concept-only` bei `claimRisk = low                                                      | medium`                                                    | Felix oder Rhajaina, je nach Nutzenfrage                 | Webmaster erst nach Demo-/Story-Klaerung                                | Mittel, wenn Zielsegment klar; niedrig ohne Zielrolle                     | Demo-Story, Artefaktbedarf und Nicht-Claims klaeren                  | Keine Landingpage- oder Sales-Aussage als send-ready markieren |
+| `demoReadiness = blocked-unverified`, fehlende OpenAPI-Belege, R3-Signal, TWL/private/sensitive Herkunft | Rhajaina blockt oder schliesst als interne Beobachtung     | keiner ohne sanitized Signal                             | Niedrig bis Stop                                                        | Nur sanitized Steering-Signal, Quellenklaerung oder bewusste Schliessung  | Kein Export in Webmaster/Felix-Kontext mit Rohdetails                |
+
+## 3. Prioritaetssignale
+
+Prioritaet wird aus Nutzensignal, Belegbarkeit und Risiko gebildet; sie ist keine Freigabe.
+
+| Signal               | Hoch                                                                      | Mittel                                                    | Niedrig / Parken                                                  |
+| -------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------- |
+| Belegbarkeit         | CHANGELOG plus OpenAPI-Endpunkt oder Demo-Artefakt                        | CHANGELOG oder Service-Anker, aber kein stabiler Endpoint | nur Idee, Marktimpuls oder unklare Herkunft                       |
+| Oeffentlicher Nutzen | klarer B2B-, Developer- oder Governance-Suchintent                        | Nutzen erklaerbar, aber Zielseite/Zielrolle offen         | Nutzen nur mit internen Details erklaerbar                        |
+| Demo-Reife           | `demo-ready` oder `needs-demo-copy-review` mit No-Call-/Read-only-Grenzen | `api-visible-needs-demo-story` oder `concept-only`        | `blocked-unverified`                                              |
+| Claim-Risiko         | R0/R1, keine kommerziellen/regulatorischen Zusagen                        | R1/R2 mit klaren Review-Fragen                            | R3 oder ungerahmte Garantie-/Preis-/Vertrags-/Kundendatenbegriffe |
+| Timing               | aktueller Release-, Changelog- oder Kampagnenbezug                        | Roadmap-/Doku-Bezug                                       | kein Anlass oder bewusstes Beobachtungsthema                      |
+
+Empfohlene Prioritaetslabels fuer Aufgabenentwuerfe:
+
+- `P1-review-now`: Starker Beleg, oeffentlicher Nutzen, naechster Schritt ist nur Review/Draft; keine externe Aktion.
+- `P2-draft-when-capacity`: Solider Kandidat, aber Story/Zielseite oder Demo-Raum braucht Ausarbeitung.
+- `P3-watchlist`: Interessant, aber kein public-safe Draft moeglich.
+- `STOP-sensitive-or-actioning`: Nicht weiter routen, bis Rhajaina/HITL sanitized Kontext oder Schliessung bestaetigt.
+
+## 4. HITL-Entscheidungspunkte
+
+Ein Aufgabenentwurf muss als HITL- oder Review-Punkt sichtbar werden, wenn mindestens eine Bedingung zutrifft:
+
+- externer Versand, LinkedIn/Post, Mailing, Kundenansprache oder Follow-up-Mail waere der naechste Schritt;
+- Website-PR, CMS-Publish, GitHub-Issue/PR-Publishing, Deployment oder produktiver Restart waere noetig;
+- Preis-, Tarif-, Vertrags-, Angebots-, Rechts-, Abrechnungs-, Settlement-, Genehmigungs-, Garantie- oder Einsparungsclaim erscheint;
+- echte Kunden-/Partner-/Personenreferenz, privater Mailinhalt oder vertrauliche Herkunft ist beteiligt;
+- TWL-Rohkontext oder gemischte sensitive Herkunft ist moeglich;
+- Felix soll eine Zusage, ein Angebot oder eine konkrete Kontaktaufnahme vorbereiten, die ueber einen internen Entwurf hinausgeht;
+- Webmaster koennte aus dem Draft direkt live publizieren, statt nur einen Review-/PR-Entwurf zu erzeugen.
+
+HITL-Formulierung im Aufgabenentwurf:
+
+```json
+{
+  "hitlRequired": true,
+  "hitlReason": "Publish-/Sending-/Claim-Gate: externer Einsatz erst nach Freigabe",
+  "allowedAutonomousWork": ["interner Draft", "Quellenanker pruefen", "Review-Fragen formulieren"],
+  "forbiddenUntilApproved": ["Senden", "Publish", "PR erstellen", "Preis-/Vertragszusage"]
+}
+```
+
+## 5. Mindestinformationen pro Aufgabenentwurf
+
+Jeder aus einem Kandidaten erzeugte Folgeimpuls soll mindestens diese Felder enthalten:
+
+```json
+{
+  "topicKey": "#CETPublicWebsiteBacklog/#CapabilitySlug",
+  "candidateId": "<release>:<slug>",
+  "sourceEvidence": [
+    { "source": "CHANGELOG.md", "locator": "...", "excerpt": "..." },
+    { "source": "openapi-export.json", "locator": "...", "excerpt": "..." }
+  ],
+  "routingOwner": "Rhajaina | Webmaster | Felix",
+  "routingReason": "Warum dieser Owner und kein anderer",
+  "prioritySignal": "P1-review-now | P2-draft-when-capacity | P3-watchlist | STOP-sensitive-or-actioning",
+  "targetAudience": "Stadtwerk/VNB/Developer/Kommunale Entscheider/interne Review-Rolle",
+  "targetSurface": "cernion.de/... | corrently.io/... | stromdao.de/... | interner Draft | kein Public Surface",
+  "demoReadiness": "demo-ready | needs-demo-copy-review | api-visible-needs-demo-story | concept-only | blocked-unverified",
+  "claimRisk": "low | medium | high plus kurze Begruendung",
+  "allowedClaims": ["konservative, belegbare Formulierungen"],
+  "forbiddenClaims": [
+    "Garantie",
+    "Preis",
+    "Vertrag",
+    "Abrechnung",
+    "Genehmigung",
+    "Kundenerfolg ohne Freigabe"
+  ],
+  "nextSafeStep": "konkreter interner Draft-/Review-/Klaerungsschritt",
+  "hitlRequired": true,
+  "stopRules": ["kein Senden", "kein Publish", "kein PR/GitHub-Write", "kein Deployment"]
+}
+```
+
+## 6. Beispielaufgaben
+
+### Beispiel A: OpenAPI-sichtbarer Website-Draft
+
+Ausgangskandidat:
+
+- `recommendedFollowUpAgent`: `webmaster`
+- `websiteTargetPage`: `cernion.de/energy-market-api`
+- `demoReadiness`: `api-visible-needs-demo-story`
+- `claimRisk`: `medium`
+- Beleg: CHANGELOG plus `POST /api/energy-market/portfolio-backtest`
+
+Aufgabenentwurf:
+
+```json
+{
+  "title": "[REQUEST][CET][Website] Portfolio-Backtest als cernion.de-Draft pruefen",
+  "routingOwner": "Webmaster",
+  "routingReason": "Starker API-Anker und Website-Zielseite; Aufgabe ist ein konservativer SEO-/FAQ-/Capability-Draft, kein Sales-Versand.",
+  "prioritySignal": "P1-review-now",
+  "nextSafeStep": "Draft mit Endpoint-Deeplink, Annahmen, Datenqualitaetsgrenzen und No-Garantie-Hinweis vorbereiten.",
+  "hitlRequired": true,
+  "stopRules": ["kein PR", "kein Publish", "kein Deployment", "keine Erlos- oder Einspargarantie"]
+}
+```
+
+### Beispiel B: B2B-Demo-/Sales-Follow-up ohne Versand
+
+Ausgangskandidat:
+
+- `recommendedFollowUpAgent`: `felix-demo-sales`
+- Zielrolle: Stadtwerk-Produktmanager oder VNB-Netzplanung
+- `demoReadiness`: `demo-ready` oder `concept-only` mit klaren No-Call-Grenzen
+- `claimRisk`: `low|medium`
+
+Aufgabenentwurf:
+
+```json
+{
+  "title": "[REQUEST][CET][Felix] Demo-Narrativ fuer read-only VDMI-Pruefpfad vorbereiten",
+  "routingOwner": "Felix",
+  "routingReason": "Hauptarbeit ist B2B-Erzaehlung und Zielsegment-Fit; Website-Aenderung ist spaeterer Review-Schritt.",
+  "prioritySignal": "P2-draft-when-capacity",
+  "nextSafeStep": "Interne Demo-Talking-Points und Follow-up-Mailentwurf mit klaren No-Call-/No-Approval-Grenzen vorbereiten.",
+  "hitlRequired": true,
+  "stopRules": [
+    "kein Versand",
+    "keine Preis-/Vertragszusage",
+    "keine Anschluss-/Kapazitaetszusage",
+    "kein CRM-Eintrag ohne Quelle"
+  ]
+}
+```
+
+### Beispiel C: Claim-Risiko / Rhajaina Review
+
+Ausgangskandidat:
+
+- `recommendedFollowUpAgent`: `rhajaina-claim-review`
+- `claimRisk`: `high`
+- Begriffe: Abrechnung, Settlement, Genehmigung, Garantie, Steuerung oder echte Kundendaten
+
+Aufgabenentwurf:
+
+```json
+{
+  "title": "[HITL][CET][Claim-Review] Billing-/Settlement-Kandidat vor Public-Routing pruefen",
+  "routingOwner": "Rhajaina",
+  "routingReason": "Externer Nutzen ist moeglich, aber R2/R3-Claim-Risiko verhindert direkte Webmaster-/Felix-Folge.",
+  "prioritySignal": "STOP-sensitive-or-actioning",
+  "nextSafeStep": "Erlaubte Nicht-Zusagen, fachliche Owner und ggf. sanitized Steering-Signal klaeren; danach neu routen oder schliessen.",
+  "hitlRequired": true,
+  "stopRules": [
+    "kein Webmaster-Draft",
+    "kein Felix-Outreach",
+    "kein Publish",
+    "kein GitHub-Issue/PR"
+  ]
+}
+```
+
+### Beispiel D: Developer-/LLM-Discoverability
+
+Ausgangskandidat:
+
+- stabiler OpenAPI-Pfad, aber wenig B2B-Story
+- Zielseite eher `corrently.io` oder Repository-Doku
+- `claimRisk`: `low`
+
+Aufgabenentwurf:
+
+```json
+{
+  "title": "[REQUEST][CET][Docs] OpenAPI-Rezept fuer public discovery vorbereiten",
+  "routingOwner": "Webmaster",
+  "routingReason": "Webmaster steuert oeffentliche Sichtbarkeit; technische Detailklaerung kann als DevOps-Doku-Folge vorbereitet werden.",
+  "prioritySignal": "P2-draft-when-capacity",
+  "nextSafeStep": "curl/Auth/Response-Beispiel und LLM-freundliche Kurzbeschreibung als Review-Draft formulieren.",
+  "hitlRequired": true,
+  "stopRules": ["kein GitHub-Issue/PR ohne Freigabe", "kein Publish", "keine Vertriebsclaims"]
+}
+```
+
+## 7. Stop-Regeln fuer PR, Publish und Sending
+
+Diese Routing-Spezifikation autorisiert niemals:
+
+- externe E-Mail, LinkedIn-, Pubbler-, Blog-, Website- oder Kundenkommunikation zu senden;
+- GitHub-Issues, PRs, Releases oder Labels zu erstellen oder zu veroeffentlichen;
+- CMS-, Website-, BookStack-, stromdao.de-, cernion.de-, corrently.io- oder corrently.energy-Aenderungen live zu publizieren;
+- produktive Deployments, Restarts, PM2/Systemd/Docker-Aktionen oder Serveraenderungen auszufuehren;
+- Preise, Angebote, Vertraege, Termine, Rechts-/Regulierungswirkung, Abrechnungsergebnisse, Einsparungen oder Garantien zuzusagen;
+- TWL-Rohkontext, Kundendaten, private Mailinhalte oder vertrauliche Entscheidungsstaende in Webmaster-/Felix-Kontexte zu exportieren.
+
+Erlaubt sind nur interne Entwuerfe, Review-Fragen, Quellenverweise, Kanban-Aufgabenentwuerfe und explizit als Draft markierte Handoffs.
+
+## 8. Sichere Default-Entscheidung
+
+Wenn die Route nicht eindeutig ist:
+
+1. Rhajaina als Triage-/Claim-Review-Owner setzen.
+2. `prioritySignal = P3-watchlist` oder `STOP-sensitive-or-actioning` waehlen.
+3. Mindestinformationen und fehlende Belege benennen.
+4. Webmaster/Felix erst nach public-safe Quellen- und Claim-Klaerung einbeziehen.
+5. Naechsten Schritt als Review, Draft oder Blocker formulieren, nie als externe Aktion.

--- a/docs/PUBLIC_WEBSITE_BACKLOG_E2E_REPORT_CONCEPT.md
+++ b/docs/PUBLIC_WEBSITE_BACKLOG_E2E_REPORT_CONCEPT.md
@@ -1,0 +1,198 @@
+# CET Public-Website-Backlog: End-to-End-Report-Konzept
+
+Status: interner Konzept-/README-Entwurf. Dieses Dokument fuehrt Kandidatenschema, Bewertungsrubrik, Release-Signal-Extractor und Agent-Routing zu einem pruefbaren Report-Ablauf zusammen. Es autorisiert keine externen Writes.
+
+## Ziel
+
+Aus einem CET-Release sollen read-only Backlog-Kandidaten entstehen, die Menschen schnell pruefen koennen:
+
+1. Welche Capability ist im Release sichtbar geworden?
+2. Welcher technische Anker belegt sie im CHANGELOG und/oder OpenAPI?
+3. Fuer welche Zielrolle und Zielseite ist eine public-safe Erklaerung denkbar?
+4. Wie reif ist eine Demo-/Website-Erzaehlung?
+5. Welche Claim-Grenze verhindert Marketing-, Regulierungs- oder Betriebsueberdehnung?
+6. Welcher Folge-Agent kann intern einen Draft, eine Review-Frage oder eine Klaerung vorbereiten?
+
+## Bausteine
+
+| Baustein                 | Datei / Quelle                                                           | Rolle im Ablauf                                                                                                                                                                |
+| ------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Kandidatenschema         | `docs/public-website-backlog-candidate-schema.md`                        | Definiert Pflichtfelder, Enums, Nachweisregeln und Validator-Kontrakt fuer maschinenlesbare Kandidaten.                                                                        |
+| Bewertungsrubrik         | `docs/PUBLIC_WEBSITE_BACKLOG_RUBRIC.md`                                  | Bewertet Domain-Routing, Demo-Reife D0-D4, Claim-Risiko R0-R3, SEO-/LLM-Discoverability und sichere Handoff-Regeln.                                                            |
+| Release-Signal-Extractor | `scripts/extract-release-signals.js`, `docs/release-signal-extractor.md` | Liest CHANGELOG/OpenAPI read-only und erzeugt neutrale Rohsignale ohne GitHub-, Website-, Kanban- oder Deploy-Writes.                                                          |
+| Backlog-Generator        | `scripts/generate-public-website-backlog.js`                             | Verdichtet Release-Eintraege und OpenAPI-Operationen zu Kandidaten mit Endpoint/Service, Zielrolle, Website-Zielseite, Demo-Reife, Claim-Risiko, Folge-Agent und Kanalpaketen. |
+| Agent-Routing            | `docs/PUBLIC_WEBSITE_BACKLOG_AGENT_ROUTING.md`                           | Uebersetzt Kandidaten in interne Rhajaina-/Webmaster-/Felix-/DevOps-Review-Impulse und Stop-Regeln.                                                                            |
+
+## Geplanter Ablauf
+
+### 1. Release-Quellen fixieren
+
+Input:
+
+- `CHANGELOG.md` aus dem CET-Release oder Release-Kandidaten.
+- `openapi-export.json` oder ein lokal gespeichertes `/api/openapi.json` aus derselben Release-Basis.
+- Optional: `llm.txt`, README-Abschnitte, Issue-/PR-Nummern nur als Beleganker, nicht als Write-Ziel.
+
+Vorbedingung: Quellen sind public-safe oder intern bereits fuer DevOps/CET sanitized. TWL-Rohkontext, Kundendaten, private Mails oder gemischt-sensitive Signale duerfen nicht in diesen Ablauf.
+
+### 2. Rohsignale extrahieren
+
+Befehl:
+
+```bash
+node scripts/extract-release-signals.js --changelog=CHANGELOG.md --openapi=openapi-export.json --format=json --limit=50
+```
+
+Ergebnis: `cernion.releaseSignals.v1` mit OpenAPI-Metadaten, Endpoint-Signalen, Service-Clustern und Changelog-Hinweisen. Dieser Schritt dient nur der technischen Orientierung und schreibt nichts.
+
+### 3. Kandidaten erzeugen
+
+Befehl:
+
+```bash
+node scripts/generate-public-website-backlog.js --changelog=CHANGELOG.md --openapi=openapi-export.json --limit=30
+node scripts/generate-public-website-backlog.js --changelog=CHANGELOG.md --openapi=openapi-export.json --limit=30 --json
+```
+
+Jeder Kandidat enthaelt mindestens:
+
+- Capability,
+- Endpoint/Service,
+- Zielrolle,
+- Website-Zielseite,
+- Demo-Reife,
+- Claim-Risiko,
+- Folge-Agent,
+- Kanalpakete und Folgehinweis.
+
+### 4. Rubrik anwenden
+
+Der Generator liefert eine erste maschinelle Einordnung. Menschliche Pruefung nutzt danach die Rubrik:
+
+- Domain-Fit: `cernion.de`, `corrently.io`, `stromdao.de`, `corrently.energy` oder kein Public Surface.
+- Demo-Reife: D0-D4. D4 bleibt ein Freigabekandidat, kein Publish.
+- Claim-Risiko: R0-R3. R2/R3 braucht Rhajaina/Fachowner/HITL oder Schliessung.
+- SEO/LLM: Entitaeten, Suchintent, Endpoint-/Doku-Deeplinks, klare Grenzen.
+
+### 5. Routing in interne Folgeimpulse
+
+Empfohlene Routing-Interpretation:
+
+| `recommendedFollowUpAgent` | Bedeutung                                                                                       | Erlaubter naechster Schritt                                            |
+| -------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `webmaster`                | Website-/FAQ-/SEO-/Doku-Draft ist plausibel und claim-sicher genug fuer einen internen Entwurf. | Interne Webmaster-REQUEST auf `public-web-presence`; kein PR/Publish.  |
+| `felix-demo-sales`         | B2B-Demo-Narrativ oder Zielsegment-Fit ist die Hauptarbeit.                                     | Interne Felix-REQUEST fuer Demo-/Talking-Point-Draft; kein Versand.    |
+| `rhajaina-claim-review`    | Claim-, Herkunfts- oder Freigabegrenze ist unklar/hoch.                                         | Review-Fragen, erlaubte Nicht-Zusagen, ggf. HITL-Blocker.              |
+| `devops-api-check`         | Developer-/OpenAPI-/corrently.io-Discoverability braucht technische Doku-Klaerung.              | Doku-/Beispiel-/Endpoint-Pruefung; kein GitHub-Issue/PR ohne Freigabe. |
+
+## Minimaler Akzeptanztest
+
+Automatisiert in `tests/generate-public-website-backlog.test.js`:
+
+- Gegeben ist ein Beispiel-Changelog mit zwei Added-Eintraegen.
+- Gegeben ist ein Beispiel-OpenAPI-Dokument mit zwei passenden Pfaden.
+- Erwartet werden mindestens zwei Kandidaten.
+- Jeder relevante Kandidat muss Capability, Endpoint/Service, Zielrolle, Website-Zielseite, Demo-Reife, Claim-Risiko und Folge-Agent enthalten.
+- Der Markdown-Report muss die Spalte `Folge-Agent` ausgeben.
+
+Fokussierter Testlauf:
+
+```bash
+npx jest tests/generate-public-website-backlog.test.js --runInBand --forceExit
+```
+
+## Beispielinput
+
+### Beispiel-CHANGELOG
+
+```md
+# Changelog
+
+## [0.68.0] — 2026-07-22
+
+### Added
+
+- **Municipal Energy Value Lagebild Endpoint** (#501): New endpoint `GET /api/dashboard/municipal-energy-value-analysis` exposes read-only dashboard rows with SLP proxy evidence and no billing relevance.
+- **Historical portfolio market value backtest** (#502): New endpoint `POST /api/energy-market/portfolio-backtest` provides demo-ready read-only market value backtests with no-call guardrails.
+```
+
+### Beispiel-openapi.json (gekuerzt)
+
+```json
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Cernion Energy Tools API", "version": "0.68.0" },
+  "paths": {
+    "/api/dashboard/municipal-energy-value-analysis": {
+      "get": {
+        "operationId": "dashboard_municipalEnergyValueAnalysisStatus",
+        "summary": "Municipal Energy Value Lagebild Endpoint",
+        "description": "Read-only municipal energy value analysis with SLP proxy evidence.",
+        "tags": ["Dashboard API"],
+        "x-ui-page": "dashboard"
+      }
+    },
+    "/api/energy-market/portfolio-backtest": {
+      "post": {
+        "operationId": "energy-market_portfolioBacktest",
+        "summary": "Historical portfolio market value backtest",
+        "description": "Read-only market value backtest for demo portfolios.",
+        "tags": ["Energy Market"],
+        "x-ui-page": "energy-market"
+      }
+    }
+  }
+}
+```
+
+## Beispielreport
+
+Erzeugt mit:
+
+```bash
+node scripts/generate-public-website-backlog.js --changelog=/tmp/cet-e2e-report-changelog.md --openapi=/tmp/cet-e2e-report-openapi.json --limit=10
+```
+
+```md
+# CET Public Website Backlog Candidates
+
+Read-only Ableitung aus CHANGELOG.md und openapi-export.json. Kein GitHub-/Website-/Kanban-Write.
+
+- generatedAt: 2026-07-22T23:34:24.070Z
+- candidateCount: 2
+
+| Capability                                 | Endpoint/Service                                   | Zielrolle | Website-Zielseite                 | Demo-Reife | Claim-Risiko                        | Folge-Agent      | Kanalpakete                                                                                                                                                                                                                                                                                     | Folgehinweis                                                                                                                                |
+| ------------------------------------------ | -------------------------------------------------- | --------- | --------------------------------- | ---------- | ----------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| municipal-energy-value-lagebild-endpoint   | GET /api/dashboard/municipal-energy-value-analysis | Felix     | cernion.de/kommunale-energiedaten | demo-ready | low (read-only, evidence)           | felix-demo-sales | Webmaster: send-ready-draft via cernion.de/corrently.io/stromdao.de<br>Rhajaina: review-package via Claim-Governance/Freigabe-/Nachweisprüfung<br>Felix: send-ready-draft via LinkedIn/Pubbler/B2B-E-Mail-Kontakte<br>Viki: send-ready-draft via Viki-Markt-Scouting/LinkedIn-Signalbeobachtung | Added-Release-Kandidat: Endpoint-Bezug prüfen: GET /api/dashboard/municipal-energy-value-analysis. Claim als read-only/guarded formulieren. |
+| historical-portfolio-market-value-backtest | POST /api/energy-market/portfolio-backtest         | Felix     | cernion.de/energy-market-api      | demo-ready | low (read-only, no-call, guardrail) | felix-demo-sales | Webmaster: send-ready-draft via cernion.de/corrently.io/stromdao.de<br>Rhajaina: review-package via Claim-Governance/Freigabe-/Nachweisprüfung<br>Felix: send-ready-draft via LinkedIn/Pubbler/B2B-E-Mail-Kontakte<br>Viki: send-ready-draft via Viki-Markt-Scouting/LinkedIn-Signalbeobachtung | Added-Release-Kandidat: Endpoint-Bezug prüfen: POST /api/energy-market/portfolio-backtest. Claim als read-only/guarded formulieren.         |
+```
+
+Interpretation: Die beiden Beispielkandidaten sind review-faehige interne Draft-Impulse. `send-ready-draft` in Kanalpaketen bedeutet nur, dass ein interner Entwurf formuliert werden kann; es ist keine Versand- oder Publish-Freigabe.
+
+## Bekannte Grenzen
+
+- Heuristische Zuordnung: Keywords und OpenAPI-Matching koennen Zielrolle, Zielseite oder Follow-up-Agent falsch priorisieren.
+- CHANGELOG-Qualitaet bestimmt die Signalqualitaet; zu knappe Eintraege erzeugen schwache Kandidaten.
+- OpenAPI-only Operations ohne Changelog-Bezug koennen technisch sichtbar sein, sind aber nicht automatisch release-relevant.
+- Claim-Risiko erkennt Triggerwoerter, ersetzt aber keine fachliche/regulatorische Pruefung.
+- Demo-Reife basiert auf Textsignalen wie `read-only`, `demo`, `no-call`, `guardrail`; echte Demo-UX, Screenshots oder Tenant-Zustaende werden nicht geprueft.
+- Der Ablauf prueft keine Website-Bestaende live und entscheidet nicht, ob eine Zielseite tatsaechlich existiert.
+- Viki-/Felix-/Webmaster-Kanalpakete sind Entwurfsformen; echte externe Kommunikation braucht separate Freigabe.
+
+## Explizite Nicht-Ziele
+
+- Keine automatischen GitHub-Issue-, Label-, Branch-, PR- oder Release-Writes.
+- Keine Website-, CMS-, BookStack-, stromdao.de-, cernion.de-, corrently.io- oder corrently.energy-Writes.
+- Keine Deployments, Restarts, PM2/Systemd/Docker-Aktionen oder Serveraenderungen.
+- Keine externen E-Mails, LinkedIn-/Pubbler-Posts, Kundenansprachen oder CRM-Fakten ohne Quelle.
+- Keine Uebernahme von TWL-Rohkontext, Kundendaten, privaten Mails oder gemischt-sensitiver Herkunft.
+- Keine fachliche Garantie zu Preisen, Einsparungen, Abrechnung, Settlement, Genehmigung, Vertrag oder Rechtswirkung.
+
+## Sichere naechste Nutzung
+
+1. Release-Signale read-only extrahieren.
+2. Kandidatenbericht erzeugen.
+3. Menschlich gegen Rubrik und Routing-Spezifikation pruefen.
+4. Falls public-web-wertvoll: interne REQUEST an `webmaster` auf `public-web-presence` formulieren.
+5. Falls Claim- oder Herkunftsrisiko: Rhajaina-/HITL-Review statt Public-Web-Folge.
+6. Erst nach expliziter Freigabe PR/Publish/Send/Deploy als separate Aufgabe behandeln.

--- a/docs/PUBLIC_WEBSITE_BACKLOG_RUBRIC.md
+++ b/docs/PUBLIC_WEBSITE_BACKLOG_RUBRIC.md
@@ -1,0 +1,230 @@
+# CET Public Website Backlog Rubrik
+
+Diese Rubrik beschreibt, wie aus einer neuen Cernion Energy Tools (CET) Capability eine oeffentlichkeitsfaehige Website-Backlog-Idee abgeleitet wird. Sie ist ein internes Bewertungs- und Handoff-Schema fuer Webmaster, Felix, Viki, DevOps und Rhajaina. Sie veroeffentlicht nichts selbst.
+
+Jede abgeleitete Idee bleibt ein Draft, bis ein separater HITL-, PR- oder Publish-Schritt sie freigibt. Website-Aenderungen, externe Claims, Preis-/Tarif-/Vertragsaussagen, regulatorische Aussagen, GitHub-Write und Deployments sind nicht durch diese Rubrik freigegeben.
+
+## 1. Eingangssignal
+
+Zulaessige Quellen fuer eine Rubrik-Bewertung:
+
+- CHANGELOG-Eintrag, Release-Note oder GitHub-Issue zu einer CET Capability.
+- `openapi-export.json`, Swagger/OpenAPI-Pfad, `llm.txt` oder Doku-Anker, der die Capability belegbar macht.
+- Freigegebene interne Steering-Signale aus Vertrieb, DevOps, Monitoring, Marktbeobachtung oder Rhajaina-Triage.
+- Plaud-/Transkript-derived Inhalte nur, wenn sie explizit als `STROMDAO_INTERNAL_FANOUT` oder als sanitized Folgekarte freigegeben sind.
+
+Nicht zulaessig fuer oeffentliche Ableitung:
+
+- TWL-Rohkontext, private Mails, Personen-/Kundendaten oder nicht freigegebene Transkripte.
+- Spekulative Preis-, Tarif-, Vertrags-, Rechts- oder Lieferzusagen.
+- Kundenreferenzen, Projektstatus oder Betriebsergebnisse ohne explizite Freigabe.
+
+## 2. Entscheidungsfolge
+
+Jede Capability wird in dieser Reihenfolge bewertet:
+
+1. Belegbarkeit: Gibt es einen stabilen technischen Anker?
+   - stark: OpenAPI-Endpunkt, dokumentierte Action, CHANGELOG + Tests, Demo-Artefakt.
+   - mittel: Issue/ADR/Plan mit klarer Service-Zuordnung.
+   - schwach: nur interne Beobachtung, Brainstorming oder Marktimpuls.
+2. Oeffentliche Relevanz: Ist der Nutzen fuer Stadtwerke, Netzbetreiber, Entwickler oder OSS-Interessenten erklaerbar, ohne interne Details offenzulegen?
+3. Ziel-Domain: Welche Seite ist fachlich passend?
+4. Demo-Reife: Darf daraus eine Demo-/Landingpage-Idee werden oder nur ein interner Draft?
+5. Claim-Risiko: Welche Aussagen sind erlaubt, welche brauchen Rhajaina/HITL?
+6. Handoff: Webmaster-Aufgabe, Felix-Vertriebsaufgabe, DevOps-/Doku-Folge oder nur Beobachtung.
+
+Ein Kandidat wird nur dann Website-Backlog, wenn Belegbarkeit mindestens mittel ist und ein sicherer, oeffentlicher Nutzen-Satz formuliert werden kann.
+
+## 3. Domain-Routing
+
+| Ziel               | Wann passend                                                                                                                              | Fachlicher Owner                                                                 | Typische Formate                                                        | Nicht verwenden fuer                                                              |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `cernion.de`       | B2B-Nutzen fuer Stadtwerke, Netzbetreiber, Regulated-Energy-Prozesse, Capability-/Use-Case-Kommunikation                                  | Felix fachlich; Webmaster fuer Struktur, SEO und Publish-Draft                   | Capability-Teaser, Fachreport, Timeline-Artikel, Demo-Landingpage, FAQ  | OSS-Developer-Howto ohne Produktnutzen; B2C-Tarife; unsichere Claims              |
+| `corrently.io`     | Entwickler-/OSS-/API-Dokumentation, Tooling, OpenAPI-/SDK-/Integrationserklaerung                                                         | DevOps/Produkt fachlich; Webmaster koordiniert Doku-Sichtbarkeit                 | API-Rezept, README-Verweis, LLM-/Developer-Discovery, Changelog-Hinweis | Vertriebsclaims, Preise, kundenspezifische Nutzenversprechen                      |
+| `stromdao.de`      | neutrale STROMDAO-Publishing-Perspektive, Methodik, Open-Source-/Energy-Data-Referenz, akademisch/verbandlich anschlussfaehige Erklaerung | STROMDAO-Publishing/Thorsten fachlich; Webmaster nutzt `stromdao-web-publishing` | Referenz-/Methodikseite, Hintergrundartikel, Projektlandkarte           | Cernion-Verkaufsseite, Produktversprechen, nicht neutralisierte Herkunftskontexte |
+| `corrently.energy` | nur wenn B2C-/Tarifkommunikation, Haushaltskundennutzen oder Corrently-Produkterlebnis betroffen ist                                      | Cori fachlich; Webmaster fuer FAQ/CTA/SEO                                        | FAQ, Tarif-/Produkttext, B2C-CTA                                        | CET-B2B-Capabilities ohne B2C-Bezug                                               |
+
+Default fuer neue CET-Capabilities ist `cernion.de`, sofern kein klarer Developer-/OSS-Fokus (`corrently.io`) oder neutraler STROMDAO-Methodikfokus (`stromdao.de`) vorliegt.
+
+## 4. Demo-Reife-Stufen
+
+| Stufe | Label                          | Kriterien                                                                                     | Erlaubter Output                                     | Nicht erlaubt                                                   |
+| ----- | ------------------------------ | --------------------------------------------------------------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------- |
+| D0    | `internal-observation`         | Kein stabiler Endpoint, unklare Zielgruppe, interne oder sensitive Herkunft                   | interne Notiz, Markt-/Roadmap-Beobachtung            | Website-Backlog, externer Teaser                                |
+| D1    | `api-visible-needs-story`      | OpenAPI-/Service-Anker vorhanden, aber noch keine Demo-Story oder sichere Nutzenformulierung  | Webmaster-Draft, Doku-Frage, DevOps-Doku-Folge       | Landingpage-Publish, Sales-Claim                                |
+| D2    | `needs-demo-copy-review`       | Endpoint plus Guardrails/Read-only oder Demo-Signal vorhanden, aber Claim-Grenzen noch offen  | Copy-Draft, FAQ-Entwurf, Rhajaina-Review-Paket       | externe Versandbereitschaft                                     |
+| D3    | `demo-ready`                   | Read-only oder synthetische Demo, reproduzierbarer Ablauf, klare No-Call-/No-Mutation-Grenzen | Demo-Teaser, Landingpage-Backlog, Felix-Demo-Snippet | Produktivitaets-, Einspar-, Preis- oder Rechtsclaim ohne Review |
+| D4    | `publish-candidate-after-hitl` | D3 plus fachliche Freigabe, PR-/Publish-Pfad, Review der Claims und Zielseite                 | PR/Pub-Freigabevorlage, geplanter Publish-Schritt    | automatisches Deployment durch die Rubrik                       |
+
+D4 ist kein automatischer Publish. Es bedeutet nur: Der naechste sichere Schritt ist eine explizite Freigabe- oder PR-Entscheidung.
+
+## 5. Claim-Risiko-Stufen
+
+| Stufe | Label                            | Kriterien                                                                                                                               | Sichere Formulierung                                                 | Gate                                                  |
+| ----- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------- |
+| R0    | `low-descriptive`                | Read-only, synthetische Demo, Nachweis-/Evidenzsicht, keine operative Zusage                                                            | "CET stellt eine pruefbare Read-only-Sicht auf ... bereit."          | Webmaster kann Draft vorbereiten; Publish bleibt HITL |
+| R1    | `medium-operational`             | Workflow-, Prozess-, Integrations- oder Automatisierungsnutzen, aber ohne Preise/Regulatorik/Mutation                                   | "unterstuetzt die Einordnung", "macht Pruefschritte nachvollziehbar" | Copy-Review + Owner-Freigabe vor externem Einsatz     |
+| R2    | `high-regulatory-commercial`     | Aussagen zu Abrechnung, Settlement, Tarifen, regulatorischer Konformitaet, Genehmigung, Vertrag, Einsparung oder kommerziellem Ergebnis | nur als Frage/Pruefauftrag formulieren, keine Ergebniszusage         | Rhajaina/Fachowner/HITL erforderlich                  |
+| R3    | `blocked-sensitive-or-actioning` | Produktion-Mutation, Device-Control, MaKo/CRM/Billing-Schreibpfad, automatische Entscheidung, Kundendaten, TWL-Rohkontext               | keine oeffentliche Formulierung aus dieser Quelle                    | blockieren oder sanitized Steering-Signal anfordern   |
+
+Triggerwoerter fuer R2/R3: Garantie, garantiert, Einsparung, Preis, Tarif, Vertrag, Abrechnung, Settlement, Genehmigung, Ablehnung, steuernd, schaltet, produktiv schreibt, Kunde X, vertraulich, TWL.
+
+## 6. SEO- und LLM-Discoverability-Regeln
+
+Jeder Website-Backlog-Kandidat sollte maschinenlesbar und suchfaehig genug sein, ohne Marketing zu ueberziehen:
+
+- Entitaeten nennen: `Cernion Energy Tools`, Stadtwerk, Netzbetreiber, Energie-Datenprozess, konkreter Service/Endpoint, relevante Norm-/Prozessbegriffe nur wenn belegbar.
+- Einen stabilen technischen Anker setzen: OpenAPI-Pfad, `operationId`, README/Doku-Link oder Changelog-Issue.
+- Einen klaren Suchintent bedienen: "Wie prueft ein Stadtwerk ...?", "Welche API liefert ...?", "Wie kann ein Netzbetreiber ... nachvollziehen?".
+- LLM-freundliche Struktur: Kurzfassung, Gegenstand, Daten-/Prozessmodell, Pruefregeln, Grenzen, Nachweise, naechster Schritt.
+- Keine erfundenen Quellen, Kundenzitate, Benchmarks oder Superlative.
+- Claims als bounded capability formulieren: "unterstuetzt", "macht sichtbar", "stellt bereit", "ordnet ein" statt "loest", "garantiert", "automatisiert rechtskonform".
+
+## 7. Handoff-Regeln
+
+### Webmaster-Aufgabe
+
+Ein Punkt ist Webmaster-Aufgabe, wenn:
+
+- eine Zielseite, FAQ, Doku-Struktur, SEO-/LLM-Discoverability oder ein Changelog-/Timeline-Draft benoetigt wird;
+- die oeffentliche Formulierung konservativ, belegbar und ohne R2/R3-Claim moeglich ist;
+- ein HITL-/PR-/Publish-Schritt als naechster sicherer Schritt formuliert werden kann.
+
+Beispiel-Handoff:
+
+```json
+{
+  "owner": "Webmaster",
+  "domain": "cernion.de",
+  "targetPage": "cernion.de/energy-market-api",
+  "change": "Capability-Teaser mit OpenAPI-Deeplink und Read-only-Grenze vorbereiten",
+  "whyNow": "CHANGELOG + OpenAPI-Endpunkt machen den Nutzen belegbar",
+  "demoReadiness": "needs-demo-copy-review",
+  "claimRisk": "R1 medium-operational",
+  "nextSafeStep": "Draft erstellen, dann Felix/Rhajaina-Freigabe vor PR/Publish"
+}
+```
+
+### Felix-Vertriebsaufgabe
+
+Ein Punkt ist eher Felix-Aufgabe, wenn:
+
+- der Hauptnutzen in B2B-Kontakt, Demo-Erzaehlung, Zielkunden-Segmentierung oder Angebotspositionierung liegt;
+- noch keine Zielseite geaendert werden muss, aber ein Sales-Snippet, Demo-Guide oder Ansprechpartner-Text noetig ist;
+- kommerzielle Aussagen, Referenzen oder Nutzenversprechen fachlich eingeordnet werden muessen.
+
+Beispiel-Handoff:
+
+```json
+{
+  "owner": "Felix",
+  "domain": "cernion.de",
+  "change": "Demo-Narrativ fuer Stadtwerke ausarbeiten; keine Website-Aenderung vor Freigabe",
+  "whyNow": "Capability ist demo-ready, aber Zielsegment und Nutzenversprechen brauchen B2B-Einordnung",
+  "demoReadiness": "demo-ready",
+  "claimRisk": "R1 medium-operational",
+  "nextSafeStep": "Felix formuliert Demo-/Kontaktpaket; Webmaster prueft danach Landingpage-Fit"
+}
+```
+
+### DevOps-/Doku-Folge
+
+Ein Punkt ist eher DevOps-/Doku-Folge, wenn:
+
+- die API oeffentlich erklaert werden sollte, aber noch Beispiele, Auth-Hinweise, OpenAPI-Korrekturen oder SDK-/curl-Rezepte fehlen;
+- `corrently.io` oder Repository-Doku die passendere erste Flaeche ist;
+- technische Stabilitaet, Versionierung oder Endpoint-Beleg erst ergaenzt werden muss.
+
+### Nur interne Beobachtung
+
+Ein Punkt bleibt intern, wenn:
+
+- Herkunft oder Kontext nicht public-safe ist;
+- die Capability nur eine Hypothese, ein Marktimpuls oder ein nicht belegter Plan ist;
+- Claim-Risiko R3 erreicht ist;
+- der Nutzen nicht erklaerbar ist, ohne interne Roadmap, Kundendaten oder vertrauliche Prozessdetails offenzulegen.
+
+Beispiel:
+
+```json
+{
+  "owner": "internal-observation",
+  "domain": null,
+  "change": "keine Website-Aenderung",
+  "whyNow": "Signal ist strategisch interessant, aber noch ohne public-safe Beleg und ohne stabilen Endpoint",
+  "demoReadiness": "internal-observation",
+  "claimRisk": "R3 blocked-sensitive-or-actioning",
+  "nextSafeStep": "sanitized Steering-Signal oder fachliche Freigabe anfordern"
+}
+```
+
+## 8. Beispielausgaben
+
+### Beispiel A: Read-only Energy-Market-Backtest
+
+- Signal: CHANGELOG-Eintrag + `POST /api/energy-market/portfolio-backtest`.
+- Domain: `cernion.de/energy-market-api`.
+- Owner: Webmaster fuer Website-Draft; Felix fuer Demo-Snippet.
+- Demo-Reife: D3 `demo-ready`, wenn synthetische Demo und No-Call-Grenzen belegt sind.
+- Claim-Risiko: R0/R1, solange nur "historische Einordnung" und "Read-only" behauptet wird.
+- Naechster sicherer Schritt: Teaser-Draft mit Endpoint-Deeplink, Review durch Felix/Rhajaina vor Publish.
+
+### Beispiel B: Billing-/Settlement-Automation
+
+- Signal: neuer Endpoint oder Konzept fuer Abrechnungs-/Settlement-Prozess.
+- Domain: vorerst keine oeffentliche Zielseite; eventuell internes Rhajaina/Fachowner-Review.
+- Owner: Rhajaina/Fachowner, spaeter Felix oder Webmaster nach Freigabe.
+- Demo-Reife: maximal D1/D2, solange operative/rechtliche Grenzen unklar sind.
+- Claim-Risiko: R2 oder R3.
+- Naechster sicherer Schritt: Claim-Grenzen, Nachweisbedarf und Nicht-Zusagen dokumentieren; keine externe Formulierung.
+
+### Beispiel C: OpenAPI-Developer-Rezept
+
+- Signal: stabiler OpenAPI-Pfad, aber wenig Produktstory.
+- Domain: `corrently.io` oder Repository-Doku zuerst.
+- Owner: DevOps/Produkt fachlich; Webmaster fuer Discoverability.
+- Demo-Reife: D1 `api-visible-needs-story`.
+- Claim-Risiko: R0, wenn rein technisch und ohne kommerzielle Zusage.
+- Naechster sicherer Schritt: curl-/Auth-/Response-Beispiel vorbereiten, danach ggf. cernion.de-Teaser pruefen.
+
+### Beispiel D: Neutrale Methodik oder OSS-Referenz
+
+- Signal: Capability erklaert eine allgemeine Energy-Data-Methodik oder OSS-Komponente.
+- Domain: `stromdao.de`, wenn neutral und nicht als Cernion-Vertriebsseite formuliert.
+- Owner: STROMDAO-Publishing; Webmaster nutzt `stromdao-web-publishing`.
+- Demo-Reife: D2/D3 je nach Artefakt.
+- Claim-Risiko: R0/R1, solange keine Produkt-/Rechts-/Kundenzusage enthalten ist.
+- Naechster sicherer Schritt: neutralisierten Methodik-Draft mit Quellen-/Artefaktankern vorbereiten, HITL vor Publish.
+
+## 9. Minimaler Backlog-Datensatz
+
+Ein Website-Backlog-Kandidat sollte mindestens diese Felder enthalten:
+
+```json
+{
+  "capability": "kurzer stabiler Capability-Name",
+  "source": ["CHANGELOG.md", "openapi-export.json", "Issue/PR falls vorhanden"],
+  "domain": "cernion.de | corrently.io | stromdao.de | corrently.energy | null",
+  "targetPage": "bestehende oder vorgeschlagene Zielseite",
+  "fachlicherOwner": "Felix | DevOps | STROMDAO-Publishing | Cori | Rhajaina | internal-observation",
+  "proposedChange": "konkreter Draft-/Doku-/FAQ-/SEO-Schritt",
+  "whyNow": "belegbarer Anlass",
+  "demoReadiness": "D0-D4 Label",
+  "claimRisk": "R0-R3 Label mit Gruenden",
+  "seoLlmHints": ["Entitaeten", "Suchintent", "Endpoint-/Doku-Deeplink"],
+  "nextSafeStep": "Draft, Review, Folgekarte oder Blocker",
+  "publishGate": "HITL/PR/Publish erforderlich; keine automatische Veroeffentlichung"
+}
+```
+
+## 10. Sichere Kurzformel
+
+Wenn unsicher, lautet die sichere Standardentscheidung:
+
+- keine Live-Aenderung;
+- internen Draft statt Publikation;
+- `cernion.de` nur fuer belegbaren B2B-Nutzen;
+- `corrently.io` fuer Developer-/OSS-Doku;
+- `stromdao.de` fuer neutralisierte Methodik;
+- R2/R3-Claims an Rhajaina/Fachowner/HITL;
+- naechster Schritt als Review-/PR-/Publish-Freigabe formulieren.

--- a/docs/public-website-backlog-candidate-schema.md
+++ b/docs/public-website-backlog-candidate-schema.md
@@ -1,0 +1,161 @@
+# CET Backlog-Kandidatenschema
+
+Ziel: kompakte, maschinenlesbare Struktur fuer Backlog-Kandidaten, die read-only aus `CHANGELOG.md` und `openapi-export.json` beziehungsweise `/api/openapi.json` abgeleitet werden. Das Schema ist ein Entscheidungs- und Handoff-Format; es loest keine GitHub-, Website-, CRM-, Matrix- oder Kanban-Writes aus.
+
+## JSON-Zielformat
+
+```json
+{
+  "schemaVersion": "cernion.publicWebsiteBacklogCandidate.v1",
+  "generatedAt": "2026-07-22T00:00:00.000Z",
+  "sourceSet": {
+    "changelogPath": "CHANGELOG.md",
+    "openapiPath": "openapi-export.json",
+    "openapiInfoVersion": "0.67.8"
+  },
+  "candidates": [
+    {
+      "id": "0.67.10:historical-portfolio-market-value-backtest",
+      "capability": "historical-portfolio-market-value-backtest",
+      "endpointOrService": ["POST /api/energy-market/portfolio-backtest", "Energy Market"],
+      "targetRole": "Stadtwerk-Produktmanager",
+      "websiteTargetPage": "cernion.de/energy-market-api",
+      "demoReadiness": "api-visible-needs-demo-story",
+      "claimRisk": "medium",
+      "sourceEvidence": [
+        {
+          "source": "CHANGELOG.md",
+          "locator": "0.67.10 Added",
+          "excerpt": "New endpoint POST /api/energy-market/portfolio-backtest computes the Day-Ahead spot market value ..."
+        },
+        {
+          "source": "openapi-export.json",
+          "locator": "paths['/api/energy-market/portfolio-backtest'].post",
+          "excerpt": "Historical portfolio market value backtest"
+        }
+      ],
+      "recommendedFollowUpAgent": "webmaster",
+      "rationale": "API-Anker ist sichtbar; oeffentliche Story muss Wertbeitrag, Annahmen und Grenzen ohne Garantie-/Abrechnungsclaim erklaeren."
+    }
+  ]
+}
+```
+
+## Felddefinitionen
+
+| Feld                                    | Typ              | Pflicht  | Zulaessige Werte / Regeln                                                                                                                                                                                                                                       | Beispiel                                                                                                          |
+| --------------------------------------- | ---------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `schemaVersion`                         | string           | ja       | Fix fuer dieses Format: `cernion.publicWebsiteBacklogCandidate.v1`. Bei inkompatiblen Feld-/Enum-Aenderungen hochzaehlen.                                                                                                                                       | `cernion.publicWebsiteBacklogCandidate.v1`                                                                        |
+| `generatedAt`                           | string, ISO-8601 | ja       | UTC-Zeitpunkt der Ableitung; reine Provenienz, kein Freigabezeitpunkt.                                                                                                                                                                                          | `2026-07-22T00:00:00.000Z`                                                                                        |
+| `sourceSet`                             | object           | ja       | Quellen, aus denen die Kandidaten abgeleitet wurden. Muss mindestens `changelogPath` und `openapiPath` enthalten; `openapiInfoVersion` empfohlen.                                                                                                               | siehe JSON oben                                                                                                   |
+| `candidates[]`                          | array<object>    | ja       | Kann leer sein; Reihenfolge darf Priorisierung abbilden, ist aber keine Veroeffentlichungsfreigabe.                                                                                                                                                             | `[ { ... } ]`                                                                                                     |
+| `candidates[].id`                       | string           | ja       | Stabiler, slugfaehiger Schluessel aus Release/Abschnitt und Capability; keine Datenbank-ID. Muster: `<release>:<slug>`.                                                                                                                                         | `0.67.10:historical-portfolio-market-value-backtest`                                                              |
+| `candidates[].capability`               | string           | ja       | Kurzer Capability-Slug oder bekannter CET-Capability-Key; energy-decision-support Sprache bevorzugen: Lagebild, Backtest, Evidenzmatrix, Guardrail, Governance-Readiness.                                                                                       | `municipal-energy-value-lagebild`                                                                                 |
+| `candidates[].endpointOrService`        | array<string>    | ja       | Mindestens ein API-Endpunkt (`METHOD /api/...`) oder Service/Tag (`Dashboard API`, `Energy Market`, `VDMI Blueprint Pack`). Mehrere Werte erlaubt, wenn CHANGELOG und OpenAPI mehrere Anker liefern.                                                            | `["GET /api/dashboard/municipal-energy-value-analysis", "Dashboard API"]`                                         |
+| `candidates[].targetRole`               | string           | ja       | Fachliche Zielrolle, nicht zwingend interner Agent. Empfohlene Werte: `Stadtwerk-Produktmanager`, `VNB-Netzplanung`, `Regulierungs-/Governance-Verantwortliche`, `Kommunale Entscheider`, `Cernion-Webmaster`, `Cernion-Demo/Vertrieb`, `Cernion-Claim-Review`. | `Kommunale Entscheider`                                                                                           |
+| `candidates[].websiteTargetPage`        | string           | ja       | Zielseite oder Platzhalter. Erlaubt sind konkrete Cernion-Zielseiten (`cernion.de/...`) oder `cernion.de/produkt-roadmap` fuer noch nicht positionierte Kandidaten. Keine automatische Publikationsannahme.                                                     | `cernion.de/kommunale-energiedaten`                                                                               |
+| `candidates[].demoReadiness`            | enum string      | ja       | `demo-ready`, `needs-demo-copy-review`, `api-visible-needs-demo-story`, `concept-only`, `blocked-unverified`. `demo-ready` nur bei API-/Demo-Anker plus read-only/No-Call/Guardrail-Beleg.                                                                      | `needs-demo-copy-review`                                                                                          |
+| `candidates[].claimRisk`                | enum string      | ja       | `low`, `medium`, `high`. `low` nur fuer belegte read-only/Guardrail/Synthetic-Demo-Aussagen; `high` bei Garantie, Abrechnung, Steuerung, Approval/Rejection, Vertrags-/Rechtswirkung oder Produktionsmutation ohne klare No-Call-Grenze.                        | `medium`                                                                                                          |
+| `candidates[].sourceEvidence`           | array<object>    | ja       | Mindestens eine CHANGELOG-Belegstelle; OpenAPI-Belegstelle verpflichtend, sobald ein Endpoint behauptet wird. Jedes Objekt: `source`, `locator`, `excerpt`. Excerpt knapp, keine Secrets/PII.                                                                   | `[{"source":"CHANGELOG.md","locator":"0.67.8 Added","excerpt":"derivedLoadProfileRows ..."}]`                     |
+| `candidates[].recommendedFollowUpAgent` | enum string      | ja       | Interner Folge-Agent oder Prozessrolle. Empfohlene Werte: `webmaster`, `felix-demo-sales`, `rhajaina-claim-review`, `viki-market-scouting`, `devops-api-check`, `product-owner-decision`. Bedeutet Handoff-Empfehlung, keine automatische Ausfuehrung.          | `rhajaina-claim-review`                                                                                           |
+| `candidates[].rationale`                | string           | ja       | 1-3 Saetze: Warum ist der Kandidat relevant, welcher Beleg traegt ihn, welche Grenze muss beachtet werden. Muss claim-sicher formuliert sein.                                                                                                                   | `Oeffentlich gut erklaerbarer Lagebild-Endpunkt; lokale Werterfassung bleibt als Evidenzstatus/Annahme markiert.` |
+| `candidates[].confidence`               | enum string      | optional | `high`, `medium`, `low`; confidence ist Ableitungsqualitaet, nicht fachliche Wahrheitsgarantie.                                                                                                                                                                 | `medium`                                                                                                          |
+| `candidates[].tags`                     | array<string>    | optional | Kleine Normalisierungsanker fuer Suche/Priorisierung, z. B. `read-only`, `guardrail`, `vdmi`, `kommunal`, `market-value`, `openapi`.                                                                                                                            | `["read-only", "kommunal", "guardrail"]`                                                                          |
+| `candidates[].nextAction`               | string           | optional | Konkreter naechster Pruef-/Draft-Schritt; kein Sendebefehl.                                                                                                                                                                                                     | `Website-Draft mit Annahmen- und No-Autarky-Grenzen formulieren.`                                                 |
+
+## Normierungsregeln
+
+1. `endpointOrService` darf nur Endpunkte enthalten, die in `openapi-export.json` oder `/api/openapi.json` nachweisbar sind; sonst nur Service-/Capability-Text wie `VDMI Blueprint Pack` verwenden.
+2. `websiteTargetPage` ist eine Zielannahme fuer Redaktion und SEO, nicht die Anweisung zu schreiben oder zu deployen.
+3. `demoReadiness = demo-ready` braucht alle drei Signale: pruefbarer API-/Demo-Anker, Demo-/Fixture-/Workbench-Hinweis, und read-only/No-Call/Guardrail/Synthetic-Beleg.
+4. `claimRisk` ist konservativ: unklare externe Wirkung bleibt `medium`; Mutation, Abrechnung, Steuerung, Approval/Rejection oder Garantie ohne klare Grenzen wird `high`.
+5. `sourceEvidence[].excerpt` soll Belege reproduzierbar machen, aber keine langen CHANGELOG-Abschnitte kopieren.
+6. Sprache: Capability- und Rationale-Texte sollen CET-typisch vorsichtig formulieren: Lagebild, Evidenz, Annahme, Pruefpfad, Guardrail, Read-only, Demo-Raum; keine Erfolgs-, Autarkie-, Garantie- oder Rechtswirkungsclaims.
+
+## Beispiel-Kandidaten aus hypothetischen CET-Release-Aenderungen
+
+```json
+[
+  {
+    "id": "0.67.10:historical-portfolio-market-value-backtest",
+    "capability": "historical-portfolio-market-value-backtest",
+    "endpointOrService": ["POST /api/energy-market/portfolio-backtest", "Energy Market"],
+    "targetRole": "Stadtwerk-Produktmanager",
+    "websiteTargetPage": "cernion.de/energy-market-api",
+    "demoReadiness": "api-visible-needs-demo-story",
+    "claimRisk": "medium",
+    "sourceEvidence": [
+      {
+        "source": "CHANGELOG.md",
+        "locator": "0.67.10 Added",
+        "excerpt": "New endpoint POST /api/energy-market/portfolio-backtest computes the Day-Ahead spot market value for an asset portfolio."
+      },
+      {
+        "source": "openapi-export.json",
+        "locator": "paths['/api/energy-market/portfolio-backtest'].post",
+        "excerpt": "Historical portfolio market value backtest"
+      }
+    ],
+    "recommendedFollowUpAgent": "webmaster",
+    "rationale": "Starker API-Anker fuer eine oeffentliche Entscheidungsunterstuetzungsseite. Der Claim muss als Backtest/Lagebild mit Annahmen und Datenqualitaetsgrenzen formuliert werden, nicht als Erlosgarantie.",
+    "confidence": "high",
+    "tags": ["market-value", "backtest", "openapi"],
+    "nextAction": "Demo-Story mit Beispielportfolio, Datenqualitaetsstufen und Negativpreis-Grenzen formulieren."
+  },
+  {
+    "id": "0.67.8:derived-municipal-load-profile",
+    "capability": "derived-municipal-load-profile",
+    "endpointOrService": ["GET /api/dashboard/municipal-energy-value-analysis", "Dashboard API"],
+    "targetRole": "Kommunale Entscheider",
+    "websiteTargetPage": "cernion.de/kommunale-energiedaten",
+    "demoReadiness": "needs-demo-copy-review",
+    "claimRisk": "low",
+    "sourceEvidence": [
+      {
+        "source": "CHANGELOG.md",
+        "locator": "0.67.8 Added",
+        "excerpt": "Bevoelkerungsbasierte Jahres-Lastkurve ... SLP-Proxy; kein Messwert."
+      },
+      {
+        "source": "openapi-export.json",
+        "locator": "paths['/api/dashboard/municipal-energy-value-analysis'].get",
+        "excerpt": "Municipal Energy Value Lagebild Endpoint"
+      }
+    ],
+    "recommendedFollowUpAgent": "rhajaina-claim-review",
+    "rationale": "Guter kommunaler Lagebild-Kandidat, weil fehlende Messwerte als Evidenzstatus/SLP-Proxy transparent bleiben. Vor externer Kommunikation muss die Grenze 'kein Messwert, nicht abrechnungsrelevant' sichtbar bleiben.",
+    "confidence": "medium",
+    "tags": ["kommunal", "lagebild", "missing-evidence", "guardrail"],
+    "nextAction": "Claim-Review fuer SLP-Proxy-, No-Autarky- und Nichtabrechnungsformulierungen."
+  },
+  {
+    "id": "unreleased:flexible-grid-connection-release-file",
+    "capability": "flexible-grid-connection-release-file-review",
+    "endpointOrService": ["VDMI Blueprint Pack", "Dashboard API"],
+    "targetRole": "VNB-Netzplanung",
+    "websiteTargetPage": "cernion.de/vdmi-governance",
+    "demoReadiness": "concept-only",
+    "claimRisk": "low",
+    "sourceEvidence": [
+      {
+        "source": "CHANGELOG.md",
+        "locator": "Unreleased Added",
+        "excerpt": "read-only vdmi_blueprint_pack_seed ... required release-file evidence gates ... no-call guards for capacity reservation, connection approval/rejection, contract creation ..."
+      }
+    ],
+    "recommendedFollowUpAgent": "felix-demo-sales",
+    "rationale": "Als Governance-/Pruefpfad gut erzaehlbar, aber ohne direkten oeffentlichen Endpoint-Anker zunaechst nur Konzept-/Demo-Packaging. No-Call-Grenzen verhindern, dass die Website eine Anschlusszusage oder Kapazitaetsreservierung suggeriert.",
+    "confidence": "medium",
+    "tags": ["vdmi", "grid-connection", "read-only", "no-call"],
+    "nextAction": "Demo-Raum oder Screenshot-/Dossier-Paket definieren, bevor ein oeffentlicher Website-Draft entsteht."
+  }
+]
+```
+
+## Minimaler Validator-Kontrakt
+
+- Alle Pflichtfelder muessen vorhanden und nicht leer sein.
+- Enum-Werte muessen exakt den oben genannten Werten entsprechen.
+- Jeder Endpoint-Wert im Muster `METHOD /api/...` muss gegen OpenAPI validiert werden.
+- `claimRisk = low` darf nicht gesetzt werden, wenn `rationale` oder `sourceEvidence[].excerpt` ungerahmte Hochrisiko-Begriffe enthaelt (`guarantee`, `Garantie`, `Abrechnung`, `settlement`, `approval`, `rejection`, `device-control`, `Steuerung`) und kein No-Call-/Read-only-Kontext belegt ist.
+- Kandidaten mit `demoReadiness = demo-ready` und `claimRisk != low` bleiben intern pruefbar, aber nicht send-ready.

--- a/docs/release-signal-extractor.md
+++ b/docs/release-signal-extractor.md
@@ -1,0 +1,96 @@
+# CET Release Signal Extractor
+
+Interner, read-only Prototyp zur Extraktion neutraler Rohsignale aus `CHANGELOG.md` und der lokalen OpenAPI-Datei `openapi-export.json`.
+
+## Zweck
+
+Das Skript `scripts/extract-release-signals.js` liest nur lokale Dateien und gibt einen JSON- oder Markdown-Report auf `stdout` aus. Es erkennt:
+
+- neue/geänderte Endpoints, soweit sie im Changelog erwähnt und im OpenAPI-Dokument vorhanden sind,
+- OpenAPI-Operationen mit Methode, Pfad, `operationId`, Service/Tag, Summary und Description,
+- Service-/Tag-Cluster aus OpenAPI,
+- changelog-nahe Release-Hinweise inklusive Section, Release, Issue-Refs und Endpoint-Refs.
+
+## Klare Grenze
+
+Der Report ist ein Rohsignal. Das Skript erstellt keine GitHub-Issues oder PRs, ändert keine Website, schreibt keine Kanban-Karten, deployed nichts und veröffentlicht nichts extern.
+
+## Aufruf
+
+```bash
+node scripts/extract-release-signals.js --format=json --limit=10
+node scripts/extract-release-signals.js --format=markdown --limit=10
+node scripts/extract-release-signals.js --changelog=CHANGELOG.md --openapi=openapi-export.json
+npm run extract:release-signals -- --format=markdown --limit=10
+```
+
+## Beispielinput
+
+Minimaler Changelog-Ausschnitt:
+
+```md
+## Unreleased
+
+### Added
+
+- **Municipal Energy Value Lagebild Endpoint** (#324): New endpoint `GET /api/dashboard/municipal-energy-value-analysis` exposes read-only rows.
+```
+
+Minimale OpenAPI-Operation:
+
+```json
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Cernion Energy Tools API", "version": "0.67.x" },
+  "paths": {
+    "/api/dashboard/municipal-energy-value-analysis": {
+      "get": {
+        "operationId": "dashboard_municipalEnergyValueAnalysisStatus",
+        "summary": "Municipal Energy Value Lagebild Endpoint",
+        "description": "Read-only municipal energy value analysis.",
+        "tags": ["Dashboard API"]
+      }
+    }
+  }
+}
+```
+
+## Beispieloutput (gekürzt)
+
+```json
+{
+  "schemaVersion": "cernion.releaseSignals.v1",
+  "extractionOnly": true,
+  "publicationBoundary": "No GitHub issues, PRs, website changes, deployments, or external publication are performed.",
+  "openapi": {
+    "title": "Cernion Energy Tools API",
+    "version": "0.67.x",
+    "pathCount": 1,
+    "operationCount": 1,
+    "tagCount": 1
+  },
+  "signals": {
+    "endpointSignals": [
+      {
+        "kind": "openapi-operation",
+        "changeClass": "changelog-added",
+        "method": "GET",
+        "path": "/api/dashboard/municipal-energy-value-analysis",
+        "operationId": "dashboard_municipalEnergyValueAnalysisStatus",
+        "service": "Dashboard API",
+        "tags": ["Dashboard API"],
+        "summary": "Municipal Energy Value Lagebild Endpoint",
+        "changelogLinks": [{ "release": "Unreleased", "section": "Added", "score": 100 }],
+        "publicationBoundary": "raw-extraction-only"
+      }
+    ]
+  }
+}
+```
+
+## Fehlerbehandlung
+
+- Fehlende Dateien enden mit `MISSING_FILE` und Exit-Code 1.
+- Ungültiges OpenAPI-JSON endet mit `INVALID_JSON` und Exit-Code 1.
+- OpenAPI-Dokumente ohne `paths` enden mit `INVALID_OPENAPI` und Exit-Code 1.
+- Nicht unterstützte Ausgabeformate enden mit `INVALID_FORMAT` und Exit-Code 1.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "check:llm": "node scripts/generate-llm-txt.js --check",
     "generate:operation-capability-index": "node scripts/generate-operation-capability-index.js",
     "check:operation-capability-index": "node scripts/generate-operation-capability-index.js --check",
+    "generate:public-website-backlog": "node scripts/generate-public-website-backlog.js",
+    "extract:release-signals": "node scripts/extract-release-signals.js",
     "check:quality-gate": "node scripts/check-quality-gate.js",
     "release:check": "npm run test:unit:ci && npm run test:tdd-matrix && npm run check:tdd-matrix-coverage && npm run audit:openapi && npm run check:llm && npm run check:operation-capability-index && npm run check:quality-gate && npm run audit:security",
     "export:openapi": "node scripts/export-openapi.js",

--- a/scripts/extract-release-signals.js
+++ b/scripts/extract-release-signals.js
@@ -444,6 +444,7 @@ function renderMarkdownReport(report) {
 
 function escapeMarkdownCell(value) {
   return String(value || '')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/\r?\n/g, '<br>');
 }

--- a/scripts/extract-release-signals.js
+++ b/scripts/extract-release-signals.js
@@ -1,0 +1,504 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Read-only release signal extractor.
+ *
+ * Reads CHANGELOG.md plus a local OpenAPI export and emits neutral raw signals for later
+ * human/agent publication workflows. This script intentionally writes no files and performs
+ * no GitHub, website, Kanban, deployment, or publication actions.
+ *
+ * Usage:
+ *   node scripts/extract-release-signals.js
+ *   node scripts/extract-release-signals.js --format=markdown --limit=10
+ *   node scripts/extract-release-signals.js --changelog=CHANGELOG.md --openapi=openapi-export.json
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const DEFAULT_CHANGELOG_PATH = path.join(ROOT, 'CHANGELOG.md');
+const DEFAULT_OPENAPI_PATH = path.join(ROOT, 'openapi-export.json');
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'options', 'head']);
+const DEFAULT_LIMIT = 50;
+
+class InputError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'InputError';
+    this.code = code;
+  }
+}
+
+function readUtf8File(filePath, label) {
+  const resolved = path.resolve(filePath);
+  try {
+    return fs.readFileSync(resolved, 'utf8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      throw new InputError('MISSING_FILE', `${label} not found: ${resolved}`);
+    }
+    throw new InputError('READ_FAILED', `${label} could not be read: ${resolved} (${err.message})`);
+  }
+}
+
+function readJsonFile(filePath, label) {
+  const raw = readUtf8File(filePath, label);
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new InputError('INVALID_JSON', `${label} is not valid JSON: ${path.resolve(filePath)}`);
+  }
+}
+
+function normalizeText(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[`*_#[\](){}:;,.!?/|]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function truncateText(value, maxLength = 260) {
+  const compact = String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (compact.length <= maxLength) return compact;
+  return `${compact.slice(0, maxLength - 1).trim()}…`;
+}
+
+function splitTokenSet(value) {
+  return new Set(
+    normalizeText(value)
+      .split(/[^a-z0-9äöüß-]+/)
+      .filter((token) => token.length >= 4)
+  );
+}
+
+function parseChangelogEntries(markdown) {
+  const entries = [];
+  let currentRelease = 'Unreleased';
+  let currentDate = null;
+  let currentSection = 'Changed';
+  let currentEntry = null;
+
+  const flush = () => {
+    if (!currentEntry) return;
+    const text = currentEntry.lines.join('\n').trim();
+    entries.push({
+      release: currentEntry.release,
+      releaseDate: currentEntry.releaseDate,
+      section: currentEntry.section,
+      title: extractEntryTitle(text),
+      text,
+      issueRefs: Array.from(text.matchAll(/#(\d+)/g)).map((match) => `#${match[1]}`),
+      endpointRefs: extractEndpointRefs(text),
+      pathRefs: extractPathRefs(text),
+    });
+    currentEntry = null;
+  };
+
+  for (const line of String(markdown || '').split(/\r?\n/)) {
+    const releaseMatch = line.match(/^##\s+(?:\[([^\]]+)\]|(Unreleased))(?:\s+[—-]\s+(.+))?/i);
+    if (releaseMatch) {
+      flush();
+      currentRelease = releaseMatch[1] || releaseMatch[2] || 'Unreleased';
+      currentDate = releaseMatch[3] ? releaseMatch[3].trim() : null;
+      currentSection = 'Changed';
+      continue;
+    }
+
+    const sectionMatch = line.match(/^###\s+(.+)$/);
+    if (sectionMatch) {
+      flush();
+      currentSection = sectionMatch[1].trim();
+      continue;
+    }
+
+    if (/^-\s+/.test(line)) {
+      flush();
+      currentEntry = {
+        release: currentRelease,
+        releaseDate: currentDate,
+        section: currentSection,
+        lines: [line.replace(/^-\s+/, '').trim()],
+      };
+      continue;
+    }
+
+    if (currentEntry && /^\s{2,}-\s+/.test(line)) {
+      currentEntry.lines.push(line.trim());
+    }
+  }
+
+  flush();
+  return entries;
+}
+
+function extractEntryTitle(text) {
+  const boldMatch = String(text || '').match(/^\*\*([^*]+)\*\*/);
+  if (boldMatch) return boldMatch[1].replace(/`/g, '').trim();
+  return truncateText(
+    String(text || '')
+      .split(':')[0]
+      .replace(/`/g, ''),
+    140
+  );
+}
+
+function extractEndpointRefs(text) {
+  const refs = [];
+  const regex = /\b(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+(\/api\/[\w./:{}-]+)/gi;
+  for (const match of String(text || '').matchAll(regex)) {
+    refs.push(`${match[1].toUpperCase()} ${match[2].replace(/[),.;]+$/, '')}`);
+  }
+  return Array.from(new Set(refs));
+}
+
+function extractPathRefs(text) {
+  const refs = [];
+  const regex = /(?:`|\b)(\/api\/[\w./:{}-]+)(?:`|\b)/g;
+  for (const match of String(text || '').matchAll(regex)) {
+    refs.push(match[1].replace(/[),.;]+$/, ''));
+  }
+  return Array.from(new Set(refs));
+}
+
+function extractOpenApiOperations(spec) {
+  if (!spec || typeof spec !== 'object' || !spec.paths || typeof spec.paths !== 'object') {
+    throw new InputError('INVALID_OPENAPI', 'OpenAPI document must contain a paths object.');
+  }
+
+  const operations = [];
+  for (const [apiPath, pathItem] of Object.entries(spec.paths).sort(([a], [b]) =>
+    a.localeCompare(b)
+  )) {
+    if (!pathItem || typeof pathItem !== 'object') continue;
+    for (const [method, operation] of Object.entries(pathItem)) {
+      const lowerMethod = method.toLowerCase();
+      if (!HTTP_METHODS.has(lowerMethod)) continue;
+      const op = operation && typeof operation === 'object' ? operation : {};
+      const tags = Array.isArray(op.tags) ? op.tags.filter(Boolean) : [];
+      operations.push({
+        method: lowerMethod.toUpperCase(),
+        path: apiPath,
+        operationId: op.operationId || `${lowerMethod.toUpperCase()}_${apiPath}`,
+        service: inferServiceName(apiPath, op, tags),
+        tags,
+        summary: op.summary || '',
+        description: op.description || '',
+      });
+    }
+  }
+  return operations;
+}
+
+function inferServiceName(apiPath, operation, tags) {
+  if (tags.length > 0) return tags[0];
+  if (operation && operation.operationId && operation.operationId.includes('_')) {
+    return operation.operationId.split('_')[0];
+  }
+  const parts = String(apiPath || '')
+    .split('/')
+    .filter(Boolean);
+  return parts[1] || 'unmapped';
+}
+
+function scoreEntryOperation(entry, operation) {
+  const entryText = `${entry.title} ${entry.text}`;
+  const operationText = [
+    operation.method,
+    operation.path,
+    operation.operationId,
+    operation.service,
+    operation.tags.join(' '),
+    operation.summary,
+    operation.description,
+  ].join(' ');
+
+  let score = 0;
+  const exactEndpoint = `${operation.method} ${operation.path}`;
+  if (entry.endpointRefs.includes(exactEndpoint)) score += 100;
+  if (entry.pathRefs.includes(operation.path)) score += 70;
+  if (normalizeText(entryText).includes(normalizeText(operation.operationId))) score += 25;
+
+  const entryTokens = splitTokenSet(entryText);
+  const operationHaystack = normalizeText(operationText);
+  for (const token of entryTokens) {
+    if (operationHaystack.includes(token)) score += 1;
+  }
+
+  return score;
+}
+
+function findChangelogLinks(operation, entries) {
+  return entries
+    .map((entry) => ({ entry, score: scoreEntryOperation(entry, operation) }))
+    .filter((item) => item.score >= 20)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        a.entry.release.localeCompare(b.entry.release) ||
+        a.entry.title.localeCompare(b.entry.title)
+    )
+    .slice(0, 5)
+    .map(({ entry, score }) => ({
+      release: entry.release,
+      section: entry.section,
+      title: entry.title,
+      issueRefs: entry.issueRefs,
+      score,
+    }));
+}
+
+function buildEndpointSignals(operations, entries, limit) {
+  return operations
+    .map((operation) => {
+      const changelogLinks = findChangelogLinks(operation, entries);
+      return {
+        kind: 'openapi-operation',
+        changeClass: inferChangeClass(changelogLinks),
+        method: operation.method,
+        path: operation.path,
+        operationId: operation.operationId,
+        service: operation.service,
+        tags: operation.tags,
+        summary: operation.summary,
+        description: truncateText(operation.description, 320),
+        changelogLinks,
+        publicationBoundary: 'raw-extraction-only',
+      };
+    })
+    .sort((a, b) => {
+      const linkDiff = b.changelogLinks.length - a.changelogLinks.length;
+      return linkDiff || a.path.localeCompare(b.path) || a.method.localeCompare(b.method);
+    })
+    .slice(0, limit);
+}
+
+function inferChangeClass(changelogLinks) {
+  if (!changelogLinks || changelogLinks.length === 0) return 'openapi-observed';
+  const sections = new Set(changelogLinks.map((link) => String(link.section).toLowerCase()));
+  if (sections.has('added')) return 'changelog-added';
+  if (sections.has('changed')) return 'changelog-changed';
+  if (sections.has('fixed')) return 'changelog-fixed';
+  if (sections.has('security')) return 'changelog-security';
+  return 'changelog-mentioned';
+}
+
+function buildServiceSignals(operations, entries) {
+  const services = new Map();
+  for (const operation of operations) {
+    const key = operation.service || 'unmapped';
+    if (!services.has(key)) {
+      services.set(key, {
+        service: key,
+        operationCount: 0,
+        tags: new Set(),
+        endpointExamples: [],
+        changelogMentions: [],
+      });
+    }
+    const service = services.get(key);
+    service.operationCount += 1;
+    operation.tags.forEach((tag) => service.tags.add(tag));
+    if (service.endpointExamples.length < 5) {
+      service.endpointExamples.push(`${operation.method} ${operation.path}`);
+    }
+  }
+
+  for (const entry of entries) {
+    const text = normalizeText(`${entry.title} ${entry.text}`);
+    for (const service of services.values()) {
+      if (text.includes(normalizeText(service.service))) {
+        service.changelogMentions.push({
+          release: entry.release,
+          section: entry.section,
+          title: entry.title,
+          issueRefs: entry.issueRefs,
+        });
+      }
+    }
+  }
+
+  return Array.from(services.values())
+    .map((service) => ({
+      ...service,
+      tags: Array.from(service.tags).sort(),
+      changelogMentions: service.changelogMentions.slice(0, 10),
+      publicationBoundary: 'raw-extraction-only',
+    }))
+    .sort(
+      (a, b) =>
+        b.changelogMentions.length - a.changelogMentions.length ||
+        b.operationCount - a.operationCount ||
+        a.service.localeCompare(b.service)
+    );
+}
+
+function buildChangelogReleaseHints(entries, limit) {
+  return entries.slice(0, limit).map((entry) => ({
+    kind: 'changelog-entry',
+    release: entry.release,
+    releaseDate: entry.releaseDate,
+    section: entry.section,
+    title: entry.title,
+    issueRefs: entry.issueRefs,
+    endpointRefs: entry.endpointRefs,
+    pathRefs: entry.pathRefs,
+    summary: truncateText(entry.text, 360),
+    publicationBoundary: 'raw-extraction-only',
+  }));
+}
+
+function buildReleaseSignals({ changelogMarkdown, openApiSpec, limit = DEFAULT_LIMIT }) {
+  const changelogEntries = parseChangelogEntries(changelogMarkdown);
+  const operations = extractOpenApiOperations(openApiSpec);
+  const recentEntries = changelogEntries.slice(0, Math.max(limit * 4, 100));
+  const releases = Array.from(new Set(changelogEntries.map((entry) => entry.release)));
+  const tagSet = new Set();
+  operations.forEach((operation) => operation.tags.forEach((tag) => tagSet.add(tag)));
+
+  return {
+    schemaVersion: 'cernion.releaseSignals.v1',
+    generatedAt: new Date().toISOString(),
+    extractionOnly: true,
+    publicationBoundary:
+      'No GitHub issues, PRs, website changes, deployments, or external publication are performed.',
+    openapi: {
+      title: openApiSpec.info && openApiSpec.info.title ? openApiSpec.info.title : null,
+      version: openApiSpec.info && openApiSpec.info.version ? openApiSpec.info.version : null,
+      pathCount: Object.keys(openApiSpec.paths || {}).length,
+      operationCount: operations.length,
+      tagCount: tagSet.size,
+    },
+    changelog: {
+      entryCount: changelogEntries.length,
+      releases,
+      latestRelease: releases[0] || null,
+    },
+    signals: {
+      endpointSignals: buildEndpointSignals(operations, recentEntries, limit),
+      serviceSignals: buildServiceSignals(operations, recentEntries),
+      changelogReleaseHints: buildChangelogReleaseHints(changelogEntries, limit),
+    },
+  };
+}
+
+function renderMarkdownReport(report) {
+  const lines = [
+    '# CET Release Signal Extraction Report',
+    '',
+    'Read-only Rohsignal-Extraktion aus CHANGELOG.md und OpenAPI.',
+    '',
+    `- generatedAt: ${report.generatedAt}`,
+    `- extractionOnly: ${report.extractionOnly}`,
+    `- publicationBoundary: ${report.publicationBoundary}`,
+    `- openapi: ${report.openapi.title || 'unknown'} ${report.openapi.version || ''}`.trim(),
+    `- paths/operations/tags: ${report.openapi.pathCount}/${report.openapi.operationCount}/${report.openapi.tagCount}`,
+    `- changelogEntries: ${report.changelog.entryCount}`,
+    '',
+    '## Endpoint-Signale',
+    '',
+    '| Change | Method | Path | Service/Tags | Summary | Changelog-Bezug |',
+    '| --- | --- | --- | --- | --- | --- |',
+  ];
+
+  for (const signal of report.signals.endpointSignals) {
+    lines.push(
+      [
+        signal.changeClass,
+        signal.method,
+        signal.path,
+        [signal.service]
+          .concat(signal.tags || [])
+          .filter(Boolean)
+          .join(', '),
+        signal.summary || signal.operationId,
+        signal.changelogLinks
+          .map((link) => `${link.release} ${link.section}: ${link.title}`)
+          .join('<br>') || 'OpenAPI-only beobachtet',
+      ]
+        .map(escapeMarkdownCell)
+        .join(' | ')
+        .replace(/^/, '| ')
+        .replace(/$/, ' |')
+    );
+  }
+
+  lines.push('', '## Changelog-Hinweise', '');
+  for (const hint of report.signals.changelogReleaseHints) {
+    const refs = hint.endpointRefs.length ? ` Endpoints: ${hint.endpointRefs.join(', ')}.` : '';
+    lines.push(`- ${hint.release} / ${hint.section}: ${hint.title}.${refs}`);
+  }
+
+  lines.push('', '## Trennung Extraction vs. Veröffentlichung', '');
+  lines.push('- Dieses Skript schreibt nicht in GitHub, Websites, Kanban oder externe Systeme.');
+  lines.push(
+    '- Der Report ist ein neutrales Rohsignal und kein Veröffentlichungs- oder Claim-Entwurf.'
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+function escapeMarkdownCell(value) {
+  return String(value || '')
+    .replace(/\|/g, '\\|')
+    .replace(/\r?\n/g, '<br>');
+}
+
+function parseArgs(argv) {
+  const getValue = (name) => {
+    const prefix = `${name}=`;
+    const inline = argv.find((arg) => arg.startsWith(prefix));
+    if (inline) return inline.slice(prefix.length);
+    const index = argv.indexOf(name);
+    if (index !== -1 && argv[index + 1]) return argv[index + 1];
+    return null;
+  };
+
+  const limitValue = getValue('--limit');
+  const limit = limitValue ? Number(limitValue) : DEFAULT_LIMIT;
+  return {
+    changelogPath: getValue('--changelog') || DEFAULT_CHANGELOG_PATH,
+    openapiPath: getValue('--openapi') || DEFAULT_OPENAPI_PATH,
+    format: getValue('--format') || (argv.includes('--markdown') ? 'markdown' : 'json'),
+    limit: Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : DEFAULT_LIMIT,
+  };
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const changelogMarkdown = readUtf8File(options.changelogPath, 'CHANGELOG.md');
+    const openApiSpec = readJsonFile(options.openapiPath, 'OpenAPI JSON');
+    const report = buildReleaseSignals({ changelogMarkdown, openApiSpec, limit: options.limit });
+
+    if (options.format === 'markdown' || options.format === 'md') {
+      process.stdout.write(renderMarkdownReport(report));
+      return;
+    }
+    if (options.format !== 'json') {
+      throw new InputError('INVALID_FORMAT', `Unsupported format: ${options.format}`);
+    }
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } catch (err) {
+    const code = err && err.code ? err.code : 'UNEXPECTED_ERROR';
+    process.stderr.write(`[extract-release-signals] ${code}: ${err.message}\n`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  InputError,
+  buildReleaseSignals,
+  extractOpenApiOperations,
+  parseArgs,
+  parseChangelogEntries,
+  renderMarkdownReport,
+};

--- a/scripts/extract-release-signals.js
+++ b/scripts/extract-release-signals.js
@@ -109,10 +109,9 @@ function parseChangelogEntries(markdown) {
       continue;
     }
 
-    const sectionMatch = line.match(/^###\s+(.+)$/);
-    if (sectionMatch) {
+    if (line.startsWith('### ')) {
       flush();
-      currentSection = sectionMatch[1].trim();
+      currentSection = line.slice(4).trim();
       continue;
     }
 
@@ -138,20 +137,28 @@ function parseChangelogEntries(markdown) {
 
 function extractEntryTitle(text) {
   const boldMatch = String(text || '').match(/^\*\*([^*]+)\*\*/);
-  if (boldMatch) return boldMatch[1].replace(/`/g, '').trim();
+  if (boldMatch) return boldMatch[1].replaceAll('`', '').trim();
   return truncateText(
     String(text || '')
       .split(':')[0]
-      .replace(/`/g, ''),
+      .replaceAll('`', ''),
     140
   );
+}
+
+function stripTrailingEndpointPunctuation(value) {
+  let cleaned = String(value || '');
+  while (cleaned.length > 0 && '),.;'.includes(cleaned.at(-1))) {
+    cleaned = cleaned.slice(0, -1);
+  }
+  return cleaned;
 }
 
 function extractEndpointRefs(text) {
   const refs = [];
   const regex = /\b(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+(\/api\/[\w./:{}-]+)/gi;
   for (const match of String(text || '').matchAll(regex)) {
-    refs.push(`${match[1].toUpperCase()} ${match[2].replace(/[),.;]+$/, '')}`);
+    refs.push(`${match[1].toUpperCase()} ${stripTrailingEndpointPunctuation(match[2])}`);
   }
   return Array.from(new Set(refs));
 }
@@ -160,7 +167,7 @@ function extractPathRefs(text) {
   const refs = [];
   const regex = /(?:`|\b)(\/api\/[\w./:{}-]+)(?:`|\b)/g;
   for (const match of String(text || '').matchAll(regex)) {
-    refs.push(match[1].replace(/[),.;]+$/, ''));
+    refs.push(stripTrailingEndpointPunctuation(match[1]));
   }
   return Array.from(new Set(refs));
 }
@@ -325,7 +332,7 @@ function buildServiceSignals(operations, entries) {
   return Array.from(services.values())
     .map((service) => ({
       ...service,
-      tags: Array.from(service.tags).sort(),
+      tags: Array.from(service.tags).sort((a, b) => a.localeCompare(b)),
       changelogMentions: service.changelogMentions.slice(0, 10),
       publicationBoundary: 'raw-extraction-only',
     }))
@@ -444,8 +451,8 @@ function renderMarkdownReport(report) {
 
 function escapeMarkdownCell(value) {
   return String(value || '')
-    .replace(/\\/g, '\\\\')
-    .replace(/\|/g, '\\|')
+    .replaceAll('\\', '\\\\')
+    .replaceAll('|', '\\|')
     .replace(/\r?\n/g, '<br>');
 }
 

--- a/scripts/generate-public-website-backlog.js
+++ b/scripts/generate-public-website-backlog.js
@@ -130,8 +130,9 @@ function normalizeText(value) {
 
 function slugify(value) {
   return normalizeText(value)
-    .replace(/[^a-z0-9äöüß]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+    .split(/[^a-z0-9äöüß]+/)
+    .filter(Boolean)
+    .join('-')
     .slice(0, 80);
 }
 
@@ -162,10 +163,9 @@ function parseChangelogEntries(markdown) {
       continue;
     }
 
-    const sectionMatch = line.match(/^###\s+(.+)$/);
-    if (sectionMatch) {
+    if (line.startsWith('### ')) {
       flush();
-      currentSection = sectionMatch[1].trim();
+      currentSection = line.slice(4).trim();
       continue;
     }
 
@@ -190,8 +190,8 @@ function parseChangelogEntries(markdown) {
 
 function extractEntryTitle(text) {
   const boldMatch = text.match(/^\*\*([^*]+)\*\*/);
-  if (boldMatch) return boldMatch[1].replace(/`/g, '').trim();
-  return text.split(':')[0].replace(/`/g, '').slice(0, 120).trim();
+  if (boldMatch) return boldMatch[1].replaceAll('`', '').trim();
+  return text.split(':')[0].replaceAll('`', '').slice(0, 120).trim();
 }
 
 function loadOpenApiOperations(spec) {
@@ -538,8 +538,8 @@ function renderChannelPackageSummary(channelPackages) {
 
 function escapeMarkdownCell(value) {
   return String(value || '')
-    .replace(/\\/g, '\\\\')
-    .replace(/\|/g, '\\|')
+    .replaceAll('\\', '\\\\')
+    .replaceAll('|', '\\|')
     .replace(/\r?\n/g, '<br>');
 }
 

--- a/scripts/generate-public-website-backlog.js
+++ b/scripts/generate-public-website-backlog.js
@@ -1,0 +1,596 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * scripts/generate-public-website-backlog.js
+ *
+ * Derives public-website/backlog candidates from CHANGELOG.md and the committed
+ * OpenAPI export. The script is intentionally read-only: it writes no GitHub,
+ * website, Matrix, or Kanban state. Operators can pipe the markdown/JSON into a
+ * guarded Rhajaina/Webmaster/Felix/Viki handoff workflow. It can package
+ * send-ready drafts per recipient/channel, but never sends them itself.
+ *
+ * Usage:
+ *   node scripts/generate-public-website-backlog.js
+ *   npm run generate:public-website-backlog
+ *   node scripts/generate-public-website-backlog.js --json
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const DEFAULT_CHANGELOG_PATH = path.join(ROOT, 'CHANGELOG.md');
+const DEFAULT_OPENAPI_PATH = path.join(ROOT, 'openapi-export.json');
+
+const PUBLIC_SITE_RULES = [
+  {
+    id: 'personal-agent',
+    site: 'cernion.de/ki-agenten',
+    keywords: ['personal agent', 'agent', 'chat', 'openai', 'work-out-loud'],
+  },
+  {
+    id: 'redispatch',
+    site: 'cernion.de/redispatch',
+    keywords: ['redispatch', '§14a', 'steuerbarkeit', 'curtailment'],
+  },
+  {
+    id: 'municipal-energy',
+    site: 'cernion.de/kommunale-energiedaten',
+    keywords: ['municipal', 'gemeinde', 'kommunal', 'plz', 'lagebild', 'wertschöpfung'],
+  },
+  {
+    id: 'vdmi-governance',
+    site: 'cernion.de/vdmi-governance',
+    keywords: ['vdmi', 'blueprint', 'governance', 'raci', 'evidence'],
+  },
+  {
+    id: 'market-data',
+    site: 'cernion.de/energy-market-api',
+    keywords: ['portfolio', 'backtest', 'epex', 'entsoe', 'market value', 'spot'],
+  },
+  {
+    id: 'budibase-workbench',
+    site: 'cernion.de/stadtwerk-workbench',
+    keywords: ['budibase', 'workbench', 'stadtwerk mauer', 'dashboard'],
+  },
+  {
+    id: 'platform-api',
+    site: 'cernion.de/api',
+    keywords: ['openapi', 'endpoint', 'api', 'rest', 'object store', 'token'],
+  },
+];
+
+const ROLE_RULES = [
+  { role: 'Webmaster', keywords: ['website', 'public', 'html', 'api', 'openapi'] },
+  { role: 'Felix', keywords: ['demo', 'tenant', 'stadtwerk', 'workbench', 'b2b'] },
+  { role: 'Rhajaina', keywords: ['claim', 'guardrail', 'evidence', 'governance', 'no-call'] },
+  { role: 'DevOps', keywords: ['endpoint', 'script', 'cache', 'job', 'openapi'] },
+];
+
+const CHANNEL_PACKAGE_RULES = [
+  {
+    recipient: 'Webmaster',
+    channels: ['cernion.de', 'corrently.io', 'stromdao.de'],
+    focus: 'Website-/Doku-/SEO-Draft mit belegbarer Capability und Endpoint-Deeplink.',
+  },
+  {
+    recipient: 'Felix',
+    channels: ['LinkedIn', 'Pubbler', 'B2B-E-Mail-Kontakte'],
+    focus: 'B2B-Demo-/Kontaktpaket für Stadtwerke, ohne Kundenerfolge oder Preise zu erfinden.',
+  },
+  {
+    recipient: 'Viki',
+    channels: ['Viki-Markt-Scouting', 'LinkedIn-Signalbeobachtung'],
+    focus: 'Markt-/Wettbewerbs-Signal prüfen und Zielsegmente für Anschlusskommunikation ableiten.',
+  },
+  {
+    recipient: 'Rhajaina',
+    channels: ['Claim-Governance', 'Freigabe-/Nachweisprüfung'],
+    focus: 'Claim-Risiko, Nachweisbedarf und Grenzen vor externer Zusage festziehen.',
+  },
+];
+
+const HIGH_RISK_TERMS = [
+  'guarantee',
+  'garantie',
+  'abrechnung',
+  'settlement',
+  'tariff',
+  'device-control',
+  'steuerung',
+  'approval',
+  'rejection',
+  'public publication',
+  'production mutation',
+];
+
+const LOW_RISK_TERMS = ['read-only', 'no-call', 'guardrail', 'evidence', 'demo', 'synthetic'];
+
+const OPERATION_MATCH_STOP_TOKENS = new Set([
+  'added',
+  'changed',
+  'computes',
+  'endpoint',
+  'energy',
+  'includes',
+  'market',
+  'output',
+  'read',
+  'value',
+]);
+
+function normalizeText(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[`*_#[\]()]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function slugify(value) {
+  return normalizeText(value)
+    .replace(/[^a-z0-9äöüß]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+function parseChangelogEntries(markdown) {
+  const entries = [];
+  let currentRelease = 'Unreleased';
+  let currentSection = 'Changed';
+  let currentEntry = null;
+
+  const flush = () => {
+    if (currentEntry) {
+      currentEntry.text = currentEntry.lines.join('\n').trim();
+      currentEntry.title = extractEntryTitle(currentEntry.text);
+      currentEntry.issueRefs = Array.from(currentEntry.text.matchAll(/#(\d+)/g)).map(
+        (m) => `#${m[1]}`
+      );
+      entries.push(currentEntry);
+      currentEntry = null;
+    }
+  };
+
+  for (const line of markdown.split(/\r?\n/)) {
+    const releaseMatch = line.match(/^##\s+(?:\[([^\]]+)\]|(Unreleased))/i);
+    if (releaseMatch) {
+      flush();
+      currentRelease = releaseMatch[1] || releaseMatch[2] || 'Unreleased';
+      currentSection = 'Changed';
+      continue;
+    }
+
+    const sectionMatch = line.match(/^###\s+(.+)$/);
+    if (sectionMatch) {
+      flush();
+      currentSection = sectionMatch[1].trim();
+      continue;
+    }
+
+    if (/^-\s+/.test(line)) {
+      flush();
+      currentEntry = {
+        release: currentRelease,
+        section: currentSection,
+        lines: [line.replace(/^-\s+/, '').trim()],
+      };
+      continue;
+    }
+
+    if (currentEntry && /^\s{2,}-\s+/.test(line)) {
+      currentEntry.lines.push(line.trim());
+    }
+  }
+
+  flush();
+  return entries;
+}
+
+function extractEntryTitle(text) {
+  const boldMatch = text.match(/^\*\*([^*]+)\*\*/);
+  if (boldMatch) return boldMatch[1].replace(/`/g, '').trim();
+  return text.split(':')[0].replace(/`/g, '').slice(0, 120).trim();
+}
+
+function loadOpenApiOperations(spec) {
+  const operations = [];
+  for (const [apiPath, pathItem] of Object.entries(spec.paths || {})) {
+    for (const [method, operation] of Object.entries(pathItem || {})) {
+      if (!['get', 'post', 'put', 'patch', 'delete'].includes(method.toLowerCase())) continue;
+      operations.push({
+        path: apiPath,
+        method: method.toUpperCase(),
+        operationId: operation.operationId || `${method.toUpperCase()}_${apiPath}`,
+        summary: operation.summary || '',
+        description: operation.description || '',
+        tags: Array.isArray(operation.tags) ? operation.tags : [],
+        uiPage: operation['x-ui-page'] || null,
+      });
+    }
+  }
+  return operations;
+}
+
+function scoreOperation(entry, operation) {
+  const haystack = normalizeText(
+    [
+      operation.path,
+      operation.operationId,
+      operation.summary,
+      operation.description,
+      operation.tags.join(' '),
+      operation.uiPage,
+    ].join(' ')
+  );
+  const entryTokens = new Set(
+    normalizeText(`${entry.title} ${entry.text}`)
+      .split(/[^a-z0-9äöüß]+/)
+      .filter((token) => token.length >= 5 && !OPERATION_MATCH_STOP_TOKENS.has(token))
+  );
+
+  let score = 0;
+  for (const token of entryTokens) {
+    if (haystack.includes(token)) score += 1;
+  }
+  if (operation.path && entry.text.includes(operation.path)) score += 50;
+  if (
+    operation.operationId &&
+    normalizeText(entry.text).includes(normalizeText(operation.operationId))
+  ) {
+    score += 10;
+  }
+  if (entry.title && haystack.includes(normalizeText(entry.title))) score += 8;
+  for (const ref of entry.issueRefs || []) {
+    if (haystack.includes(ref.toLowerCase())) score += 2;
+  }
+  return score;
+}
+
+function findRelatedOperations(entry, operations, max = 3) {
+  return operations
+    .map((operation) => ({ ...operation, matchScore: scoreOperation(entry, operation) }))
+    .filter((operation) => operation.matchScore >= 3)
+    .sort(
+      (a, b) =>
+        b.matchScore - a.matchScore ||
+        a.path.localeCompare(b.path) ||
+        a.method.localeCompare(b.method)
+    )
+    .slice(0, max)
+    .map(({ matchScore: _matchScore, ...operation }) => operation);
+}
+
+function selectByKeywordRules(text, rules, fallbackField) {
+  const normalized = normalizeText(text);
+  let best = null;
+  for (const rule of rules) {
+    const score = rule.keywords.filter((keyword) =>
+      normalized.includes(normalizeText(keyword))
+    ).length;
+    if (!best || score > best.score) best = { ...rule, score };
+  }
+  if (best && best.score > 0) return best[fallbackField];
+  return null;
+}
+
+function inferWebsiteTarget(entry, relatedOperations) {
+  const operationText = relatedOperations
+    .map((op) => `${op.path} ${op.summary} ${op.tags.join(' ')} ${op.uiPage || ''}`)
+    .join(' ');
+  return (
+    selectByKeywordRules(
+      `${entry.title} ${entry.text} ${operationText}`,
+      PUBLIC_SITE_RULES,
+      'site'
+    ) || 'cernion.de/produkt-roadmap'
+  );
+}
+
+function inferTargetRole(entry, relatedOperations) {
+  const operationText = relatedOperations
+    .map((op) => `${op.path} ${op.summary} ${op.tags.join(' ')} ${op.uiPage || ''}`)
+    .join(' ');
+  const combinedText = normalizeText(`${entry.title} ${entry.text} ${operationText}`);
+  if (
+    relatedOperations.length > 0 &&
+    ['demo', 'fixture', 'seed', 'workbench', 'dashboard'].some((term) =>
+      combinedText.includes(term)
+    )
+  ) {
+    return 'Felix';
+  }
+  return (
+    selectByKeywordRules(`${entry.title} ${entry.text} ${operationText}`, ROLE_RULES, 'role') ||
+    'Rhajaina'
+  );
+}
+
+function inferDemoReadiness(entry, relatedOperations) {
+  const text = normalizeText(entry.text);
+  const hasEndpoint =
+    relatedOperations.length > 0 || /\b(get|post|put|patch|delete)\s+\/api\//i.test(entry.text);
+  const hasDemoSignal = ['demo', 'fixture', 'seed', 'workbench', 'dashboard', 'html'].some((term) =>
+    text.includes(term)
+  );
+  const hasGuard = ['read-only', 'no-call', 'guardrail', 'synthetic'].some((term) =>
+    text.includes(term)
+  );
+
+  if (hasEndpoint && hasDemoSignal && hasGuard) return 'demo-ready';
+  if (hasEndpoint && (hasDemoSignal || hasGuard)) return 'needs-demo-copy-review';
+  if (hasEndpoint) return 'api-visible-needs-demo-story';
+  return 'concept-only';
+}
+
+function inferClaimRisk(entry) {
+  const text = normalizeText(entry.text);
+  const highHits = HIGH_RISK_TERMS.filter((term) => text.includes(normalizeText(term)));
+  const lowHits = LOW_RISK_TERMS.filter((term) => text.includes(normalizeText(term)));
+
+  if (highHits.length > 0 && lowHits.length === 0) {
+    return { level: 'high', reasons: highHits.slice(0, 3) };
+  }
+  if (highHits.length > 0) {
+    return { level: 'medium', reasons: highHits.slice(0, 3) };
+  }
+  if (lowHits.length > 0) {
+    return { level: 'low', reasons: lowHits.slice(0, 3) };
+  }
+  return { level: 'medium', reasons: ['manual public-claim review required'] };
+}
+
+function inferRecommendedFollowUpAgent(candidate) {
+  if (candidate.claimRisk === 'high') return 'rhajaina-claim-review';
+  if (candidate.demoReadiness === 'concept-only') return 'felix-demo-sales';
+  if (candidate.targetRole === 'Felix' && candidate.demoReadiness === 'demo-ready') {
+    return 'felix-demo-sales';
+  }
+  if (candidate.websiteTargetPage.includes('corrently.io')) return 'devops-api-check';
+  if (candidate.endpoints.length > 0) return 'webmaster';
+  return 'rhajaina-claim-review';
+}
+
+function buildChannelPackages(candidate) {
+  const packages = [];
+  const recipients = new Set(['Webmaster', 'Rhajaina']);
+
+  if (candidate.targetRole && candidate.targetRole !== 'DevOps')
+    recipients.add(candidate.targetRole);
+  if (
+    candidate.demoReadiness === 'demo-ready' ||
+    candidate.websiteTargetPage.includes('workbench')
+  ) {
+    recipients.add('Felix');
+  }
+  if (candidate.claimRisk !== 'high') recipients.add('Viki');
+
+  for (const recipient of recipients) {
+    const rule = CHANNEL_PACKAGE_RULES.find((item) => item.recipient === recipient);
+    if (!rule) continue;
+    packages.push({
+      recipient,
+      channels: selectChannelsForCandidate(rule.channels, candidate),
+      sendReadiness: inferSendReadiness(candidate, recipient),
+      messageAngle: buildMessageAngle(candidate, recipient),
+      safeClaim: buildSafeClaim(candidate),
+      proofRequired: buildProofRequired(candidate),
+      nextAction: buildRecipientNextAction(candidate, recipient),
+      focus: rule.focus,
+    });
+  }
+
+  return packages;
+}
+
+function selectChannelsForCandidate(channels, candidate) {
+  if (candidate.websiteTargetPage.includes('stromdao.de')) {
+    return channels.filter((channel) => channel !== 'cernion.de');
+  }
+  if (candidate.websiteTargetPage.includes('corrently')) {
+    return channels.filter((channel) => channel !== 'stromdao.de');
+  }
+  return channels;
+}
+
+function inferSendReadiness(candidate, recipient) {
+  if (candidate.claimRisk === 'high') return 'blocked-claim-review';
+  if (recipient === 'Rhajaina') return 'review-package';
+  if (candidate.demoReadiness === 'demo-ready' && candidate.claimRisk === 'low')
+    return 'send-ready-draft';
+  if (candidate.demoReadiness === 'concept-only') return 'needs-story-packaging';
+  return 'needs-copy-review';
+}
+
+function buildMessageAngle(candidate, recipient) {
+  const endpointText = candidate.endpoints.length
+    ? `mit ${candidate.endpoints[0]} als prüfbarem API-Anker`
+    : 'als noch zu erzählende Capability ohne stabilen Endpoint-Anker';
+  if (recipient === 'Felix') return `B2B-Demo-Nutzen für Stadtwerke ${endpointText}.`;
+  if (recipient === 'Viki') return `Marktsignal und Zielsegment-Relevanz ${endpointText}.`;
+  if (recipient === 'Webmaster')
+    return `Public-Web-Draft für ${candidate.websiteTargetPage} ${endpointText}.`;
+  return `Claim-/Nachweisprüfung für ${candidate.capability} ${endpointText}.`;
+}
+
+function buildSafeClaim(candidate) {
+  const readiness = candidate.demoReadiness === 'demo-ready' ? 'demo-fähige' : 'prüfbare';
+  return `CET stellt eine ${readiness} Read-only-Fähigkeit für ${candidate.title} bereit.`;
+}
+
+function buildProofRequired(candidate) {
+  const proof = ['CHANGELOG-Eintrag', 'openapi-export.json'];
+  if (candidate.endpoints.length) proof.push(candidate.endpoints[0]);
+  if (candidate.claimRisk !== 'low') proof.push('fachliche Claim-Prüfung');
+  return proof;
+}
+
+function buildRecipientNextAction(candidate, recipient) {
+  if (recipient === 'Webmaster') return `Draft für ${candidate.websiteTargetPage} vorbereiten.`;
+  if (recipient === 'Felix')
+    return 'B2B-Anschreib-/Demo-Snippet mit belegbaren Grenzen formulieren.';
+  if (recipient === 'Viki') return 'Markt-Scouting auf passende Zielrollen/Trigger anreichern.';
+  return 'Claim-Risiko, No-Call-Grenzen und Nachweise prüfen.';
+}
+
+function extractCapability(entry) {
+  const explicit = Array.from(entry.text.matchAll(/`([^`]+)`/g))
+    .map((match) => match[1])
+    .find(
+      (value) =>
+        /(?:capability|endpoint|api|workflow|seed|backtest)/i.test(value) &&
+        !/^(?:GET|POST|PUT|PATCH|DELETE)\s+\/api\//i.test(value) &&
+        !/\.(?:js|json|md|html|css)$/i.test(value)
+    );
+  if (explicit) return explicit;
+  if (entry.title) return slugify(entry.title);
+  return slugify(entry.text) || 'release-capability';
+}
+
+function buildBacklogCandidates({ changelogMarkdown, openApiSpec, limit = 30 }) {
+  const entries = parseChangelogEntries(changelogMarkdown).filter((entry) =>
+    ['Added', 'Changed', 'Fixed', 'Security'].includes(entry.section)
+  );
+  const operations = loadOpenApiOperations(openApiSpec);
+
+  return entries.slice(0, limit).map((entry) => {
+    const relatedOperations = findRelatedOperations(entry, operations);
+    const risk = inferClaimRisk(entry);
+    const candidate = {
+      id: `${entry.release}:${slugify(entry.title)}`,
+      release: entry.release,
+      changelogSection: entry.section,
+      title: entry.title,
+      capability: extractCapability(entry),
+      endpoints: relatedOperations.map((op) => `${op.method} ${op.path}`),
+      serviceOrTag: relatedOperations[0]?.tags?.[0] || 'unmapped',
+      targetRole: inferTargetRole(entry, relatedOperations),
+      websiteTargetPage: inferWebsiteTarget(entry, relatedOperations),
+      demoReadiness: inferDemoReadiness(entry, relatedOperations),
+      claimRisk: risk.level,
+      claimRiskReasons: risk.reasons,
+      issueRefs: entry.issueRefs,
+      recommendedFollowUp: buildFollowUp(entry, relatedOperations, risk.level),
+    };
+    candidate.recommendedFollowUpAgent = inferRecommendedFollowUpAgent(candidate);
+    candidate.channelPackages = buildChannelPackages(candidate);
+    return candidate;
+  });
+}
+
+function buildFollowUp(entry, relatedOperations, claimRisk) {
+  const endpointText = relatedOperations.length
+    ? `Endpoint-Bezug prüfen: ${relatedOperations.map((op) => `${op.method} ${op.path}`).join(', ')}.`
+    : 'Capability zuerst in eine öffentliche Demo-/Story-Fläche übersetzen.';
+  const riskText =
+    claimRisk === 'high'
+      ? 'Vor Veröffentlichung Claim juristisch/fachlich härten.'
+      : 'Claim als read-only/guarded formulieren.';
+  return `${entry.section}-Release-Kandidat: ${endpointText} ${riskText}`;
+}
+
+function renderMarkdownReport(candidates, meta = {}) {
+  const lines = [
+    '# CET Public Website Backlog Candidates',
+    '',
+    'Read-only Ableitung aus CHANGELOG.md und openapi-export.json. Kein GitHub-/Website-/Kanban-Write.',
+    '',
+    `- generatedAt: ${meta.generatedAt || new Date().toISOString()}`,
+    `- candidateCount: ${candidates.length}`,
+    '',
+    '| Capability | Endpoint/Service | Zielrolle | Website-Zielseite | Demo-Reife | Claim-Risiko | Folge-Agent | Kanalpakete | Folgehinweis |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- | --- |',
+  ];
+
+  for (const candidate of candidates) {
+    lines.push(
+      [
+        candidate.capability,
+        candidate.endpoints.length ? candidate.endpoints.join('<br>') : candidate.serviceOrTag,
+        candidate.targetRole,
+        candidate.websiteTargetPage,
+        candidate.demoReadiness,
+        `${candidate.claimRisk}${candidate.claimRiskReasons.length ? ` (${candidate.claimRiskReasons.join(', ')})` : ''}`,
+        candidate.recommendedFollowUpAgent || inferRecommendedFollowUpAgent(candidate),
+        renderChannelPackageSummary(candidate.channelPackages || []),
+        candidate.recommendedFollowUp,
+      ]
+        .map(escapeMarkdownCell)
+        .join(' | ')
+        .replace(/^/, '| ')
+        .replace(/$/, ' |')
+    );
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function renderChannelPackageSummary(channelPackages) {
+  return channelPackages
+    .map((pkg) => `${pkg.recipient}: ${pkg.sendReadiness} via ${pkg.channels.join('/')}`)
+    .join('<br>');
+}
+
+function escapeMarkdownCell(value) {
+  return String(value || '')
+    .replace(/\|/g, '\\|')
+    .replace(/\r?\n/g, '<br>');
+}
+
+function parseArgs(argv) {
+  return {
+    json: argv.includes('--json'),
+    limit: Number(argv.find((arg) => arg.startsWith('--limit='))?.split('=')[1] || 30),
+    changelogPath:
+      argv
+        .find((arg) => arg.startsWith('--changelog='))
+        ?.split('=')
+        .slice(1)
+        .join('=') || DEFAULT_CHANGELOG_PATH,
+    openapiPath:
+      argv
+        .find((arg) => arg.startsWith('--openapi='))
+        ?.split('=')
+        .slice(1)
+        .join('=') || DEFAULT_OPENAPI_PATH,
+  };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const changelogMarkdown = fs.readFileSync(options.changelogPath, 'utf8');
+  const openApiSpec = JSON.parse(fs.readFileSync(options.openapiPath, 'utf8'));
+  const generatedAt = new Date().toISOString();
+  const candidates = buildBacklogCandidates({
+    changelogMarkdown,
+    openApiSpec,
+    limit: options.limit,
+  });
+
+  if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify({ schemaVersion: 'cernion.publicWebsiteBacklog.v2', generatedAt, candidates }, null, 2)}\n`
+    );
+    return;
+  }
+
+  process.stdout.write(renderMarkdownReport(candidates, { generatedAt }));
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  buildChannelPackages,
+  buildBacklogCandidates,
+  extractCapability,
+  findRelatedOperations,
+  inferClaimRisk,
+  inferDemoReadiness,
+  inferRecommendedFollowUpAgent,
+  loadOpenApiOperations,
+  parseChangelogEntries,
+  renderMarkdownReport,
+};

--- a/scripts/generate-public-website-backlog.js
+++ b/scripts/generate-public-website-backlog.js
@@ -347,9 +347,13 @@ function inferRecommendedFollowUpAgent(candidate) {
   if (candidate.targetRole === 'Felix' && candidate.demoReadiness === 'demo-ready') {
     return 'felix-demo-sales';
   }
-  if (candidate.websiteTargetPage.includes('corrently.io')) return 'devops-api-check';
+  if (hasSiteHost(candidate.websiteTargetPage, 'corrently.io')) return 'devops-api-check';
   if (candidate.endpoints.length > 0) return 'webmaster';
   return 'rhajaina-claim-review';
+}
+
+function hasSiteHost(sitePath, expectedHost) {
+  return String(sitePath || '').split('/')[0] === expectedHost;
 }
 
 function buildChannelPackages(candidate) {
@@ -534,6 +538,7 @@ function renderChannelPackageSummary(channelPackages) {
 
 function escapeMarkdownCell(value) {
   return String(value || '')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/\r?\n/g, '<br>');
 }

--- a/tests/extract-release-signals.test.js
+++ b/tests/extract-release-signals.test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const {
+  buildReleaseSignals,
+  extractOpenApiOperations,
+  parseChangelogEntries,
+  renderMarkdownReport,
+} = require('../scripts/extract-release-signals');
+
+const fixtureOpenApi = {
+  openapi: '3.0.0',
+  info: { title: 'Cernion Energy Tools API', version: '0.67.test' },
+  paths: {
+    '/api/dashboard/municipal-energy-value-analysis': {
+      get: {
+        operationId: 'dashboard_municipalEnergyValueAnalysisStatus',
+        summary: 'Municipal Energy Value Lagebild Endpoint',
+        description: 'Read-only municipal energy value analysis for public evidence work.',
+        tags: ['Dashboard API'],
+      },
+    },
+    '/api/energy-market/portfolio-backtest': {
+      post: {
+        operationId: 'energy-market_portfolioBacktest',
+        summary: 'Historical portfolio market value backtest',
+        tags: ['Energy Market'],
+      },
+    },
+  },
+};
+
+const fixtureChangelog = `
+# Changelog
+
+## Unreleased
+
+### Added
+- **Municipal Energy Value Lagebild Endpoint** (\`services/dashboard-api.service.js\`, #324): New endpoint \`GET /api/dashboard/municipal-energy-value-analysis\` exposes read-only rows for public evidence work.
+
+## [0.67.10] — 2026-07-01
+
+### Changed
+- **portfolioBacktest runs as async background job** (\`services/energy-market.service.js\`, #357): The endpoint \`POST /api/energy-market/portfolio-backtest\` now returns 202 job links.
+`;
+
+describe('extract-release-signals', () => {
+  describe('parseChangelogEntries', () => {
+    it('extracts release hints, issue refs, and endpoint refs', () => {
+      const entries = parseChangelogEntries(fixtureChangelog);
+
+      expect(entries).toHaveLength(2);
+      expect(entries[0]).toMatchObject({
+        release: 'Unreleased',
+        section: 'Added',
+        title: 'Municipal Energy Value Lagebild Endpoint',
+        issueRefs: ['#324'],
+        endpointRefs: ['GET /api/dashboard/municipal-energy-value-analysis'],
+      });
+      expect(entries[1]).toMatchObject({
+        release: '0.67.10',
+        releaseDate: '2026-07-01',
+        endpointRefs: ['POST /api/energy-market/portfolio-backtest'],
+      });
+    });
+  });
+
+  describe('extractOpenApiOperations', () => {
+    it('extracts method, path, service, tags, summaries, and descriptions', () => {
+      expect(extractOpenApiOperations(fixtureOpenApi)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            method: 'GET',
+            path: '/api/dashboard/municipal-energy-value-analysis',
+            service: 'Dashboard API',
+            tags: ['Dashboard API'],
+            summary: 'Municipal Energy Value Lagebild Endpoint',
+          }),
+        ])
+      );
+    });
+
+    it('rejects OpenAPI documents without a paths object', () => {
+      expect(() => extractOpenApiOperations({ info: {} })).toThrow('paths object');
+    });
+  });
+
+  describe('buildReleaseSignals', () => {
+    it('builds neutral raw signals with extraction/publication boundary', () => {
+      const report = buildReleaseSignals({
+        changelogMarkdown: fixtureChangelog,
+        openApiSpec: fixtureOpenApi,
+        limit: 10,
+      });
+
+      expect(report).toMatchObject({
+        schemaVersion: 'cernion.releaseSignals.v1',
+        extractionOnly: true,
+        openapi: {
+          title: 'Cernion Energy Tools API',
+          version: '0.67.test',
+          pathCount: 2,
+          operationCount: 2,
+        },
+        changelog: { entryCount: 2, latestRelease: 'Unreleased' },
+      });
+      expect(report.publicationBoundary).toContain('No GitHub issues');
+      expect(report.signals.endpointSignals).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            changeClass: 'changelog-added',
+            method: 'GET',
+            path: '/api/dashboard/municipal-energy-value-analysis',
+            changelogLinks: [expect.objectContaining({ release: 'Unreleased' })],
+            publicationBoundary: 'raw-extraction-only',
+          }),
+          expect.objectContaining({
+            changeClass: 'changelog-changed',
+            method: 'POST',
+            path: '/api/energy-market/portfolio-backtest',
+          }),
+        ])
+      );
+      expect(report.signals.serviceSignals[0]).toHaveProperty(
+        'publicationBoundary',
+        'raw-extraction-only'
+      );
+    });
+  });
+
+  describe('renderMarkdownReport', () => {
+    it('renders endpoint and changelog sections plus publication boundary', () => {
+      const report = buildReleaseSignals({
+        changelogMarkdown: fixtureChangelog,
+        openApiSpec: fixtureOpenApi,
+        limit: 2,
+      });
+      const markdown = renderMarkdownReport(report);
+
+      expect(markdown).toContain('# CET Release Signal Extraction Report');
+      expect(markdown).toContain('GET | /api/dashboard/municipal-energy-value-analysis');
+      expect(markdown).toContain('Trennung Extraction vs. Veröffentlichung');
+      expect(markdown).toContain('schreibt nicht in GitHub');
+    });
+  });
+
+  describe('CLI error handling', () => {
+    it('returns a clear error for missing files', () => {
+      const result = spawnSync(
+        process.execPath,
+        ['scripts/extract-release-signals.js', '--changelog=/tmp/cet-missing-changelog.md'],
+        { cwd: path.join(__dirname, '..'), encoding: 'utf8' }
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('MISSING_FILE');
+    });
+
+    it('returns a clear error for invalid JSON', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cet-release-signals-'));
+      const changelogPath = path.join(tmpDir, 'CHANGELOG.md');
+      const openapiPath = path.join(tmpDir, 'openapi.json');
+      fs.writeFileSync(changelogPath, fixtureChangelog, 'utf8');
+      fs.writeFileSync(openapiPath, '{not-json', 'utf8');
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          'scripts/extract-release-signals.js',
+          `--changelog=${changelogPath}`,
+          `--openapi=${openapiPath}`,
+        ],
+        { cwd: path.join(__dirname, '..'), encoding: 'utf8' }
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('INVALID_JSON');
+    });
+  });
+});

--- a/tests/generate-public-website-backlog.test.js
+++ b/tests/generate-public-website-backlog.test.js
@@ -1,0 +1,265 @@
+'use strict';
+
+const {
+  buildChannelPackages,
+  buildBacklogCandidates,
+  inferClaimRisk,
+  inferDemoReadiness,
+  loadOpenApiOperations,
+  parseChangelogEntries,
+  renderMarkdownReport,
+} = require('../scripts/generate-public-website-backlog');
+
+const fixtureOpenApi = {
+  paths: {
+    '/api/energy-market/portfolio-backtest': {
+      post: {
+        operationId: 'energy-market_portfolioBacktest',
+        summary: 'Historical portfolio market value backtest',
+        tags: ['Energy Market'],
+        'x-ui-page': 'energy-market',
+      },
+    },
+    '/api/dashboard/municipal-energy-value-analysis': {
+      get: {
+        operationId: 'dashboard_municipalEnergyValueAnalysisStatus',
+        summary: 'Municipal Energy Value Lagebild Endpoint',
+        tags: ['Dashboard API'],
+        'x-ui-page': 'dashboard',
+      },
+    },
+  },
+};
+
+describe('generate-public-website-backlog', () => {
+  describe('parseChangelogEntries', () => {
+    it('extracts release, section, title, body, and issue references', () => {
+      const entries = parseChangelogEntries(`
+# Changelog
+
+## [0.67.10] — 2026-07-01
+
+### Added
+- **Historical portfolio market value backtest** (\`services/energy-market.service.js\`, #357): New endpoint \`POST /api/energy-market/portfolio-backtest\` computes market value.
+  - Includes no-call guardrails.
+`);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        release: '0.67.10',
+        section: 'Added',
+        title: 'Historical portfolio market value backtest',
+        issueRefs: ['#357'],
+      });
+      expect(entries[0].text).toContain('no-call guardrails');
+    });
+  });
+
+  describe('loadOpenApiOperations', () => {
+    it('extracts HTTP operations with UI annotations and tags', () => {
+      const operations = loadOpenApiOperations(fixtureOpenApi);
+      expect(operations).toEqual([
+        expect.objectContaining({
+          method: 'POST',
+          path: '/api/energy-market/portfolio-backtest',
+          operationId: 'energy-market_portfolioBacktest',
+          uiPage: 'energy-market',
+          tags: ['Energy Market'],
+        }),
+        expect.objectContaining({
+          method: 'GET',
+          path: '/api/dashboard/municipal-energy-value-analysis',
+        }),
+      ]);
+    });
+  });
+
+  describe('buildBacklogCandidates', () => {
+    it('maps changelog entries to public backlog fields', () => {
+      const changelogMarkdown = `
+## [0.67.10] — 2026-07-01
+
+### Added
+- **Historical portfolio market value backtest** (\`services/energy-market.service.js\`, #357): New endpoint \`POST /api/energy-market/portfolio-backtest\` computes the Day-Ahead spot market value for an asset portfolio. Includes read-only no-call guardrails and demo-ready API output.
+`;
+
+      const [candidate] = buildBacklogCandidates({
+        changelogMarkdown,
+        openApiSpec: fixtureOpenApi,
+      });
+      expect(candidate).toMatchObject({
+        capability: 'historical-portfolio-market-value-backtest',
+        endpoints: ['POST /api/energy-market/portfolio-backtest'],
+        serviceOrTag: 'Energy Market',
+        targetRole: 'Felix',
+        websiteTargetPage: 'cernion.de/energy-market-api',
+        demoReadiness: 'demo-ready',
+        claimRisk: 'low',
+      });
+      expect(candidate.recommendedFollowUp).toContain('Endpoint-Bezug prüfen');
+      expect(candidate.channelPackages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            recipient: 'Felix',
+            channels: expect.arrayContaining(['LinkedIn', 'Pubbler', 'B2B-E-Mail-Kontakte']),
+            sendReadiness: 'send-ready-draft',
+            safeClaim: expect.stringContaining('Read-only-Fähigkeit'),
+          }),
+          expect.objectContaining({
+            recipient: 'Webmaster',
+            channels: expect.arrayContaining(['cernion.de', 'corrently.io', 'stromdao.de']),
+          }),
+          expect.objectContaining({ recipient: 'Viki' }),
+          expect.objectContaining({ recipient: 'Rhajaina', sendReadiness: 'review-package' }),
+        ])
+      );
+    });
+
+    it('keeps unmapped capabilities visible as concept-only candidates', () => {
+      const changelogMarkdown = `
+## Unreleased
+
+### Added
+- **VDMI Blueprint Pack seed**: Adds a read-only seed with explicit no-call guards and evidence gates.
+`;
+
+      const [candidate] = buildBacklogCandidates({
+        changelogMarkdown,
+        openApiSpec: fixtureOpenApi,
+      });
+      expect(candidate.endpoints).toEqual([]);
+      expect(candidate.websiteTargetPage).toBe('cernion.de/vdmi-governance');
+      expect(candidate.demoReadiness).toBe('concept-only');
+      expect(candidate.claimRisk).toBe('low');
+    });
+
+    it('acceptance: turns example changelog and OpenAPI into at least two routed report candidates', () => {
+      const changelogMarkdown = `
+# Changelog
+
+## [0.68.0] — 2026-07-22
+
+### Added
+- **Municipal Energy Value Lagebild Endpoint** (#501): New endpoint \`GET /api/dashboard/municipal-energy-value-analysis\` exposes read-only dashboard rows with SLP proxy evidence and no billing relevance.
+- **Historical portfolio market value backtest** (#502): New endpoint \`POST /api/energy-market/portfolio-backtest\` provides demo-ready read-only market value backtests with no-call guardrails.
+`;
+
+      const candidates = buildBacklogCandidates({
+        changelogMarkdown,
+        openApiSpec: fixtureOpenApi,
+      });
+
+      expect(candidates).toHaveLength(2);
+      expect(candidates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            capability: 'municipal-energy-value-lagebild-endpoint',
+            endpoints: ['GET /api/dashboard/municipal-energy-value-analysis'],
+            serviceOrTag: 'Dashboard API',
+            targetRole: expect.any(String),
+            websiteTargetPage: 'cernion.de/kommunale-energiedaten',
+            demoReadiness: expect.stringMatching(/needs-demo-copy-review|demo-ready/),
+            claimRisk: expect.stringMatching(/low|medium/),
+            recommendedFollowUpAgent: expect.stringMatching(
+              /webmaster|felix-demo-sales|rhajaina-claim-review|devops-api-check/
+            ),
+          }),
+          expect.objectContaining({
+            capability: 'historical-portfolio-market-value-backtest',
+            endpoints: ['POST /api/energy-market/portfolio-backtest'],
+            serviceOrTag: 'Energy Market',
+            targetRole: expect.any(String),
+            websiteTargetPage: 'cernion.de/energy-market-api',
+            demoReadiness: 'demo-ready',
+            claimRisk: 'low',
+            recommendedFollowUpAgent: 'felix-demo-sales',
+          }),
+        ])
+      );
+    });
+  });
+
+  describe('risk/readiness helpers', () => {
+    it('marks public billing/settlement claims as high risk without guardrails', () => {
+      expect(
+        inferClaimRisk({ text: 'Guarantee settlement approval and billing automation.' })
+      ).toEqual({
+        level: 'high',
+        reasons: ['guarantee', 'settlement', 'approval'],
+      });
+    });
+
+    it('requires demo copy review when an endpoint has guardrails but no demo signal', () => {
+      expect(
+        inferDemoReadiness({ text: 'Read-only endpoint with no-call guardrails.' }, [
+          { method: 'GET', path: '/api/dashboard/example' },
+        ])
+      ).toBe('needs-demo-copy-review');
+    });
+  });
+
+  describe('buildChannelPackages', () => {
+    it('blocks external send-readiness for high-risk claims and keeps proof requirements', () => {
+      const packages = buildChannelPackages({
+        title: 'Billing approval automation',
+        capability: 'billing-approval-automation',
+        endpoints: ['POST /api/billing/approve'],
+        targetRole: 'Felix',
+        websiteTargetPage: 'cernion.de/api',
+        demoReadiness: 'api-visible-needs-demo-story',
+        claimRisk: 'high',
+      });
+
+      expect(packages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            recipient: 'Felix',
+            sendReadiness: 'blocked-claim-review',
+            proofRequired: expect.arrayContaining([
+              'CHANGELOG-Eintrag',
+              'openapi-export.json',
+              'POST /api/billing/approve',
+              'fachliche Claim-Prüfung',
+            ]),
+          }),
+        ])
+      );
+      expect(packages.map((pkg) => pkg.recipient)).not.toContain('Viki');
+    });
+  });
+
+  describe('renderMarkdownReport', () => {
+    it('renders the required public-backlog columns', () => {
+      const report = renderMarkdownReport(
+        [
+          {
+            capability: 'portfolioBacktest',
+            endpoints: ['POST /api/energy-market/portfolio-backtest'],
+            serviceOrTag: 'Energy Market',
+            targetRole: 'Felix',
+            websiteTargetPage: 'cernion.de/energy-market-api',
+            demoReadiness: 'demo-ready',
+            claimRisk: 'low',
+            claimRiskReasons: ['read-only'],
+            channelPackages: [
+              {
+                recipient: 'Felix',
+                channels: ['LinkedIn', 'Pubbler'],
+                sendReadiness: 'send-ready-draft',
+              },
+            ],
+            recommendedFollowUp: 'Claim als read-only formulieren.',
+          },
+        ],
+        { generatedAt: '2026-07-21T00:00:00.000Z' }
+      );
+
+      expect(report).toContain('Capability | Endpoint/Service | Zielrolle | Website-Zielseite');
+      expect(report).toContain('Folge-Agent');
+      expect(report).toContain('POST /api/energy-market/portfolio-backtest');
+      expect(report).toContain('demo-ready');
+      expect(report).toContain('Kanalpakete');
+      expect(report).toContain('Felix: send-ready-draft via LinkedIn/Pubbler');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add read-only CHANGELOG/OpenAPI release-signal extraction (`extract:release-signals`)
- add public-website backlog candidate generation with capability, endpoint/service, target role, website target page, demo readiness, claim risk, follow-up agent, and channel packages
- add internal docs for schema, rubric, routing, extractor, and the E2E report concept
- add focused Jest acceptance coverage for the example changelog + example OpenAPI flow

## Verification
- `npm run build`
- `node --check scripts/extract-release-signals.js`
- `node --check scripts/generate-public-website-backlog.js`
- `npx jest tests/extract-release-signals.test.js tests/generate-public-website-backlog.test.js --runInBand --forceExit`
- `npx eslint scripts/extract-release-signals.js scripts/generate-public-website-backlog.js tests/extract-release-signals.test.js tests/generate-public-website-backlog.test.js`
- `npx prettier --check scripts/extract-release-signals.js scripts/generate-public-website-backlog.js tests/extract-release-signals.test.js tests/generate-public-website-backlog.test.js docs/PUBLIC_WEBSITE_BACKLOG_AGENT_ROUTING.md docs/PUBLIC_WEBSITE_BACKLOG_E2E_REPORT_CONCEPT.md docs/PUBLIC_WEBSITE_BACKLOG_RUBRIC.md docs/public-website-backlog-candidate-schema.md docs/release-signal-extractor.md package.json`

## Safety / non-goals
- no automatic GitHub issue creation beyond this PR
- no website/CMS/BookStack writes
- no deploys, restarts, external sends, or CRM writes
- no TWL raw-context transfer

Kanban: t_8fc173cd
