### PR TITLE
feat: route Willi-Mako context through agent surfaces (#498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- **Route Willi-Mako MaKo context through Capability Broker, CoPilot and Sidecar** (`src/capability-catalog.js`, `services/capability-broker.service.js`, `services/personal-agent.service.js`, `tests/capability-broker.service.test.js`, `tests/agent-sidecar-willi-mako-routing.test.js`, `tests/personal-agent-willi-mako-evidence.test.js`, #498): Extends the existing read-only `market_communication_evidence_chain` capability so generic MaKo/EDIFACT code-context questions (`APERAK`, `UTILMD`, `MSCONS`, `EDIFACT`, Fehlercode/Prüfidentifikator/Nachrichtentyp/Segmentstruktur) can surface `willi-mako.resolveStructure` / `willi-mako.search` through Capability Broker recommendations and existing Sidecar discovery (`cernion.recommend_capability`). `personal-agent.askCernionAgent` now optionally enriches CoPilot answers with advisory Willi-Mako evidence via `ctx.call('willi-mako.resolveStructure', ...)`, capped at conservative limits and failing open to `unavailable` without failing the answer. The routing is deliberately generic — `Z17` is only an acceptance-test example, not a special case — and preserves no-call boundaries: no APERAK/UTILMD/MSCONS/EDIFACT message creation, validation, dispatch, mutation, legal final decision, HITL/workflow, billing/settlement/tariff/device-control or external connector action is performed.
+
 ## [0.67.9] — 2026-07-24
 
 ### Fixed

--- a/llm.txt
+++ b/llm.txt
@@ -246,11 +246,11 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: e0dd9a0467715fc298a7e201aa9905f6043eeda05bd51bc43c9c174e22bcd5ae
+- CHANGELOG.md: ee39171b5f72737852419c60d5506d3f1b821624e2ea26d8a232e8435f4ddced
 - README.md: 20212e8ece52ae9dfb251bdd93b4a9d719f6887623f9b11b6c542b719b49c29f
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
-- src/capability-catalog.js: 4abecc2ae81b220b9e5f812225413f094eb36da4876d2546092720b817a85d12
+- src/capability-catalog.js: 6ae98f1fe24fe8fafdc6c0e0630c1c37cd0f2eada865bf7df95caee4f3d4b4d7
 - openapi-export.json: d501f75e91e8a7ebffc78768ac4e67c6b66734a7f075b7eba2f169057e172f6a
 
 ## OpenAPI Surface (full contract, not embedded)
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 939b1cb67ddc585405831f10a176738e1167891b4a5330ac3d16a6bd9c4fd2c7
+- llm_txt_sha256: 961a7f6abdea66edbb2e0d8a7adbc0cb996cb3c0d73f0490ad38e819eab3d4c9

--- a/llm.txt
+++ b/llm.txt
@@ -250,7 +250,7 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - README.md: 20212e8ece52ae9dfb251bdd93b4a9d719f6887623f9b11b6c542b719b49c29f
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
-- src/capability-catalog.js: 6ae98f1fe24fe8fafdc6c0e0630c1c37cd0f2eada865bf7df95caee4f3d4b4d7
+- src/capability-catalog.js: 7faf4ceef8ab42b19ba6cafe8b4b3917793f881b5ef6b4761f64aab7f8189f44
 - openapi-export.json: d501f75e91e8a7ebffc78768ac4e67c6b66734a7f075b7eba2f169057e172f6a
 
 ## OpenAPI Surface (full contract, not embedded)
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 961a7f6abdea66edbb2e0d8a7adbc0cb996cb3c0d73f0490ad38e819eab3d4c9
+- llm_txt_sha256: 713ad96f3b7bae883539b9045144f67f033fc1ed45e890242ee282e42db0055a

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -79641,7 +79641,7 @@
       "agentable": true,
       "nonAgentableReason": null,
       "capabilityCandidates": [
-        "willi-mako.resolve_structure"
+        "market_communication_evidence_chain"
       ],
       "domains": [
         "market-data"
@@ -79743,7 +79743,7 @@
       "agentable": true,
       "nonAgentableReason": null,
       "capabilityCandidates": [
-        "willi-mako.search"
+        "market_communication_evidence_chain"
       ],
       "domains": [
         "market-data"

--- a/services/capability-broker.service.js
+++ b/services/capability-broker.service.js
@@ -5,6 +5,7 @@ const {
   GLOBAL_DO_NOT_USE,
 } = require('../src/capability-catalog');
 const { buildServiceCatalogue } = require('../src/agent-planning-utils');
+const { hasMakoEdifactCodeContextSignal } = require('../src/mako-edifact-signal');
 
 const {
   listCompiledDomainRoutes,
@@ -1518,13 +1519,7 @@ function findBestCapability(taskText, options = {}) {
   // evidence-chain-specific combo above so a genuine evidence-chain proof request still
   // wins on its own more specific signals; this block instead catches "explain this
   // MaKo/EDIFACT code/segment/message-type" style questions that don't mention evidence.
-  const hasMakoEdifactCodeContextSignal =
-    /(aperak|utilmd|mscons|edifact)/i.test(haystack) &&
-    /(fehlercode|prüfidentifikator|pruefidentifikator|nachrichtentyp|segmentstruktur|segment|prüfhinweis|pruefhinweis|erkl[aä]r|bedeutet|marktkommunikation|mako.?kontext|\bmako\b)/i.test(
-      haystack
-    );
-
-  if (hasMakoEdifactCodeContextSignal) {
+  if (hasMakoEdifactCodeContextSignal(haystack)) {
     const makoCodeContextCapability = findCapabilityByName('market_communication_evidence_chain');
     if (makoCodeContextCapability) {
       return { capability: makoCodeContextCapability, score: 132, usedFallback: false };

--- a/services/capability-broker.service.js
+++ b/services/capability-broker.service.js
@@ -1511,6 +1511,26 @@ function findBestCapability(taskText, options = {}) {
     }
   }
 
+  // ── Generic MaKo/EDIFACT code-context questions (energychain/cernion-energy-tools#498)
+  // Deliberately generic (APERAK/UTILMD/MSCONS/EDIFACT + Fehlercode/Prüfidentifikator/
+  // Nachrichtentyp/Segmentstruktur/explanatory intent) — no Z17-only special case. Z17 is
+  // used only as an acceptance-test example for this generic routing. Placed after the
+  // evidence-chain-specific combo above so a genuine evidence-chain proof request still
+  // wins on its own more specific signals; this block instead catches "explain this
+  // MaKo/EDIFACT code/segment/message-type" style questions that don't mention evidence.
+  const hasMakoEdifactCodeContextSignal =
+    /(aperak|utilmd|mscons|edifact)/i.test(haystack) &&
+    /(fehlercode|prüfidentifikator|pruefidentifikator|nachrichtentyp|segmentstruktur|segment|prüfhinweis|pruefhinweis|erkl[aä]r|bedeutet|marktkommunikation|mako.?kontext|\bmako\b)/i.test(
+      haystack
+    );
+
+  if (hasMakoEdifactCodeContextSignal) {
+    const makoCodeContextCapability = findCapabilityByName('market_communication_evidence_chain');
+    if (makoCodeContextCapability) {
+      return { capability: makoCodeContextCapability, score: 132, usedFallback: false };
+    }
+  }
+
   // ── Redispatch/RCS Special Case Governance — must precede VDMI decision check
   // 'vergütungszusage' + 'netzbetreiber' combo would otherwise trigger VDMI grid-connection
   // decision governance (score 130). RCS/Expost signals narrow the domain unambiguously.
@@ -2780,6 +2800,12 @@ function buildActionTemplate(action) {
       limit: 3,
     };
   }
+  if (action === 'willi-mako.search' || action === 'willi-mako.resolveStructure') {
+    return {
+      query: null,
+      limit: 5,
+    };
+  }
   if (action === 'grid-operations.vnbLookup') {
     return {
       bdew: '__step_1.data.results[0].bdewCode',
@@ -3013,6 +3039,12 @@ function interpolateTemplateWithKnownContext(
   if (action === 'grid-operations.marketPartners') {
     if (hydrated.query === null || hydrated.query === undefined || hydrated.query === '') {
       hydrated.query = queryCandidate;
+    }
+  }
+
+  if (action === 'willi-mako.search' || action === 'willi-mako.resolveStructure') {
+    if (hydrated.query === null || hydrated.query === undefined || hydrated.query === '') {
+      hydrated.query = knownContext.query || String(taskText || '').trim() || null;
     }
   }
 

--- a/services/personal-agent.service.js
+++ b/services/personal-agent.service.js
@@ -1026,6 +1026,21 @@ function isCopilotEnergySharingQuestion(question) {
   );
 }
 
+/**
+ * Generic MaKo/EDIFACT code-context signal (energychain/cernion-energy-tools#498).
+ * Deliberately generic — no Z17-only special case; Z17 is used only as an
+ * acceptance-test example for this generic routing.
+ */
+function isCopilotMakoEdifactQuestion(question) {
+  const text = String(question || '').toLowerCase();
+  return (
+    /(aperak|utilmd|mscons|edifact)/i.test(text) &&
+    /(fehlercode|prüfidentifikator|pruefidentifikator|nachrichtentyp|segmentstruktur|segment|prüfhinweis|pruefhinweis|erkl[aä]r|bedeutet|marktkommunikation|mako.?kontext|\bmako\b)/i.test(
+      text
+    )
+  );
+}
+
 function extractCopilotAnalysisSignals(question) {
   const text = String(question || '');
   const lower = text.toLowerCase();
@@ -2584,6 +2599,7 @@ module.exports = {
           datapointEvidence,
           objectEvidence,
           planningEvidence,
+          makoKnowledgeEvidence,
         ] = await Promise.all([
           this.searchCopilotEntities(ctx, { searchTerm, searchDomain, maxEvidence }),
           this.collectCopilotKnowledgeEvidence(ctx, {
@@ -2594,6 +2610,10 @@ module.exports = {
           this.collectCopilotDatapointEvidence(ctx, { queryTerms, maxEvidence }),
           this.collectCopilotObjectEvidence(ctx, { context, queryTerms, maxEvidence }),
           this.collectCopilotPlanningEvidence(ctx, { analysisSignals, maxEvidence }),
+          this.collectCopilotMakoKnowledgeEvidence(ctx, {
+            question: ctx.params.question,
+            maxEvidence,
+          }),
         ]);
 
         const baseAnswer = this.buildCopilotSearchAnswer({
@@ -2608,6 +2628,7 @@ module.exports = {
           datapointEvidence,
           objectEvidence,
           planningEvidence,
+          makoKnowledgeEvidence,
           maxEvidence,
         });
         const enhancedAnswer = await this.enhanceCopilotAnswerWithConsultingBrief(ctx, baseAnswer, {
@@ -8438,6 +8459,65 @@ module.exports = {
       }
     },
 
+    /**
+     * Optional, advisory Willi-Mako / Marktkommunikation knowledge context for
+     * generic MaKo/EDIFACT code-context questions (APERAK/UTILMD/MSCONS/EDIFACT
+     * Fehlercode, Prüfidentifikator, Nachrichtentyp, Segmentstruktur, ...).
+     * Only called when isCopilotMakoEdifactQuestion() detects such a question —
+     * never unconditionally. Read-only via willi-mako.resolveStructure with a
+     * conservative limit; degrades to unavailable/skipped on any failure so a
+     * knowledge-service outage never fails askCernionAgent. Never upgrades
+     * confidence by itself (energychain/cernion-energy-tools#498).
+     */
+    async collectCopilotMakoKnowledgeEvidence(ctx, { question, maxEvidence = 5 } = {}) {
+      if (!isCopilotMakoEdifactQuestion(question)) {
+        return { source: 'willi-mako', status: 'skipped', hits: [], trace: { hitCount: 0 } };
+      }
+      try {
+        const result = await ctx.call('willi-mako.resolveStructure', {
+          query: compactString(question, 600),
+          limit: Math.min(Math.max(Number(maxEvidence) || 5, 1), 5),
+        });
+        if (!result || result.success === false) {
+          return {
+            source: 'willi-mako',
+            status: 'unavailable',
+            hits: [],
+            trace: { hitCount: 0, error: result?.error?.code || 'MAKO_KNOWLEDGE_UNAVAILABLE' },
+          };
+        }
+        const sources = Array.isArray(result.data?.sources) ? result.data.sources : [];
+        const hits = toCopilotList(
+          sources,
+          (entry) => ({
+            source: 'willi-mako',
+            value: compactString(
+              [entry.title, entry.url ? `URL: ${entry.url}` : null].filter(Boolean).join(' · '),
+              400
+            ),
+            metadata: { sourceId: entry.id || null, score: entry.score ?? null },
+          }),
+          maxEvidence
+        );
+        return {
+          source: 'willi-mako',
+          status: hits.length > 0 ? 'available' : 'missing',
+          hits,
+          noCallBoundaries: Array.isArray(result.data?.noCallBoundaries)
+            ? result.data.noCallBoundaries
+            : [],
+          trace: { hitCount: hits.length, confidence: result.data?.confidence || 'none' },
+        };
+      } catch (_err) {
+        return {
+          source: 'willi-mako',
+          status: 'unavailable',
+          hits: [],
+          trace: { hitCount: 0, error: 'MAKO_KNOWLEDGE_UNAVAILABLE' },
+        };
+      }
+    },
+
     async collectCopilotKnowledgeEvidence(ctx, { question, searchTerm, maxEvidence = 5 } = {}) {
       const query = compactString([searchTerm, question].filter(Boolean).join(' · '), 600);
       const result = await queryKnowledgeEvidenceAdapter(ctx, {
@@ -8847,6 +8927,7 @@ module.exports = {
       datapointEvidence = { status: 'unavailable', hits: [] },
       objectEvidence = { status: 'unavailable', hits: [] },
       planningEvidence = { status: 'skipped', hits: [] },
+      makoKnowledgeEvidence = { status: 'skipped', hits: [] },
       maxEvidence = 5,
     } = {}) {
       const results = Array.isArray(searchResult.results) ? searchResult.results : [];
@@ -8909,12 +8990,20 @@ module.exports = {
         datapointEvidence.status ? `datapoints:${datapointEvidence.status}` : null,
         objectEvidence.status ? `objects:${objectEvidence.status}` : null,
         planningEvidence.status ? `planner:${planningEvidence.status}` : null,
+        makoKnowledgeEvidence.status && makoKnowledgeEvidence.status !== 'skipped'
+          ? `makoKnowledge:${makoKnowledgeEvidence.status}`
+          : null,
       ].filter(Boolean);
       const guardrails = [
         'Copilot soll Knowledge-RAG, Datapoints und Object-Store-Evidence als Antwortkontext nutzen.',
         'Copilot darf Evidence-Snippets nutzernah zusammenfassen, auch wenn daraus keine perfekte Kurzantwort ableitbar ist.',
         'Copilot darf keine Ausführungs-, Lösch-, Signatur-, Override- oder Nominierungsaktion durchführen.',
         'Bei fehlender oder widersprüchlicher Evidence muss Copilot Unsicherheit benennen und darf gezielt nach fehlendem Kontext fragen.',
+        ...(makoKnowledgeEvidence.status === 'available'
+          ? [
+              'Willi-Mako Marktkommunikations-Kontext ist unverbindlicher Wissens-/Struktur-Hinweis, kein offizieller MaKo-Nachweis und keine Anweisung zum Versand einer APERAK/UTILMD/MSCONS-Nachricht.',
+            ]
+          : []),
       ];
 
       const risks = [
@@ -9006,6 +9095,7 @@ module.exports = {
           datapoints: datapointEvidence,
           objects: objectEvidence,
           planning: planningEvidence,
+          makoKnowledge: makoKnowledgeEvidence,
         },
         guardrails,
         processContext,

--- a/services/personal-agent.service.js
+++ b/services/personal-agent.service.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const { MoleculerClientError } = require('moleculer').Errors;
 const jobStore = require('../src/job-store');
 const { getTenantId, tenantNamespace } = require('../src/tenant-context');
+const { hasMakoEdifactCodeContextSignal } = require('../src/mako-edifact-signal');
 const {
   buildContextStack,
   buildPersistableSessionState,
@@ -1032,13 +1033,7 @@ function isCopilotEnergySharingQuestion(question) {
  * acceptance-test example for this generic routing.
  */
 function isCopilotMakoEdifactQuestion(question) {
-  const text = String(question || '').toLowerCase();
-  return (
-    /(aperak|utilmd|mscons|edifact)/i.test(text) &&
-    /(fehlercode|prüfidentifikator|pruefidentifikator|nachrichtentyp|segmentstruktur|segment|prüfhinweis|pruefhinweis|erkl[aä]r|bedeutet|marktkommunikation|mako.?kontext|\bmako\b)/i.test(
-      text
-    )
-  );
+  return hasMakoEdifactCodeContextSignal(question);
 }
 
 function extractCopilotAnalysisSignals(question) {

--- a/src/capability-catalog.js
+++ b/src/capability-catalog.js
@@ -8470,19 +8470,6 @@ const CURATED_CAPABILITIES = [
       'imsys abrechnungsreife',
       'portal screenshot proof',
       'portalhinweis nachweis',
-      // Generic MaKo/EDIFACT code-context signals (energychain/cernion-energy-tools#498).
-      // Kept generic on purpose — no Z17-only special case; Z17 is used only as an
-      // acceptance-test example for this generic routing.
-      'aperak',
-      'utilmd',
-      'mscons',
-      'edifact',
-      'fehlercode',
-      'prüfidentifikator',
-      'pruefidentifikator',
-      'nachrichtentyp',
-      'mako',
-      'marktkommunikation',
     ],
     preferredActions: [
       'dashboard-api.marketCommunicationEvidenceChainStatus',

--- a/src/capability-catalog.js
+++ b/src/capability-catalog.js
@@ -8470,14 +8470,29 @@ const CURATED_CAPABILITIES = [
       'imsys abrechnungsreife',
       'portal screenshot proof',
       'portalhinweis nachweis',
+      // Generic MaKo/EDIFACT code-context signals (energychain/cernion-energy-tools#498).
+      // Kept generic on purpose — no Z17-only special case; Z17 is used only as an
+      // acceptance-test example for this generic routing.
+      'aperak',
+      'utilmd',
+      'mscons',
+      'edifact',
+      'fehlercode',
+      'prüfidentifikator',
+      'pruefidentifikator',
+      'nachrichtentyp',
+      'mako',
+      'marktkommunikation',
     ],
     preferredActions: [
       'dashboard-api.marketCommunicationEvidenceChainStatus',
+      'willi-mako.resolveStructure',
+      'willi-mako.search',
       'edm-validation.validate',
       'settlement.readiness',
       'vdmi.findings',
     ],
-    fallbackActions: ['dashboard-api.marketCommunicationEvidenceChainStatus'],
+    fallbackActions: ['dashboard-api.marketCommunicationEvidenceChainStatus', 'willi-mako.search'],
     avoid: [
       'settlement.exportA96',
       'settlement.prepareBilling',
@@ -8502,6 +8517,7 @@ const CURATED_CAPABILITIES = [
       'Portal-/Provider-/Kundenaussagen sind Hinweise, aber nie offizieller Marktkommunikationsnachweis.',
       'Fehlende MaLo/MeLo-, UTILMD-, Zaehlerwert-, EDM-Qualitaets- und Abrechnungsschritt-Evidenz wird als positiver Follow-up sichtbar.',
       'Keine MaKo-Persistenz, kein UTILMD-Parser, keine Settlement-/Billing-Freigabe, keine HITL-Erzeugung und keine externen Calls.',
+      'willi-mako.search/resolveStructure liefern nur unverbindlichen Wissens-/Struktur-Kontext (Willi-Mako), keinen offiziellen Marktkommunikationsnachweis.',
     ],
     routingPattern: 'market_communication_evidence_chain',
   },

--- a/src/mako-edifact-signal.js
+++ b/src/mako-edifact-signal.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * Generic MaKo/EDIFACT code-context signal (energychain/cernion-energy-tools#498).
+ * Shared by capability-broker routing and the personal-agent Copilot evidence
+ * enrichment so the detection logic — and its no-Z17-special-case guarantee —
+ * lives in exactly one place. Deliberately generic; Z17 is used only as an
+ * acceptance-test example for this routing, never as a special-cased branch.
+ */
+function hasMakoEdifactCodeContextSignal(text) {
+  const haystack = String(text || '').toLowerCase();
+  return (
+    /(aperak|utilmd|mscons|edifact)/i.test(haystack) &&
+    /(fehlercode|prüfidentifikator|pruefidentifikator|nachrichtentyp|segmentstruktur|segment|prüfhinweis|pruefhinweis|erkl[aä]r|bedeutet|marktkommunikation|mako.?kontext|\bmako\b)/i.test(
+      haystack
+    )
+  );
+}
+
+module.exports = { hasMakoEdifactCodeContextSignal };

--- a/tests/agent-sidecar-willi-mako-routing.test.js
+++ b/tests/agent-sidecar-willi-mako-routing.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+// energychain/cernion-energy-tools#498 — sidecar-visible discovery of the
+// market-communication / Willi-Mako context path via the existing
+// `cernion.recommend_capability` tool. Wires the REAL capability-broker
+// service (not a stub) behind the real agent-sidecar service so the actual
+// generic MaKo/EDIFACT routing logic is exercised end-to-end. Only the
+// downstream willi-mako MCP call is mocked — no live MCP/Qdrant calls.
+
+const { ServiceBroker } = require('moleculer');
+const AgentSidecarService = require('../services/agent-sidecar.service');
+const CapabilityBrokerService = require('../services/capability-broker.service');
+
+jest.mock('../src/mcp-client', () => ({
+  callWithNewSession: jest.fn(),
+}));
+
+const { callWithNewSession } = require('../src/mcp-client');
+const WilliMakoService = require('../services/willi-mako.service');
+
+describe('agent-sidecar cernion.recommend_capability — Willi-Mako routing (#498)', () => {
+  let broker;
+
+  function readOnlyMeta(tenantId = 'public') {
+    return {
+      meta: {
+        apiToken: {
+          scope: 'read-only',
+          scopes: ['read-only'],
+          tenantId,
+          userId: 'svc:openclaw',
+        },
+      },
+    };
+  }
+
+  beforeEach(() => {
+    callWithNewSession.mockReset();
+  });
+
+  beforeAll(async () => {
+    broker = new ServiceBroker({ logger: false, transporter: null });
+    broker.createService(AgentSidecarService);
+    broker.createService(CapabilityBrokerService);
+    broker.createService(WilliMakoService);
+    await broker.start();
+  });
+
+  afterAll(async () => {
+    await broker.stop();
+  });
+
+  it('recommends the read-only market-communication capability with Willi-Mako support for a generic APERAK question', async () => {
+    const result = await broker.call(
+      'agent-sidecar.callTool',
+      {
+        name: 'cernion.recommend_capability',
+        input: {
+          task: 'APERAK Fehlercode Z18 erklären',
+          knownContext: { tenantId: 'public' },
+        },
+      },
+      readOnlyMeta('public')
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.structuredContent.capability).toBe('market_communication_evidence_chain');
+    const actionNames = result.structuredContent.recommendedPlan.map((step) => step.action);
+    expect(actionNames).toContain('dashboard-api.marketCommunicationEvidenceChainStatus');
+    expect(
+      actionNames.some((a) => a === 'willi-mako.resolveStructure' || a === 'willi-mako.search')
+    ).toBe(true);
+
+    // Read-only/advisory only: no consequential MaKo mutation action recommended.
+    expect(actionNames).not.toContain('mako.dispatch');
+    expect(actionNames).not.toContain('mscons-import.import');
+    expect(actionNames).not.toContain('hitl.create');
+    expect(result.safetyClass).toBeDefined();
+    expect(result.sideEffects).toBe('none');
+  });
+
+  it('lets the recommended willi-mako.resolveStructure step actually resolve read-only via the willi-mako service', async () => {
+    callWithNewSession.mockResolvedValue({
+      success: true,
+      data: {
+        results: [
+          {
+            id: 'wm-1',
+            slug: 'aperak-fehlercode-z18',
+            title: 'APERAK Fehlercode Z18',
+            score: 28,
+            category: 'edifact',
+            tags: ['APERAK', 'Fehlercode'],
+            excerpt: 'Kurzfassung.',
+            url: 'https://stromhaltig.de/wissen/aperak-fehlercode-z18',
+          },
+        ],
+      },
+    });
+
+    const recommendation = await broker.call(
+      'agent-sidecar.callTool',
+      {
+        name: 'cernion.recommend_capability',
+        input: { task: 'APERAK Fehlercode Z18 erklären' },
+      },
+      readOnlyMeta('public')
+    );
+
+    const williMakoStep = recommendation.structuredContent.recommendedPlan.find(
+      (step) => step.action === 'willi-mako.resolveStructure' || step.action === 'willi-mako.search'
+    );
+    expect(williMakoStep).toBeDefined();
+
+    const evidence = await broker.call(williMakoStep.action, williMakoStep.params);
+    expect(evidence.success).toBe(true);
+    expect(callWithNewSession).toHaveBeenCalledWith(
+      'cernion_willi_mako_search',
+      expect.objectContaining({ query: 'APERAK Fehlercode Z18 erklären' }),
+      undefined
+    );
+  });
+});

--- a/tests/capability-broker.service.test.js
+++ b/tests/capability-broker.service.test.js
@@ -889,6 +889,66 @@ describe('Capability Broker Service', () => {
     expect(actionNames).not.toContain('personal-agent.execute');
   });
 
+  // energychain/cernion-energy-tools#498 — generic MaKo/EDIFACT code-context routing.
+  // Z17 is used here only as an acceptance-test example; the routing signal itself
+  // (see findBestCapability's hasMakoEdifactCodeContextSignal block) is generic and
+  // must not special-case Z17.
+  describe('generic MaKo/EDIFACT code-context routing (#498)', () => {
+    it.each([
+      ['was bedeutet eine Z17 in einer APERAK?'],
+      ['APERAK Fehlercode Z18 erklären'],
+      ['Welche UTILMD-Segmentstruktur ist für Lieferantenwechsel relevant?'],
+      ['Was bedeutet ein MSCONS Prüfhinweis im MaKo-Kontext?'],
+    ])(
+      'routes "%s" to the read-only market-communication capability with Willi-Mako support',
+      async (task) => {
+        const result = await broker.call('capability-broker.recommend', { task });
+
+        expect(result.capability).toBe('market_communication_evidence_chain');
+        expect(result.recommendedCapabilities[0].capability).toBe(
+          'market_communication_evidence_chain'
+        );
+
+        const actionNames = result.recommendedPlan.map((step) => step.action);
+        expect(actionNames).toEqual(
+          expect.arrayContaining(['dashboard-api.marketCommunicationEvidenceChainStatus'])
+        );
+        expect(
+          actionNames.some((a) => a === 'willi-mako.resolveStructure' || a === 'willi-mako.search')
+        ).toBe(true);
+
+        // Still read-only/advisory: no consequential MaKo action is ever recommended.
+        expect(actionNames).not.toContain('mako.dispatch');
+        expect(actionNames).not.toContain('mscons-import.import');
+        expect(actionNames).not.toContain('settlement.exportA96');
+        expect(actionNames).not.toContain('settlement.prepareBilling');
+        expect(actionNames).not.toContain('hitl.create');
+        expect(actionNames).not.toContain('personal-agent.execute');
+        expect(result.doNotUse.map((d) => d.action)).not.toContain('willi-mako.search');
+      }
+    );
+
+    it('carries a Willi-Mako query param populated from the task text for willi-mako.search/resolveStructure steps', async () => {
+      const task = 'APERAK Fehlercode Z18 erklären';
+      const result = await broker.call('capability-broker.recommend', { task });
+
+      const williMakoStep = result.recommendedPlan.find(
+        (step) =>
+          step.action === 'willi-mako.resolveStructure' || step.action === 'willi-mako.search'
+      );
+      expect(williMakoStep).toBeDefined();
+      expect(williMakoStep.params.query).toBe(task);
+    });
+
+    it('does not require a Z17-specific branch: an analogous Z-code-free APERAK question still routes generically', async () => {
+      const result = await broker.call('capability-broker.recommend', {
+        task: 'APERAK Nachrichtentyp und Prüfidentifikator erklären, ohne konkreten Fehlercode.',
+      });
+
+      expect(result.capability).toBe('market_communication_evidence_chain');
+    });
+  });
+
   it('routes E2E Steuerbarkeitscheck governance prompts to the read-only matrix view', async () => {
     const result = await broker.call('capability-broker.recommend', {
       task: 'Baue eine E2E Steuerbarkeitscheck Governance Evidenzmatrix fuer §14a Redispatch Steuerbarkeit mit Messkonzept, Rollenmatrix, Abgabeprozess und Abrechnung Grenze.',

--- a/tests/personal-agent-willi-mako-evidence.test.js
+++ b/tests/personal-agent-willi-mako-evidence.test.js
@@ -1,0 +1,174 @@
+'use strict';
+
+// Focused unit tests for energychain/cernion-energy-tools#498: routing generic
+// MaKo/EDIFACT code-context questions through personal-agent.askCernionAgent's
+// read-only Willi-Mako evidence enrichment (ctx.call('willi-mako.resolveStructure', ...)).
+// All willi-mako calls are mocked — no live MCP/Qdrant calls.
+
+const PersonalAgentService = require('../services/personal-agent.service');
+
+function buildServiceHarness() {
+  return {
+    ...PersonalAgentService.methods,
+  };
+}
+
+function buildBaseCtxCallMock({ williMakoResponse, williMakoSpy } = {}) {
+  return jest.fn(async (action, params) => {
+    if (action === 'query.search') {
+      return { query: params.q, domain: params.domain, totalResults: 0, results: [] };
+    }
+    if (action === 'knowledge-rag.query') {
+      return { success: true, data: { results: [] } };
+    }
+    if (action === 'datapoint.list') {
+      return { datapoints: [] };
+    }
+    if (action === 'object-store.query') {
+      return { docs: [] };
+    }
+    if (action === 'willi-mako.resolveStructure') {
+      williMakoSpy?.(params);
+      if (williMakoResponse) return williMakoResponse;
+      return {
+        success: true,
+        data: {
+          topic: params.query,
+          sources: [
+            {
+              id: 'wm-1',
+              title: 'APERAK-Fehlercodes in der Marktkommunikation',
+              url: 'https://stromhaltig.de/wissen/aperak-fehlercodes',
+              score: 30,
+            },
+          ],
+          structuralHints: [{ category: 'edifact', tags: ['APERAK'], hint: 'context hint' }],
+          validationCandidates: [],
+          noCallBoundaries: [
+            'This response is not legally binding and is not an instruction to send a MaKo message.',
+          ],
+          confidence: 'low',
+        },
+      };
+    }
+    throw new Error(`unexpected action ${action}`);
+  });
+}
+
+describe('askCernionAgent Willi-Mako MaKo/EDIFACT evidence (#498)', () => {
+  const handler = PersonalAgentService.actions.askCernionAgent.handler;
+
+  test.each([
+    'was bedeutet eine Z17 in einer APERAK?',
+    'APERAK Fehlercode Z18 erklären',
+    'Welche UTILMD-Segmentstruktur ist für Lieferantenwechsel relevant?',
+    'Was bedeutet ein MSCONS Prüfhinweis im MaKo-Kontext?',
+  ])(
+    'calls willi-mako.resolveStructure (read-only) for generic MaKo question: %s',
+    async (question) => {
+      const service = buildServiceHarness();
+      const williMakoSpy = jest.fn();
+      const ctx = {
+        meta: { tenantId: 'tenant-a' },
+        params: { question, domain: 'auto', maxEvidence: 5, context: {} },
+        call: buildBaseCtxCallMock({ williMakoSpy }),
+      };
+
+      const result = await handler.call(service, ctx);
+
+      expect(williMakoSpy).toHaveBeenCalledTimes(1);
+      expect(williMakoSpy.mock.calls[0][0]).toMatchObject({ query: question });
+      expect(williMakoSpy.mock.calls[0][0].limit).toBeLessThanOrEqual(5);
+
+      expect(result.evidenceBySource.makoKnowledge.status).toBe('available');
+      expect(result.evidenceBySource.makoKnowledge.hits.length).toBeGreaterThan(0);
+      expect(result.evidenceBySource.makoKnowledge.hits[0].source).toBe('willi-mako');
+      expect(result.processContext).toContain('makoKnowledge:available');
+
+      // Read-only / advisory: no consequential MaKo action is ever surfaced.
+      expect(result.forbiddenActions).toEqual(
+        expect.arrayContaining(['execute', 'confirm', 'delete', 'override', 'sign', 'nominate'])
+      );
+
+      // Confidence is never overstated purely because Willi-Mako context exists —
+      // this evidence source stays outside the confidence ladder (never 'high').
+      expect(['low', 'medium']).toContain(result.confidence);
+    }
+  );
+
+  test('does not call willi-mako.resolveStructure for a non-MaKo question (no unnecessary calls)', async () => {
+    const service = buildServiceHarness();
+    const williMakoSpy = jest.fn();
+    const ctx = {
+      meta: { tenantId: 'tenant-a' },
+      params: {
+        question: 'Welcher VNB ist in Wiesloch zuständig?',
+        domain: 'auto',
+        maxEvidence: 5,
+        context: {},
+      },
+      call: buildBaseCtxCallMock({ williMakoSpy }),
+    };
+
+    const result = await handler.call(service, ctx);
+
+    expect(williMakoSpy).not.toHaveBeenCalled();
+    expect(result.evidenceBySource.makoKnowledge.status).toBe('skipped');
+    expect(result.processContext).not.toContain(expect.stringMatching(/^makoKnowledge:/));
+  });
+
+  test('degrades gracefully to unavailable when willi-mako.resolveStructure fails, without failing the whole answer', async () => {
+    const service = buildServiceHarness();
+    const ctx = {
+      meta: { tenantId: 'tenant-a' },
+      params: {
+        question: 'APERAK Fehlercode Z18 erklären',
+        domain: 'auto',
+        maxEvidence: 5,
+        context: {},
+      },
+      call: jest.fn(async (action) => {
+        if (action === 'query.search') return { totalResults: 0, results: [] };
+        if (action === 'knowledge-rag.query') return { success: true, data: { results: [] } };
+        if (action === 'datapoint.list') return { datapoints: [] };
+        if (action === 'object-store.query') return { docs: [] };
+        if (action === 'willi-mako.resolveStructure') {
+          throw new Error('MCP timeout');
+        }
+        throw new Error(`unexpected action ${action}`);
+      }),
+    };
+
+    const result = await handler.call(service, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.evidenceBySource.makoKnowledge.status).toBe('unavailable');
+    expect(result.evidenceBySource.makoKnowledge.hits).toEqual([]);
+  });
+
+  test('never sends, validates, or dispatches an EDIFACT message — only read-only structural context', async () => {
+    const service = buildServiceHarness();
+    const williMakoSpy = jest.fn();
+    const ctx = {
+      meta: { tenantId: 'tenant-a' },
+      params: {
+        question: 'APERAK Fehlercode Z18 erklären',
+        domain: 'auto',
+        maxEvidence: 5,
+        context: {},
+      },
+      call: buildBaseCtxCallMock({ williMakoSpy }),
+    };
+
+    await handler.call(service, ctx);
+
+    expect(ctx.call).not.toHaveBeenCalledWith(
+      expect.stringMatching(/willi-mako\.(?!search|resolveStructure)/),
+      expect.anything(),
+      expect.anything()
+    );
+    const calledActions = ctx.call.mock.calls.map(([action]) => action);
+    expect(calledActions).not.toContain('willi-mako.dispatch');
+    expect(calledActions).not.toContain('willi-mako.send');
+  });
+});

--- a/tests/personal-agent-willi-mako-evidence.test.js
+++ b/tests/personal-agent-willi-mako-evidence.test.js
@@ -13,7 +13,7 @@ function buildServiceHarness() {
   };
 }
 
-function buildBaseCtxCallMock({ williMakoResponse, williMakoSpy } = {}) {
+function buildBaseCtxCallMock({ williMakoResponse, williMakoSpy, williMakoImpl } = {}) {
   return jest.fn(async (action, params) => {
     if (action === 'query.search') {
       return { query: params.q, domain: params.domain, totalResults: 0, results: [] };
@@ -28,6 +28,7 @@ function buildBaseCtxCallMock({ williMakoResponse, williMakoSpy } = {}) {
       return { docs: [] };
     }
     if (action === 'willi-mako.resolveStructure') {
+      if (williMakoImpl) return williMakoImpl(params);
       williMakoSpy?.(params);
       if (williMakoResponse) return williMakoResponse;
       return {
@@ -127,15 +128,10 @@ describe('askCernionAgent Willi-Mako MaKo/EDIFACT evidence (#498)', () => {
         maxEvidence: 5,
         context: {},
       },
-      call: jest.fn(async (action) => {
-        if (action === 'query.search') return { totalResults: 0, results: [] };
-        if (action === 'knowledge-rag.query') return { success: true, data: { results: [] } };
-        if (action === 'datapoint.list') return { datapoints: [] };
-        if (action === 'object-store.query') return { docs: [] };
-        if (action === 'willi-mako.resolveStructure') {
+      call: buildBaseCtxCallMock({
+        williMakoImpl: () => {
           throw new Error('MCP timeout');
-        }
-        throw new Error(`unexpected action ${action}`);
+        },
       }),
     };
 


### PR DESCRIPTION
## Summary
- Routes generic MaKo/EDIFACT code-context questions through the existing read-only `market_communication_evidence_chain` capability.
- Surfaces `willi-mako.resolveStructure` / `willi-mako.search` via Capability Broker and existing Sidecar discovery (`cernion.recommend_capability`).
- Adds optional CoPilot/Personal-Agent Willi-Mako evidence enrichment via `ctx.call('willi-mako.resolveStructure', ...)` with graceful degradation and no-call boundaries.
- Updates `CHANGELOG.md`, `operation-capability-index.json`, and `llm.txt`.

## Safety / non-goals
- No Z17-only hardcoding; Z17 is only an acceptance-test example.
- No direct MCP calls outside `services/willi-mako.service.js`.
- No APERAK/UTILMD/MSCONS/EDIFACT message creation, validation, dispatch, mutation, HITL/workflow, billing/settlement/tariff/device-control or external connector action.
- No legally binding MaKo interpretation.

## Verification
- `npm test -- --runTestsByPath tests/capability-broker.service.test.js tests/agent-sidecar-willi-mako-routing.test.js tests/personal-agent-willi-mako-evidence.test.js --runInBand --forceExit` → PASS, 3 suites / 194 tests.
- `npm run lint` → PASS, 0 errors, existing repo-wide warnings only.
- `npm run generate:llm` → PASS.
- `npm run check:llm` → PASS.
- GitNexus `detect-changes` / `impact` → LOW/MEDIUM routing-scope risk; index warned stale for sibling worktree.

Implements #498.
