### PR TITLE
feat: add MCP server with 9 meta-tools over the REST API (v0.99.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.2] — 2026-08-02
+
+### Added
+- **Real MCP server** (`POST/GET/DELETE /api/mcp`, JSON-RPC 2.0 over the streamable-HTTP transport, `@modelcontextprotocol/sdk`'s server-side `McpServer`/`StreamableHTTPServerTransport`) exposing 9 layer-based meta-tools (`cernion_ask`, `cernion_search`, `cernion_describe`, `cernion_execute_read`, `cernion_run_receipt`, `cernion_prepare_process`, `cernion_execute_process`, `cernion_process_status`, `cernion_get_context`) instead of a 1:1 mapping over the platform's ~1,100 REST operations. Authenticates with the same Bearer tokens as the REST API (`ck_...` API tokens, `csess_...` session tokens, legacy passthrough). See `docs/mcp-server.md` for the full design, including explicit, evidence-based deviations from the original design concept found while wiring it against the real codebase (no `confirmation_token` field exists anywhere in `copilot-process`; generic process intents have no wired auto-execution by design — only 4 reserved operation families do; agent receipts have no direct execution path, only dry-run planning).
+- `services/mcp-server.service.js` — the 9 meta-tool actions (also reachable individually over plain REST at `POST /api/mcp-server/<action>` for debugging), each orchestrating existing services (`agent-manifest`, `personal-agent`, `agent-receipts`, `blueprint-management`, `cookbook`, `copilot-process`, `job-status`, `hitl`, `agent-sidecar`, `tenant-quota`) rather than reimplementing them.
+- `src/mcp-transport.js` — the MCP wire-protocol layer: one `StreamableHTTPServerTransport` + one dedicated `McpServer` per session, tool callbacks closed over that session's resolved auth.
+- `src/mcp-auth.js` / `src/mcp-rbac-gate.js` — because `/api/mcp` is a raw (non-aliased) route on `services/api.service.js`'s `/api` gateway, it bypasses `onBeforeCall`'s bearer-token resolution and RBAC enforcement entirely. These two modules replicate the relevant parts of that logic (ck_/csess_/legacy token resolution; the "any non-GET request requires the `full-access` role" rule) so a `read-only`-scoped token can't reach through MCP what it can't reach through REST — a real gap that would otherwise exist, not a hypothetical one.
+- `src/mcp-execute-read-policy.js` — server-side allowlist for `cernion_execute_read`: GET is always allowed (mirrors `src/gateway-request-classifiers.js`), a short list of read/dry-run POST endpoints are allowed despite the verb, and admin/secret surfaces (backup/restore, system admin, token-manager, auth, tenant-quotas) are denied regardless of method. `execute_read` itself reaches the underlying operation via a loopback HTTP call into `/api${path}` with the caller's real bearer token forwarded, rather than re-implementing moleculer-web's alias→action routing table — reuses the real gateway's auth/RBAC/tenant-scoping/rate-limiting instead of risking drift from a second implementation of it.
+- `src/mcp-uri.js` — typed `cernion://{kind}/{id}` refs (`capability`, `operation`, `receipt`, `blueprint`, `recipe`, `intent`, `job`, `hitl`) shared by all 9 tools so `search`/`describe` results can be passed directly into the read/write/status tools.
+- `'MCP Server'` OpenAPI tag registered in `src/llm-manifest-taxonomy.js` (→ `platform` domain) so the new operations don't fall into `llm.txt`'s unmapped-taxonomy-gap check.
+
+### Testing
+- `tests/mcp-server.service.test.js` (22 tests) — the 9 actions against stubbed dependency services (matches this repo's existing `ServiceBroker`-with-stub-services convention), including the RBAC gate's allow/deny paths.
+- `tests/mcp-transport.test.js` (6 tests) — a genuine end-to-end round trip: a real Node HTTP server running the actual transport handlers, a real `@modelcontextprotocol/sdk` client connecting over `StreamableHTTPClientTransport`, `tools/list` returning exactly the 9 documented tools, and both the legacy-token and `ck_` full-access/read-only auth paths exercised for real.
+
 ## [0.99.1] — 2026-08-02
 
 ### Added

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,169 @@
+# MCP Server (v0.99.2)
+
+A real MCP (Model Context Protocol) server — JSON-RPC 2.0 over the
+streamable-HTTP transport — sitting in front of this platform's REST API.
+It exposes **9 meta-tools** instead of a 1:1 tool-per-endpoint mapping, per
+the original design concept. It authenticates with the same Bearer tokens
+as the REST API (`ck_...` API tokens, `csess_...` session tokens, or legacy
+plain tokens).
+
+- Endpoint: `POST/GET/DELETE /api/mcp`
+- Transport implementation: `src/mcp-transport.js`
+- Tool business logic: `services/mcp-server.service.js`
+- Also reachable per-tool over plain REST for debugging: `POST /api/mcp-server/<action>` (e.g. `POST /api/mcp-server/search`), same auth as everything else on `/api`.
+
+## Connecting
+
+```bash
+curl -sX POST http://localhost:3000/api/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer ck_...' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"0.0.1"}}}'
+```
+
+The response carries an `mcp-session-id` header; subsequent requests
+(`tools/list`, `tools/call`, ...) must include that same header. A
+`DELETE /api/mcp` with the header ends the session early.
+
+Any MCP-SDK client works too — see `tests/mcp-transport.test.js` for a
+full round-trip example using `@modelcontextprotocol/sdk`'s
+`StreamableHTTPClientTransport`.
+
+## The 9 tools
+
+| # | Tool | Maps to | Read-only? |
+|---|------|---------|------------|
+| 1 | `cernion_ask` | `personal-agent.askCernionAgent` / `.answerDossier` | No — POST, gated (see Auth) |
+| 2 | `cernion_search` | `agent-manifest.list{Capabilities,Operations}`, `agent-receipts.list`, `blueprint-management.list`, `cookbook.search` | Yes |
+| 3 | `cernion_describe` | `agent-manifest.getCapability`, `agent-receipts.get`+`explainStored`, `blueprint-management.get`, `cookbook.get` | Yes |
+| 4 | `cernion_execute_read` | Loopback HTTP call into `/api/...` (see below) | Yes, allowlisted |
+| 5 | `cernion_run_receipt` | `agent-receipts.test` (plan); `copilot-process.prepareProcessIntent` (run) | plan: yes; run: no |
+| 6 | `cernion_prepare_process` | `copilot-process.prepareProcessIntent` | No |
+| 7 | `cernion_execute_process` | `copilot-process.executeProcessIntent` / `.rejectProcessIntent` | No |
+| 8 | `cernion_process_status` | `copilot-process.getProcessIntent`/`.listProcessIntents`, `job-status.status`, `hitl.get`/`.list` | Yes |
+| 9 | `cernion_get_context` | `agent-sidecar.descriptor`, `tenant-quota.getQuotas` | Yes |
+
+Typed refs use `cernion://{kind}/{id}` (`src/mcp-uri.js`) with
+`kind ∈ {capability, operation, receipt, blueprint, recipe, intent, job,
+hitl}` — `search`/`describe` emit them, the write/status tools accept them
+back instead of requiring separate id+kind params.
+
+## Deviations from the original concept doc — read before relying on this
+
+The original design doc (see project memory / PR description) assumed a
+few things about the existing REST surface that turned out not to hold once
+checked against the real code. Documenting them here so nobody re-discovers
+the hard way:
+
+1. **No `confirmation_token`.** `copilot-process.prepareProcessIntent` only
+   ever returns an `intentId` — there is no signed confirmation token
+   anywhere in that service. `cernion_execute_process` therefore only takes
+   `intentId` (or a `cernion://intent/{id}` ref). The safety property the
+   concept wanted — "a client cannot prepare-and-execute in one shot" — is
+   still preserved structurally (two separate tool calls, the id must be
+   echoed back), just without a cryptographic token.
+
+2. **Generic process intents don't auto-execute — by design, not a gap.**
+   `copilot-process.js`'s `_executeIntent` dispatch table only has cases for
+   4 reserved operation families (`vdmi`, `gridConnection`, `znp`,
+   `connectionRejectionEvidence`), each with its own dedicated `prepare*`
+   REST action. Any intent created through the **generic**
+   `prepareProcessIntent` (which is all `cernion_prepare_process` and
+   `cernion_run_receipt` mode=run currently use) will get
+   `UNKNOWN_OPERATION_FAMILY` if you try to execute it — the docstring in
+   `copilot-process.service.js` calls this "establishes the intake/
+   classification/HITL boundary only." `cernion_execute_process` catches
+   that specific error and rewraps it with a clearer message
+   (`MCP_INTENT_REQUIRES_MANUAL_EXECUTION`) rather than a raw 400. Rejecting
+   a generic intent still works fully.
+   **v1.1 follow-up**: wire the 4 reserved-family `prepare*` actions
+   (`prepareVdmiEvidence`, `prepareGridConnectionValidation`,
+   `prepareZnpAssumption`, `prepareConnectionRejectionEvidence`) into
+   `cernion_prepare_process` so at least those get real end-to-end
+   execution through MCP. Not done here — each has its own param shape
+   that needs the same care this file's ground-truth research took for the
+   generic path.
+
+3. **Receipts have no direct execution path either.** There is no
+   "run this receipt for real" REST action — only `test`/`testStored`
+   (dry-run planning, confirmed to never call write actions) and
+   `explain`/`explainStored`. `cernion_run_receipt` mode=run therefore
+   doesn't invent one: if the dry-run plan is executable, it creates a
+   confirmation intent (`operationFamily: 'agent-receipt'`) the same way
+   `cernion_prepare_process` does, which inherits deviation #2 above —
+   i.e. it still needs a human to actually carry out the change today.
+
+4. **`kind: "object"` is not implemented in `cernion_search`/`describe`.**
+   The concept doc's `kind` enum included `object`. The only real backing
+   candidate, `object-store.query`, requires a caller-supplied `namespace`
+   (Mango selector scoped to one namespace) — it isn't a free-text
+   discovery surface, so it doesn't fit `search`'s "find things by query"
+   contract. Left out rather than forced.
+
+5. **`cernion_execute_read` is allowlist-based, not universal**, even
+   though the concept called for covering "all ~1,100 endpoints." See
+   "How execute_read actually works" below for why, and what's covered.
+
+## How `execute_read` actually works
+
+`agent-manifest.listOperations()` gives `{method, path, operationId}` for
+every catalogued REST operation, but nothing that maps back to the actual
+Moleculer action that serves it (moleculer-web's alias→action resolution
+lives entirely inside `services/api.service.js` and isn't exposed). Rather
+than re-implementing that routing table (risking silent drift from the
+real one, and re-implementing the auth/RBAC/tenant-scoping/rate-limiting
+`onBeforeCall` already does correctly), `execute_read` makes a genuine HTTP
+loopback call to `http://127.0.0.1:${PORT}/api${path}`, forwarding the
+calling MCP session's real Bearer token. This means execute_read
+operations run through the *exact same* gateway stack as a direct REST
+call — no duplicated security logic, and it automatically covers any
+future REST endpoint without code changes here.
+
+A request is allowed (`src/mcp-execute-read-policy.js`) if:
+- the method is GET (mirrors `src/gateway-request-classifiers.js`'s
+  `isReadMethod`), or
+- it's one of a short list of POST endpoints that are read/dry-run despite
+  the verb (`evidence-router/route`, `knowledge-rag/{query,semantic,
+  federated-search}`, `agent-receipts/{select,evaluate,test,explain}`,
+  `cookbook/{search,validate}`, `copilot/{ask-cernion-agent,answer-dossier}`)
+
+and is denied regardless of method if the path matches an admin/secret
+surface (`backup`, `restore`, `system/admin`, `domain-routes/reload`,
+`token-manager`, `auth`, `tenant-quotas`) — the concept doc's "Nicht
+exponieren" list.
+
+## Auth and RBAC — why this needed its own gate
+
+`/api/mcp` is registered as a **raw** (non-aliased) route handler, the same
+pattern already used for `/metrics` and the datasource upload endpoints —
+which means it bypasses `services/api.service.js`'s `onBeforeCall`
+entirely, including its bearer-token resolution and RBAC enforcement.
+`src/mcp-auth.js` replicates that resolution (ck_ API token via
+`token-manager.verify`, csess_ session token via `auth.verify`, legacy
+plain-Bearer passthrough) once per MCP session, at the `initialize` call —
+the resolved `ctx.meta` is then reused for every tool call in that session.
+
+Critically, `onBeforeCall`'s `enforceRbacForPath` requires the
+**`full-access` role for any non-GET request**, with a short exemption
+list this repo doesn't need here. Bypassing that check would let a
+`read-only`-scoped API token reach writes through MCP that it can't reach
+through REST — a real gap, not a hypothetical one. `src/mcp-rbac-gate.js`
+enforces the same rule, called explicitly inside the write-shaped actions
+(`ask`, `prepareProcess`, `executeProcess`, and `runReceipt`'s mode=run
+branch) before they touch anything. Legacy plain-Bearer tokens are exempt
+here too, matching `onBeforeCall`'s own legacy branch (which also never
+calls `enforceRbacForPath`) — that's an existing platform behavior this
+file inherits, not something introduced by the MCP server.
+
+`execute_read` doesn't need this separate gate — it goes through the real
+gateway via HTTP loopback, so RBAC is enforced by the actual `onBeforeCall`
+for whatever downstream path it hits.
+
+## Not exposed
+
+Following the concept doc's scope: backup/restore, tenant-quota writes,
+system admin tools, and `domain-routes/reload` are excluded via the
+`execute_read` denylist. HITL `approve`/`reject`/`escalate` (which require
+the separate `hitl-approver` role) are not wired into any of the 9 tools —
+only read access (`hitl.get`/`.list` via `cernion_process_status`).

--- a/llm.txt
+++ b/llm.txt
@@ -251,7 +251,7 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: 63d4b644e8900f65927b81c60f5d1391a7089f02367187d707580fdab570edf1
+- openapi-export.json: 170d80bbe316fbd4f2a87c3471ff9b9d78169649644f7414baf7aebc0727e86d
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 1021
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: c1d11ee5e3764d740725bda701f70af4c7581e5f5994a0b675af2541de37e16d
+- llm_txt_sha256: d49e3ef42ad8277400b8b34b7998b9fd0899a93bd2eedfbcda2b053e4db71f13

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.1
-- changelog_latest_release: 0.99.1
+- version: 0.99.2
+- changelog_latest_release: 0.99.2
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -182,7 +182,7 @@ recipes:
   transformation-financing-scenario-view "Management needs one dossier-safe view over cashflow, gas…"
 resolve: GET /api/_agent/operations?domain=governance
 
-### platform (13 capabilities · 9 recipes · 418 operations)
+### platform (13 capabilities · 9 recipes · 427 operations)
 capabilities: datasource_registry_classification_governance, dr_readiness_evidence_gate, energy_sidecar_route_registry, evidence_grounding_confidence_audit, evu_api_migration_diagnostics, file_ingest_monitor, hitl_role_based_evidence_request, live_update_stream_contract_status, receipt_grounded_presentation_contract, stadtwerk_mauer_e2e_process_demo, stadtwerk_mauer_external_interface_stubs, stadtwerk_mauer_mastr_data_overlay, stadtwerk_mauer_sandbox_runtime
 recipes:
   agentic-production-feedback-prompt "An engineering agent should receive a consistent, redacted…"
@@ -246,17 +246,17 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: b4f0014ea45bff001e30810adda75dd8364f25582daf236c2b994f153f87e4ab
+- CHANGELOG.md: e83be3d58b950f8955dd2dc6263c3c369a28b453d8c1e19e0bef28347800be1f
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: 50a7a9fbeb6e11f604382fe5f2ad7077d202b528da3aee08702c2fcdc88fb123
+- openapi-export.json: 63d4b644e8900f65927b81c60f5d1391a7089f02367187d707580fdab570edf1
 
 ## OpenAPI Surface (full contract, not embedded)
-- path_count: 1012
-- operation_count: 1124
+- path_count: 1021
+- operation_count: 1133
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 6b1f10c1fa53013250d79e1abf50972cf4d17e85678969fea2f5bee09f5d3e5b
+- llm_txt_sha256: c1d11ee5e3764d740725bda701f70af4c7581e5f5994a0b675af2541de37e16d

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,8 +2,8 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.64.0",
-    "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com."
+    "version": "0.99.2",
+    "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
     {
@@ -71,6 +71,10 @@
     {
       "name": "Personal Agent",
       "description": "Interactive personal chat orchestration (v0.52). Builds deterministic L0-L4 context stacks with strict token budgeting. Layer 4 is transient and never persisted."
+    },
+    {
+      "name": "OpenAI Compatible",
+      "description": "Inbound OpenAI-compatible facade for authenticated Cernion advisory completions."
     },
     {
       "name": "Actor Personas",
@@ -1421,43 +1425,6 @@
         "x-openai-isConsequential": false
       }
     },
-    "/api/copilot-process/intents/{intentId}": {
-      "get": {
-        "operationId": "getProcessIntent",
-        "summary": "Get a process execution intent by ID (status, payload, audit trail)",
-        "tags": [
-          "Copilot Process"
-        ],
-        "responses": {
-          "200": {
-            "description": "Process execution intent",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Intent not found"
-          }
-        },
-        "description": "Returns intent status, payload summary, and audit trail. Read-only.",
-        "parameters": [
-          {
-            "name": "intentId",
-            "in": "path",
-            "required": true,
-            "description": "Intent UUID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "x-openai-isConsequential": false
-      }
-    },
     "/api/copilot-process/intents": {
       "get": {
         "operationId": "listProcessIntents",
@@ -1528,6 +1495,43 @@
               "default": 20,
               "minimum": 1,
               "maximum": 100
+            }
+          }
+        ],
+        "x-openai-isConsequential": false
+      }
+    },
+    "/api/copilot-process/intents/{intentId}": {
+      "get": {
+        "operationId": "getProcessIntent",
+        "summary": "Get a process execution intent by ID (status, payload, audit trail)",
+        "tags": [
+          "Copilot Process"
+        ],
+        "responses": {
+          "200": {
+            "description": "Process execution intent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Intent not found"
+          }
+        },
+        "description": "Returns intent status, payload summary, and audit trail. Read-only.",
+        "parameters": [
+          {
+            "name": "intentId",
+            "in": "path",
+            "required": true,
+            "description": "Intent UUID",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -2266,6 +2270,111 @@
                     "routing": {
                       "type": "object",
                       "additionalProperties": true
+                    },
+                    "resolved": {
+                      "type": "object",
+                      "description": "Blueprint/Capability resolution outcome (energychain/cernion-energy-tools#271). kind is \"blueprint\" when a read-only execution plan was compiled, \"none\" otherwise.",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "blueprint",
+                            "none"
+                          ]
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "canonicalInputs": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Normalized inputs used to compile the execution plan, if any."
+                    },
+                    "recommendedEndpoints": {
+                      "type": "array",
+                      "description": "Read-only endpoint recommendations (energychain/cernion-energy-tools#271 architecture follow-up). Cernion recommends which approved read-only endpoint(s) are the evidence surface for this request and what each result set means fachlich — it does not execute them or synthesize a final answer; that is the responsibility of the consuming agent/orchestrator. May contain more than one complementary endpoint.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "method": {
+                            "type": "string",
+                            "example": "GET"
+                          },
+                          "path": {
+                            "type": "string",
+                            "example": "/api/assets/solar"
+                          },
+                          "query": {
+                            "type": "object",
+                            "additionalProperties": true
+                          },
+                          "resultSemantics": {
+                            "type": "object",
+                            "description": "Fachliche Bedeutung des Result-Sets dieses Endpoints.",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "example": "asset_list"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "execution": {
+                      "type": "object",
+                      "nullable": true,
+                      "description": "Alias of recommendedEndpoints[0] for backward compatibility with #271 consumers that only read a single plan, or null when none is available.",
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "example": "read_only_rest_plan"
+                        },
+                        "method": {
+                          "type": "string",
+                          "example": "GET"
+                        },
+                        "path": {
+                          "type": "string",
+                          "example": "/api/assets/solar"
+                        },
+                        "query": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    },
+                    "policy": {
+                      "type": "object",
+                      "properties": {
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "sideEffects": {
+                          "type": "string"
+                        },
+                        "tenantScoped": {
+                          "type": "boolean"
+                        },
+                        "externalSideEffects": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    "noPlanReason": {
+                      "type": "string",
+                      "description": "Present when resolved.kind is \"none\" — explains why no executable read-only plan was available."
                     }
                   }
                 }
@@ -2300,6 +2409,19 @@
                     "additionalProperties": true,
                     "description": "Optional tenant, user, object, process or document context."
                   },
+                  "inputs": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Optional canonical structured input values (e.g. assetType, location, minCapacity, maxCapacity, commissioningYear, limit) for Blueprint read-only REST-plan compilation. Separate from context.",
+                    "example": {
+                      "assetType": "solar",
+                      "location": "69168",
+                      "minCapacity": 10,
+                      "maxCapacity": 13,
+                      "commissioningYear": 2025,
+                      "limit": 100
+                    }
+                  },
                   "domain": {
                     "type": "string",
                     "enum": [
@@ -2332,6 +2454,11 @@
                     "maximum": 12,
                     "default": 5,
                     "description": "Maximum number of evidence items returned."
+                  },
+                  "includeFederatedKnowledge": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Opt-in only (default false, does not change the default evidence sources/output shape). When true, additionally queries knowledge-rag.federatedSearch (Marktkommunikation/regulatory collections) and includes it as an advisory evidenceBySource.federatedKnowledge entry."
                   }
                 }
               }
@@ -2343,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.64.0",
+  "x-version": "0.99.2",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -3,11 +3,11 @@
   "info": {
     "title": "Cernion Energy Tools API",
     "version": "0.99.2",
-    "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com."
+    "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
     {
-      "url": "http://10.0.0.101:3900",
+      "url": "https://api.cernion.de",
       "description": "Cernion API Server"
     }
   ],

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,12 +2,12 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.1",
+    "version": "0.99.2",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com."
   },
   "servers": [
     {
-      "url": "https://api.cernion.de",
+      "url": "http://10.0.0.101:3900",
       "description": "Cernion API Server"
     }
   ],
@@ -50507,6 +50507,195 @@
         ]
       }
     },
+    "/api/mcp-server/ask": {
+      "post": {
+        "operationId": "mcp-server_ask",
+        "summary": "MCP meta-tool: cernion_ask",
+        "tags": [
+          "MCP Server"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp-server/search": {
+      "post": {
+        "operationId": "mcp-server_search",
+        "summary": "MCP meta-tool: cernion_search",
+        "tags": [
+          "MCP Server"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp-server/describe": {
+      "post": {
+        "operationId": "mcp-server_describe",
+        "summary": "MCP meta-tool: cernion_describe",
+        "tags": [
+          "MCP Server"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp-server/execute-read": {
+      "post": {
+        "operationId": "mcp-server_executeRead",
+        "summary": "MCP meta-tool: cernion_execute_read",
+        "tags": [
+          "MCP Server"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp-server/run-receipt": {
+      "post": {
+        "operationId": "mcp-server_runReceipt",
+        "summary": "MCP meta-tool: cernion_run_receipt",
+        "tags": [
+          "MCP Server"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp-server/prepare-process": {
+      "post": {
+        "operationId": "mcp-server_prepareProcess",
+        "summary": "MCP meta-tool: cernion_prepare_process",
+        "tags": [
+          "MCP Server"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp-server/execute-process": {
+      "post": {
+        "operationId": "mcp-server_executeProcess",
+        "summary": "MCP meta-tool: cernion_execute_process",
+        "tags": [
+          "MCP Server"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp-server/process-status": {
+      "post": {
+        "operationId": "mcp-server_processStatus",
+        "summary": "MCP meta-tool: cernion_process_status",
+        "tags": [
+          "MCP Server"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp-server/get-context": {
+      "post": {
+        "operationId": "mcp-server_getContext",
+        "summary": "MCP meta-tool: cernion_get_context",
+        "tags": [
+          "MCP Server"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/mscons-import/parse": {
       "post": {
         "operationId": "mscons-import_parse",
@@ -90895,5 +91084,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.1"
+  "x-version": "0.99.2"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,21 +1,21 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.1",
-  "sourceOpenApiHash": "50a7a9fbeb6e11f604382fe5f2ad7077d202b528da3aee08702c2fcdc88fb123",
+  "packageVersion": "0.99.2",
+  "sourceOpenApiHash": "63d4b644e8900f65927b81c60f5d1391a7089f02367187d707580fdab570edf1",
   "coverage": {
-    "rawOperationCount": 1124,
-    "operationCount": 868,
-    "agentableCount": 866,
+    "rawOperationCount": 1133,
+    "operationCount": 877,
+    "agentableCount": 875,
     "nonAgentableCount": 2,
     "byOperationKind": {
       "data_read": 385,
       "admin": 8,
-      "object_store_write": 224,
+      "object_store_write": 229,
       "process_step": 20,
-      "process_start": 39,
+      "process_start": 42,
       "advisory_plan": 46,
-      "draft_write": 10,
+      "draft_write": 11,
       "external_effect": 4,
       "dashboard_read": 125,
       "internal": 7
@@ -61561,6 +61561,569 @@
           "grid operator",
           "VNB",
           "distribution grid"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "mcp-server_ask",
+      "method": "POST",
+      "path": "/api/mcp-server/ask",
+      "service": "mcp-server",
+      "action": "mcp-server.ask",
+      "summary": "MCP meta-tool: cernion_ask",
+      "tags": [
+        "MCP Server"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "object_store_write",
+      "consequenceLevel": "medium",
+      "recommendedExecutionMode": "prepare",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "mcp-server.ask"
+      ],
+      "domains": [
+        "platform"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "mcp-server:write"
+      ],
+      "tenantScoped": true,
+      "writesTo": [
+        "mcp-server"
+      ],
+      "sideEffects": [
+        "creates_or_modifies_stored_object"
+      ],
+      "idempotency": "not_idempotent",
+      "rollbackHint": "Use the corresponding update/delete operation on the same resource to revert.",
+      "parameters": {
+        "required": [],
+        "optional": []
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "mcp",
+          "server",
+          "ask",
+          "meta",
+          "tool",
+          "cernion"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Please mcp meta-tool: cernion_ask"
+        ],
+        "synonyms": [
+          "agent infrastructure",
+          "system"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "mcp-server_describe",
+      "method": "POST",
+      "path": "/api/mcp-server/describe",
+      "service": "mcp-server",
+      "action": "mcp-server.describe",
+      "summary": "MCP meta-tool: cernion_describe",
+      "tags": [
+        "MCP Server"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "object_store_write",
+      "consequenceLevel": "medium",
+      "recommendedExecutionMode": "prepare",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "mcp-server.describe"
+      ],
+      "domains": [
+        "platform"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "mcp-server:write"
+      ],
+      "tenantScoped": true,
+      "writesTo": [
+        "mcp-server"
+      ],
+      "sideEffects": [
+        "creates_or_modifies_stored_object"
+      ],
+      "idempotency": "not_idempotent",
+      "rollbackHint": "Use the corresponding update/delete operation on the same resource to revert.",
+      "parameters": {
+        "required": [],
+        "optional": []
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "mcp",
+          "server",
+          "describe",
+          "meta",
+          "tool",
+          "cernion"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Please mcp meta-tool: cernion_describe"
+        ],
+        "synonyms": [
+          "agent infrastructure",
+          "system"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "mcp-server_executeProcess",
+      "method": "POST",
+      "path": "/api/mcp-server/execute-process",
+      "service": "mcp-server",
+      "action": "mcp-server.executeProcess",
+      "summary": "MCP meta-tool: cernion_execute_process",
+      "tags": [
+        "MCP Server"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "process_start",
+      "consequenceLevel": "high",
+      "recommendedExecutionMode": "confirm",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "mcp-server.execute_process"
+      ],
+      "domains": [
+        "platform"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "mcp-server:write"
+      ],
+      "tenantScoped": true,
+      "writesTo": [
+        "mcp-server"
+      ],
+      "sideEffects": [
+        "starts_new_process_instance"
+      ],
+      "idempotency": "not_idempotent",
+      "rollbackHint": "No companion rollback operation detected in this service - verify reversibility with backend/tenant admin before invoking.",
+      "parameters": {
+        "required": [],
+        "optional": []
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "mcp",
+          "server",
+          "execute",
+          "process",
+          "meta",
+          "tool",
+          "cernion"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Please mcp meta-tool: cernion_execute_process"
+        ],
+        "synonyms": [
+          "agent infrastructure",
+          "system"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "mcp-server_executeRead",
+      "method": "POST",
+      "path": "/api/mcp-server/execute-read",
+      "service": "mcp-server",
+      "action": "mcp-server.executeRead",
+      "summary": "MCP meta-tool: cernion_execute_read",
+      "tags": [
+        "MCP Server"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "process_start",
+      "consequenceLevel": "high",
+      "recommendedExecutionMode": "confirm",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "mcp-server.execute_read"
+      ],
+      "domains": [
+        "platform"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "mcp-server:write"
+      ],
+      "tenantScoped": true,
+      "writesTo": [
+        "mcp-server"
+      ],
+      "sideEffects": [
+        "starts_new_process_instance"
+      ],
+      "idempotency": "not_idempotent",
+      "rollbackHint": "No companion rollback operation detected in this service - verify reversibility with backend/tenant admin before invoking.",
+      "parameters": {
+        "required": [],
+        "optional": []
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "mcp",
+          "server",
+          "execute",
+          "read",
+          "meta",
+          "tool",
+          "cernion"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Please mcp meta-tool: cernion_execute_read"
+        ],
+        "synonyms": [
+          "agent infrastructure",
+          "system"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "mcp-server_getContext",
+      "method": "POST",
+      "path": "/api/mcp-server/get-context",
+      "service": "mcp-server",
+      "action": "mcp-server.getContext",
+      "summary": "MCP meta-tool: cernion_get_context",
+      "tags": [
+        "MCP Server"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "object_store_write",
+      "consequenceLevel": "medium",
+      "recommendedExecutionMode": "prepare",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "mcp-server.get_context"
+      ],
+      "domains": [
+        "platform"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "mcp-server:write"
+      ],
+      "tenantScoped": true,
+      "writesTo": [
+        "mcp-server"
+      ],
+      "sideEffects": [
+        "creates_or_modifies_stored_object"
+      ],
+      "idempotency": "not_idempotent",
+      "rollbackHint": "Use the corresponding update/delete operation on the same resource to revert.",
+      "parameters": {
+        "required": [],
+        "optional": []
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "mcp",
+          "server",
+          "context",
+          "meta",
+          "tool",
+          "cernion"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Show me mcp meta-tool: cernion_get_context"
+        ],
+        "synonyms": [
+          "agent infrastructure",
+          "system"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "mcp-server_prepareProcess",
+      "method": "POST",
+      "path": "/api/mcp-server/prepare-process",
+      "service": "mcp-server",
+      "action": "mcp-server.prepareProcess",
+      "summary": "MCP meta-tool: cernion_prepare_process",
+      "tags": [
+        "MCP Server"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "draft_write",
+      "consequenceLevel": "low",
+      "recommendedExecutionMode": "prepare",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "mcp-server.prepare_process"
+      ],
+      "domains": [
+        "platform"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "mcp-server:write"
+      ],
+      "tenantScoped": true,
+      "writesTo": [
+        "mcp-server"
+      ],
+      "sideEffects": [
+        "creates_draft_or_intent"
+      ],
+      "idempotency": "not_idempotent",
+      "rollbackHint": "Discard the created draft/intent - no persisted business state changes until a subsequent confirm/promote step.",
+      "parameters": {
+        "required": [],
+        "optional": []
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "mcp",
+          "server",
+          "prepare",
+          "process",
+          "meta",
+          "tool",
+          "cernion"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Please mcp meta-tool: cernion_prepare_process"
+        ],
+        "synonyms": [
+          "agent infrastructure",
+          "system"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "mcp-server_processStatus",
+      "method": "POST",
+      "path": "/api/mcp-server/process-status",
+      "service": "mcp-server",
+      "action": "mcp-server.processStatus",
+      "summary": "MCP meta-tool: cernion_process_status",
+      "tags": [
+        "MCP Server"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "object_store_write",
+      "consequenceLevel": "medium",
+      "recommendedExecutionMode": "prepare",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "mcp-server.process_status"
+      ],
+      "domains": [
+        "platform"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "mcp-server:write"
+      ],
+      "tenantScoped": true,
+      "writesTo": [
+        "mcp-server"
+      ],
+      "sideEffects": [
+        "creates_or_modifies_stored_object"
+      ],
+      "idempotency": "not_idempotent",
+      "rollbackHint": "Use the corresponding update/delete operation on the same resource to revert.",
+      "parameters": {
+        "required": [],
+        "optional": []
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "mcp",
+          "server",
+          "process",
+          "status",
+          "meta",
+          "tool",
+          "cernion"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Please mcp meta-tool: cernion_process_status"
+        ],
+        "synonyms": [
+          "agent infrastructure",
+          "system"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "mcp-server_runReceipt",
+      "method": "POST",
+      "path": "/api/mcp-server/run-receipt",
+      "service": "mcp-server",
+      "action": "mcp-server.runReceipt",
+      "summary": "MCP meta-tool: cernion_run_receipt",
+      "tags": [
+        "MCP Server"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "process_start",
+      "consequenceLevel": "high",
+      "recommendedExecutionMode": "confirm",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "mcp-server.run_receipt"
+      ],
+      "domains": [
+        "platform"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "mcp-server:write"
+      ],
+      "tenantScoped": true,
+      "writesTo": [
+        "mcp-server"
+      ],
+      "sideEffects": [
+        "starts_new_process_instance"
+      ],
+      "idempotency": "not_idempotent",
+      "rollbackHint": "No companion rollback operation detected in this service - verify reversibility with backend/tenant admin before invoking.",
+      "parameters": {
+        "required": [],
+        "optional": []
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "mcp",
+          "server",
+          "run",
+          "receipt",
+          "meta",
+          "tool",
+          "cernion"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Please mcp meta-tool: cernion_run_receipt"
+        ],
+        "synonyms": [
+          "agent infrastructure",
+          "system"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "mcp-server_search",
+      "method": "POST",
+      "path": "/api/mcp-server/search",
+      "service": "mcp-server",
+      "action": "mcp-server.search",
+      "summary": "MCP meta-tool: cernion_search",
+      "tags": [
+        "MCP Server"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "object_store_write",
+      "consequenceLevel": "medium",
+      "recommendedExecutionMode": "prepare",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "mcp-server.search"
+      ],
+      "domains": [
+        "platform"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "mcp-server:write"
+      ],
+      "tenantScoped": true,
+      "writesTo": [
+        "mcp-server"
+      ],
+      "sideEffects": [
+        "creates_or_modifies_stored_object"
+      ],
+      "idempotency": "not_idempotent",
+      "rollbackHint": "Use the corresponding update/delete operation on the same resource to revert.",
+      "parameters": {
+        "required": [],
+        "optional": []
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "mcp",
+          "server",
+          "search",
+          "meta",
+          "tool",
+          "cernion"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Show me mcp meta-tool: cernion_search"
+        ],
+        "synonyms": [
+          "agent infrastructure",
+          "system"
         ],
         "curated": false
       },

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -2,7 +2,7 @@
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
   "packageVersion": "0.99.2",
-  "sourceOpenApiHash": "63d4b644e8900f65927b81c60f5d1391a7089f02367187d707580fdab570edf1",
+  "sourceOpenApiHash": "170d80bbe316fbd4f2a87c3471ff9b9d78169649644f7414baf7aebc0727e86d",
   "coverage": {
     "rawOperationCount": 1133,
     "operationCount": 877,

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
         "pouchdb-find": "^9.0.0",
         "prom-client": "^15.1.3",
         "swagger-ui-dist": "^5.32.11",
-        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@zazuko/env-node": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.1",
+  "version": "0.99.2",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {
@@ -100,7 +100,8 @@
     "pouchdb-find": "^9.0.0",
     "prom-client": "^15.1.3",
     "swagger-ui-dist": "^5.32.11",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@zazuko/env-node": "^3.1.0",

--- a/scripts/export-openapi.js
+++ b/scripts/export-openapi.js
@@ -324,7 +324,8 @@ function buildStaticSpec() {
       version: packageVersion,
       description:
         'MicroService Agent System for Energy Markets - REST API with AI integration.\n\n' +
-        'CERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.',
+        'CERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\n' +
+        'For the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/.',
     },
     servers: [
       {

--- a/services/agent.service.js
+++ b/services/agent.service.js
@@ -321,6 +321,7 @@ function buildParamSchemaIndex(services) {
     'znp',
     'object-store',
     'cookbook',
+    'mcp-server',
   ]);
   for (const svc of services) {
     if (!svc.name || svc.name.startsWith('$') || skipServices.has(svc.name)) continue;

--- a/services/api.service.js
+++ b/services/api.service.js
@@ -974,7 +974,7 @@ module.exports = {
         title: 'Cernion Energy Tools API',
         version: packageVersion,
         description:
-          'MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.',
+          'MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/.',
       },
       tags: [
         { name: 'Energy', description: 'Energy market operations' },

--- a/services/api.service.js
+++ b/services/api.service.js
@@ -23,6 +23,7 @@ const {
   isReadOnlySidecarInvocation,
   isOperationsRunbookInvocation,
 } = require('../src/gateway-request-classifiers');
+const { createMcpHttpHandlers } = require('../src/mcp-transport');
 
 const UPLOAD_DIR = path.join(__dirname, '..', 'uploads');
 const CONTENT_TYPE_HEADER = 'Content-Type';
@@ -2545,6 +2546,20 @@ module.exports = {
               );
             }
           },
+
+          // MCP server (v0.99.2): real MCP JSON-RPC over streamable-HTTP.
+          // Raw handlers (like the datasource upload endpoints above) so
+          // the MCP SDK's transport owns the request/response lifecycle —
+          // see src/mcp-transport.js for session/auth handling.
+          'POST /mcp'(req, res) {
+            return this.mcpTransport.post(req, res);
+          },
+          'GET /mcp'(req, res) {
+            return this.mcpTransport.get(req, res);
+          },
+          'DELETE /mcp'(req, res) {
+            return this.mcpTransport.delete(req, res);
+          },
         },
 
         callingOptions: {},
@@ -3469,6 +3484,7 @@ module.exports = {
   },
 
   created() {
+    this.mcpTransport = createMcpHttpHandlers(this.broker);
     this.logger.info('API Gateway created');
   },
 

--- a/services/mcp-server.service.js
+++ b/services/mcp-server.service.js
@@ -1,0 +1,652 @@
+'use strict';
+
+/**
+ * MCP Server meta-tools (v0.99.2)
+ *
+ * Nine layer-based meta-tools that expose the ~1,100+ REST operations of
+ * this platform to MCP clients without a 1:1 tool-per-endpoint mapping (see
+ * docs/mcp-server.md for the full design). This service is the thin
+ * protocol-facing layer: each action orchestrates existing services
+ * (`agent-manifest`, `personal-agent`, `evidence-router`, `copilot-process`,
+ * `job-status`, `agent-receipts`, `blueprint-management`, `cookbook`,
+ * `hitl`, `agent-sidecar`, `tenant-quota`) rather than reimplementing them.
+ *
+ * These actions are dispatched two ways:
+ *  - by `src/mcp-transport.js`, which speaks the real MCP JSON-RPC protocol
+ *    over the `/api/mcp` streamable-HTTP endpoint (see that module for how
+ *    `ctx.meta.mcpBearerToken` / `ctx.meta.authUser` / `ctx.meta.tenantId`
+ *    get populated from the session's bearer token);
+ *  - directly over REST via each action's own `rest:` alias (autoAliases on
+ *    the `/api` route), for debugging and for callers that don't speak MCP.
+ *    In that path `ctx.meta` is populated the same way onBeforeCall does it
+ *    for every other endpoint (see services/api.service.js).
+ *
+ * IMPORTANT — read before extending: `executeRead` and `runReceipt` (mode:
+ * "run") are the two write/consequential-adjacent surfaces here; they are
+ * deliberately conservative (see their handlers' comments) rather than
+ * attempting a generic "execute anything" dispatcher.
+ */
+
+const axios = require('axios');
+const { MoleculerClientError } = require('moleculer').Errors;
+const { buildRef, parseRef } = require('../src/mcp-uri');
+const { checkExecuteReadPolicy } = require('../src/mcp-execute-read-policy');
+const { assertFullAccessForWrite } = require('../src/mcp-rbac-gate');
+
+const SEARCH_KINDS = ['capability', 'operation', 'receipt', 'blueprint', 'recipe'];
+const DESCRIBE_KINDS = ['capability', 'operation', 'receipt', 'blueprint', 'recipe'];
+const PROCESS_STATUS_KINDS = ['intent', 'job', 'hitl'];
+const OPENAPI_TAG = 'MCP Server';
+
+function textIncludes(haystackParts, needle) {
+  const q = String(needle || '')
+    .toLowerCase()
+    .trim();
+  if (!q) return true;
+  return haystackParts
+    .filter(Boolean)
+    .map((p) => String(p).toLowerCase())
+    .some((p) => p.includes(q));
+}
+
+function resolveKindAndId(ctx, allowedKinds) {
+  const fromRef = parseRef(ctx.params.ref);
+  const kind = fromRef?.kind || ctx.params.kind;
+  const id = fromRef?.id || ctx.params.id;
+  if (!kind || !allowedKinds.includes(kind)) {
+    throw new MoleculerClientError(
+      `Unsupported or missing kind (expected one of: ${allowedKinds.join(', ')})`,
+      422,
+      'MCP_UNSUPPORTED_KIND',
+      { kind, allowedKinds }
+    );
+  }
+  if (!id) {
+    throw new MoleculerClientError('Missing id (or a fully-qualified ref)', 422, 'MCP_MISSING_ID', {
+      kind,
+    });
+  }
+  return { kind, id };
+}
+
+module.exports = {
+  name: 'mcp-server',
+
+  actions: {
+    // ── Layer 1: Ask ────────────────────────────────────────────────────
+    ask: {
+      rest: 'POST /ask',
+      openapi: { tags: [OPENAPI_TAG], summary: 'MCP meta-tool: cernion_ask' },
+      params: {
+        question: { type: 'string', min: 1, max: 8000 },
+        context: { type: 'object', optional: true },
+        sessionId: { type: 'string', optional: true },
+        domain: { type: 'string', optional: true },
+        mode: { type: 'string', optional: true },
+        format: {
+          type: 'enum',
+          values: ['compact', 'dossier'],
+          optional: true,
+          default: 'compact',
+        },
+        maxEvidence: { type: 'number', optional: true, convert: true, min: 1, max: 12 },
+        parentDossierId: { type: 'string', optional: true },
+      },
+      async handler(ctx) {
+        // The REST equivalents (POST /api/copilot/ask-cernion-agent,
+        // /answer-dossier) require the full-access role — see
+        // src/mcp-rbac-gate.js for why this must be enforced here too.
+        assertFullAccessForWrite(ctx.meta);
+        const { question, context, sessionId, domain, maxEvidence, parentDossierId } = ctx.params;
+        if (ctx.params.format === 'dossier') {
+          const result = await ctx.call('personal-agent.answerDossier', {
+            question,
+            sessionId,
+            domain,
+            context,
+            maxEvidence,
+            parentDossierId,
+            mode: parentDossierId ? 'answer_dossier_followup' : 'answer_dossier',
+          });
+          return { success: true, resolved: { tool: 'cernion_ask', format: 'dossier' }, ...result };
+        }
+        const result = await ctx.call('personal-agent.askCernionAgent', {
+          question,
+          sessionId,
+          context,
+          domain,
+          mode: ctx.params.mode,
+          maxEvidence,
+        });
+        return { success: true, resolved: { tool: 'cernion_ask', format: 'compact' }, ...result };
+      },
+    },
+
+    // ── Layer 2: Discover & understand ─────────────────────────────────
+    search: {
+      rest: 'POST /search',
+      openapi: { tags: [OPENAPI_TAG], summary: 'MCP meta-tool: cernion_search' },
+      params: {
+        query: { type: 'string', min: 1, max: 500 },
+        kind: { type: 'enum', values: SEARCH_KINDS, optional: true },
+        domain: { type: 'string', optional: true },
+        limit: { type: 'number', optional: true, convert: true, min: 1, max: 50, default: 10 },
+      },
+      async handler(ctx) {
+        const { query, domain, limit } = ctx.params;
+        const kinds = ctx.params.kind ? [ctx.params.kind] : SEARCH_KINDS;
+        const perKindLimit = Math.max(limit, 5);
+
+        const searchers = {
+          capability: async () => {
+            const res = await ctx.call('agent-manifest.listCapabilities', { domain });
+            return (res.data || [])
+              .filter((c) =>
+                textIncludes([c.capability, c.intent, c.domain, ...(c.keywords || [])], query)
+              )
+              .slice(0, perKindLimit)
+              .map((c) => ({
+                ref: buildRef('capability', c.capability),
+                kind: 'capability',
+                title: c.capability,
+                summary: c.intent || '',
+                riskClass: 'read',
+              }));
+          },
+          operation: async () => {
+            const res = await ctx.call('agent-manifest.listOperations', { domain });
+            return (res.data || [])
+              .filter((op) =>
+                textIncludes([op.operationId, op.path, op.summary, ...(op.tags || [])], query)
+              )
+              .slice(0, perKindLimit)
+              .map((op) => ({
+                ref: buildRef('operation', op.operationId || `${op.method} ${op.path}`),
+                kind: 'operation',
+                title: op.operationId || `${op.method} ${op.path}`,
+                summary: op.summary || `${op.method} ${op.path}`,
+                riskClass: checkExecuteReadPolicy(op.method, op.path).allowed ? 'read' : 'write',
+              }));
+          },
+          receipt: async () => {
+            const res = await ctx.call('agent-receipts.list', { domain, limit: 200 });
+            return (res.data || [])
+              .filter((r) =>
+                textIncludes([r.receiptId, r.title, r.description, ...(r.tags || [])], query)
+              )
+              .slice(0, perKindLimit)
+              .map((r) => ({
+                ref: buildRef('receipt', r.receiptId),
+                kind: 'receipt',
+                title: r.title,
+                summary: r.description || '',
+                riskClass: 'write',
+              }));
+          },
+          blueprint: async () => {
+            const res = await ctx.call('blueprint-management.list', {
+              includeDrafts: true,
+              includeActive: true,
+            });
+            return (res.data || [])
+              .filter((b) => textIncludes([b.blueprintId, b.id, b.title, b.description], query))
+              .slice(0, perKindLimit)
+              .map((b) => ({
+                ref: buildRef('blueprint', b.blueprintId || b.id),
+                kind: 'blueprint',
+                title: b.title || b.blueprintId || b.id,
+                summary: b.description || '',
+                riskClass: 'write',
+              }));
+          },
+          recipe: async () => {
+            const res = await ctx.call('cookbook.search', {
+              query: query.length >= 5 ? query : query.padEnd(5, ' '),
+              limit: perKindLimit,
+            });
+            return (res.data || []).map((r) => ({
+              ref: buildRef('recipe', r.id),
+              kind: 'recipe',
+              title: r.title || r.id,
+              summary: r.description || r.summary || '',
+              riskClass: 'read',
+            }));
+          },
+        };
+
+        const settled = await Promise.allSettled(kinds.map((k) => searchers[k]()));
+        const results = settled.flatMap((s) => (s.status === 'fulfilled' ? s.value : []));
+        const errors = settled
+          .map((s, i) =>
+            s.status === 'rejected' ? { kind: kinds[i], message: s.reason?.message } : null
+          )
+          .filter(Boolean);
+
+        return {
+          success: true,
+          query,
+          kinds,
+          count: Math.min(results.length, limit),
+          results: results.slice(0, limit),
+          ...(errors.length ? { partialErrors: errors } : {}),
+        };
+      },
+    },
+
+    describe: {
+      rest: 'POST /describe',
+      openapi: { tags: [OPENAPI_TAG], summary: 'MCP meta-tool: cernion_describe' },
+      params: {
+        ref: { type: 'string', optional: true },
+        kind: { type: 'enum', values: DESCRIBE_KINDS, optional: true },
+        id: { type: 'string', optional: true },
+      },
+      async handler(ctx) {
+        const { kind, id } = resolveKindAndId(ctx, DESCRIBE_KINDS);
+
+        if (kind === 'capability') {
+          const res = await ctx.call('agent-manifest.getCapability', { name: id });
+          return { success: true, ref: buildRef(kind, id), kind, data: res.data };
+        }
+
+        if (kind === 'operation') {
+          const res = await ctx.call('agent-manifest.listOperations', {});
+          const op = (res.data || []).find((row) => row.operationId === id);
+          if (!op) {
+            throw new MoleculerClientError(
+              `Operation not found: ${id}`,
+              404,
+              'MCP_OPERATION_NOT_FOUND',
+              {
+                id,
+              }
+            );
+          }
+          return {
+            success: true,
+            ref: buildRef(kind, id),
+            kind,
+            data: { ...op, executeReadPolicy: checkExecuteReadPolicy(op.method, op.path) },
+          };
+        }
+
+        if (kind === 'receipt') {
+          const receipt = await ctx.call('agent-receipts.get', { id });
+          let explanation = null;
+          try {
+            explanation = await ctx.call('agent-receipts.explainStored', { id });
+          } catch (err) {
+            explanation = { success: false, error: err.message };
+          }
+          return {
+            success: true,
+            ref: buildRef(kind, id),
+            kind,
+            data: { receipt: receipt.data, explanation: explanation.data || explanation },
+          };
+        }
+
+        if (kind === 'blueprint') {
+          const res = await ctx.call('blueprint-management.get', { id });
+          return { success: true, ref: buildRef(kind, id), kind, data: res.data };
+        }
+
+        // kind === 'recipe'
+        const res = await ctx.call('cookbook.get', { id });
+        return { success: true, ref: buildRef(kind, id), kind, data: res.data };
+      },
+    },
+
+    // ── Layer 3: Read ───────────────────────────────────────────────────
+    executeRead: {
+      rest: 'POST /execute-read',
+      openapi: { tags: [OPENAPI_TAG], summary: 'MCP meta-tool: cernion_execute_read' },
+      params: {
+        ref: { type: 'string', optional: true },
+        operationId: { type: 'string', optional: true },
+        method: { type: 'string', optional: true },
+        path: { type: 'string', optional: true },
+        pathParams: { type: 'object', optional: true, default: {} },
+        query: { type: 'object', optional: true, default: {} },
+        body: { type: 'object', optional: true },
+      },
+      async handler(ctx) {
+        let method = ctx.params.method;
+        let path = ctx.params.path;
+
+        if (!method || !path) {
+          const opRef = parseRef(ctx.params.ref);
+          const operationId = opRef?.id || ctx.params.operationId;
+          if (!operationId) {
+            throw new MoleculerClientError(
+              'execute_read requires either (ref or operationId) or (method and path)',
+              422,
+              'MCP_MISSING_OPERATION'
+            );
+          }
+          const res = await ctx.call('agent-manifest.listOperations', {});
+          const op = (res.data || []).find((row) => row.operationId === operationId);
+          if (!op) {
+            throw new MoleculerClientError(
+              `Operation not found: ${operationId}`,
+              404,
+              'MCP_OPERATION_NOT_FOUND',
+              { operationId }
+            );
+          }
+          method = op.method;
+          path = op.path;
+        }
+
+        const policy = checkExecuteReadPolicy(method, path);
+        if (!policy.allowed) {
+          throw new MoleculerClientError(
+            `execute_read refused: ${method} ${path} is not on the read-only allowlist (${policy.reason})`,
+            403,
+            'MCP_EXECUTE_READ_FORBIDDEN',
+            { method, path, reason: policy.reason }
+          );
+        }
+
+        let resolvedPath = String(path).replace(/\/api/, '');
+        for (const [name, value] of Object.entries(ctx.params.pathParams || {})) {
+          resolvedPath = resolvedPath.replace(`:${name}`, encodeURIComponent(String(value)));
+        }
+        if (/:[a-zA-Z_]+/.test(resolvedPath)) {
+          throw new MoleculerClientError(
+            `Unresolved path parameter(s) in ${resolvedPath} — supply them via pathParams`,
+            422,
+            'MCP_UNRESOLVED_PATH_PARAM'
+          );
+        }
+
+        const bearerToken = ctx.meta?.mcpBearerToken;
+        if (!bearerToken) {
+          throw new MoleculerClientError(
+            'execute_read requires an authenticated MCP session bearer token',
+            401,
+            'MCP_NO_BEARER_TOKEN'
+          );
+        }
+
+        const port = process.env.PORT || 3000;
+        const url = `http://127.0.0.1:${port}/api${resolvedPath}`;
+
+        try {
+          const response = await axios({
+            method: method.toLowerCase(),
+            url,
+            params: ctx.params.query,
+            data: method.toUpperCase() === 'POST' ? ctx.params.body : undefined,
+            headers: { Authorization: `Bearer ${bearerToken}` },
+            timeout: 10000,
+            validateStatus: () => true,
+          });
+
+          const result = {
+            success: response.status >= 200 && response.status < 300,
+            resolvedRequest: { method: method.toUpperCase(), path: resolvedPath },
+            status: response.status,
+            data: response.data,
+          };
+          if (response.data && typeof response.data === 'object' && response.data.jobId) {
+            result.jobRef = buildRef('job', response.data.jobId);
+          }
+          return result;
+        } catch (err) {
+          throw new MoleculerClientError(
+            `execute_read upstream call failed: ${err.message}`,
+            502,
+            'MCP_EXECUTE_READ_UPSTREAM_ERROR',
+            { method, path: resolvedPath }
+          );
+        }
+      },
+    },
+
+    // ── Layer 3b: Curated receipts (plan always; run creates an intent) ──
+    runReceipt: {
+      rest: 'POST /run-receipt',
+      openapi: { tags: [OPENAPI_TAG], summary: 'MCP meta-tool: cernion_run_receipt' },
+      params: {
+        id: { type: 'string', optional: true },
+        receipt: { type: 'object', optional: true },
+        context: { type: 'object', optional: true, default: {} },
+        input: { type: 'object', optional: true, default: {} },
+        mode: { type: 'enum', values: ['plan', 'run'], optional: true, default: 'plan' },
+      },
+      async handler(ctx) {
+        if (!ctx.params.id && !ctx.params.receipt) {
+          throw new MoleculerClientError(
+            'run_receipt requires either id (stored receipt) or receipt (inline definition)',
+            422,
+            'MCP_MISSING_RECEIPT'
+          );
+        }
+
+        const testResult = await ctx.call('agent-receipts.test', {
+          id: ctx.params.id,
+          receipt: ctx.params.receipt,
+          context: ctx.params.context,
+          input: ctx.params.input,
+        });
+        const plan = testResult.data;
+
+        if (ctx.params.mode === 'plan' || !plan.executable) {
+          return {
+            success: true,
+            mode: 'plan',
+            ref: plan.receiptId ? buildRef('receipt', plan.receiptId) : null,
+            plan,
+            ...(ctx.params.mode === 'run' && !plan.executable
+              ? {
+                  note: 'Not executable yet — see missingRequiredInputs/errors. Returning plan only.',
+                }
+              : {}),
+          };
+        }
+
+        // mode: 'run' and executable — no direct auto-execution path exists
+        // for arbitrary receipts server-side (see docs/mcp-server.md), so we
+        // route through the same intent mechanism cernion_prepare_process
+        // uses rather than inventing an unreviewed execution path.
+        assertFullAccessForWrite(ctx.meta);
+        const intentResult = await ctx.call('copilot-process.prepareProcessIntent', {
+          operationFamily: 'agent-receipt',
+          proposedAction: `run_receipt:${plan.receiptId}`,
+          targetType: 'agentReceipt',
+          targetId: plan.receiptId,
+          inputSummary: `Run receipt ${plan.receiptId} (${plan.plan.steps.length} planned step(s))`,
+          payload: {
+            receiptId: plan.receiptId,
+            context: ctx.params.context,
+            input: ctx.params.input,
+            plan,
+          },
+          risk: 'medium',
+          reason: 'cernion_run_receipt mode=run',
+        });
+
+        return {
+          success: true,
+          mode: 'run',
+          plan,
+          intent: intentResult.receipt,
+          executeVia: intentResult.executeVia,
+          note:
+            'Receipts have no direct auto-execution path — a confirmation intent was created instead. ' +
+            'Use cernion_execute_process with the returned intent ref after human confirmation.',
+        };
+      },
+    },
+
+    // ── Layer 4: Write (two-phase, single path) ────────────────────────
+    prepareProcess: {
+      rest: 'POST /prepare-process',
+      openapi: { tags: [OPENAPI_TAG], summary: 'MCP meta-tool: cernion_prepare_process' },
+      params: {
+        operationFamily: { type: 'string', min: 1, max: 64 },
+        proposedAction: { type: 'string', min: 1, max: 200 },
+        targetType: { type: 'string', optional: true },
+        targetId: { type: 'string', optional: true },
+        inputSummary: { type: 'string', optional: true, max: 500 },
+        payload: { type: 'object', optional: true, default: {} },
+        risk: {
+          type: 'enum',
+          values: ['low', 'medium', 'high'],
+          optional: true,
+          default: 'medium',
+        },
+        reason: { type: 'string', optional: true, max: 500 },
+        correlationId: { type: 'string', optional: true },
+        decisionFrameId: { type: 'string', optional: true },
+      },
+      async handler(ctx) {
+        assertFullAccessForWrite(ctx.meta);
+        const result = await ctx.call('copilot-process.prepareProcessIntent', ctx.params);
+        return { ...result, ref: buildRef('intent', result.receipt.intentId) };
+      },
+    },
+
+    executeProcess: {
+      rest: 'POST /execute-process',
+      openapi: { tags: [OPENAPI_TAG], summary: 'MCP meta-tool: cernion_execute_process' },
+      params: {
+        ref: { type: 'string', optional: true },
+        intentId: { type: 'string', optional: true },
+        action: { type: 'enum', values: ['execute', 'reject'], optional: true, default: 'execute' },
+        reason: { type: 'string', optional: true },
+        executedBy: { type: 'string', optional: true },
+        rejectedBy: { type: 'string', optional: true },
+        correlationId: { type: 'string', optional: true },
+      },
+      async handler(ctx) {
+        assertFullAccessForWrite(ctx.meta);
+        const refParsed = parseRef(ctx.params.ref);
+        const intentId = refParsed?.id || ctx.params.intentId;
+        if (!intentId) {
+          throw new MoleculerClientError(
+            'execute_process requires intentId (or a cernion://intent/{id} ref)',
+            422,
+            'MCP_MISSING_INTENT_ID'
+          );
+        }
+
+        if (ctx.params.action === 'reject') {
+          if (!ctx.params.reason) {
+            throw new MoleculerClientError(
+              'reject requires reason',
+              422,
+              'MCP_MISSING_REJECT_REASON'
+            );
+          }
+          return ctx.call('copilot-process.rejectProcessIntent', {
+            intentId,
+            reason: ctx.params.reason,
+            rejectedBy: ctx.params.rejectedBy,
+          });
+        }
+
+        try {
+          return await ctx.call('copilot-process.executeProcessIntent', {
+            intentId,
+            executedBy: ctx.params.executedBy,
+            correlationId: ctx.params.correlationId,
+          });
+        } catch (err) {
+          if (err.type === 'UNKNOWN_OPERATION_FAMILY') {
+            throw new MoleculerClientError(
+              `Intent ${intentId} belongs to a domain-agnostic operationFamily with no wired ` +
+                'auto-execution — by design, generic process intents establish the intake/HITL ' +
+                'boundary only and must be executed by a human outside this API. See docs/mcp-server.md.',
+              409,
+              'MCP_INTENT_REQUIRES_MANUAL_EXECUTION',
+              { intentId }
+            );
+          }
+          throw err;
+        }
+      },
+    },
+
+    // ── Layer 5: Status ─────────────────────────────────────────────────
+    processStatus: {
+      rest: 'POST /process-status',
+      openapi: { tags: [OPENAPI_TAG], summary: 'MCP meta-tool: cernion_process_status' },
+      params: {
+        ref: { type: 'string', optional: true },
+        kind: { type: 'enum', values: PROCESS_STATUS_KINDS, optional: true },
+        id: { type: 'string', optional: true },
+        list: { type: 'enum', values: ['open'], optional: true },
+      },
+      async handler(ctx) {
+        if (ctx.params.list === 'open') {
+          const [intents, hitlItems] = await Promise.allSettled([
+            ctx.call('copilot-process.listProcessIntents', {
+              status: 'pending_confirmation',
+              limit: 50,
+            }),
+            ctx.call('hitl.list', { status: 'pending', limit: 50 }),
+          ]);
+          return {
+            success: true,
+            list: 'open',
+            intents: intents.status === 'fulfilled' ? intents.value.intents : [],
+            hitlItems: hitlItems.status === 'fulfilled' ? hitlItems.value.items : [],
+            note: 'Async jobs are not bulk-listable — check individual cernion://job/{id} refs.',
+          };
+        }
+
+        const { kind, id } = resolveKindAndId(ctx, PROCESS_STATUS_KINDS);
+
+        if (kind === 'intent') {
+          const data = await ctx.call('copilot-process.getProcessIntent', { intentId: id });
+          return { success: true, ref: buildRef(kind, id), kind, data };
+        }
+        if (kind === 'job') {
+          const data = await ctx.call('job-status.status', { jobId: id });
+          return { success: true, ref: buildRef(kind, id), kind, data };
+        }
+        // kind === 'hitl'
+        const data = await ctx.call('hitl.get', { id });
+        return { success: true, ref: buildRef(kind, id), kind, data: data.item };
+      },
+    },
+
+    // ── Layer 0: Context ────────────────────────────────────────────────
+    getContext: {
+      rest: 'POST /get-context',
+      openapi: { tags: [OPENAPI_TAG], summary: 'MCP meta-tool: cernion_get_context' },
+      params: {
+        tenantId: { type: 'string', optional: true },
+      },
+      async handler(ctx) {
+        const descriptor = await ctx.call('agent-sidecar.descriptor', {});
+        const tenantId = ctx.params.tenantId || ctx.meta?.tenantId || null;
+
+        let quotas = null;
+        let quotasNote;
+        if (tenantId) {
+          try {
+            const res = await ctx.call('tenant-quota.getQuotas', { id: tenantId });
+            quotas = res.data;
+          } catch (err) {
+            quotasNote = `Quota lookup skipped: ${err.message}`;
+          }
+        } else {
+          quotasNote =
+            'No tenantId available on this session — pass one explicitly to include quotas.';
+        }
+
+        return {
+          success: true,
+          descriptor,
+          tenantId,
+          quotas,
+          ...(quotasNote ? { quotasNote } : {}),
+          persona: ctx.meta?.authUser || null,
+        };
+      },
+    },
+  },
+};

--- a/src/agent-planning-utils.js
+++ b/src/agent-planning-utils.js
@@ -38,6 +38,7 @@ function buildServiceCatalogue(services) {
     'object-store',
     'cookbook',
     'capability-broker',
+    'mcp-server',
   ]);
 
   for (const svc of services) {

--- a/src/llm-manifest-taxonomy.js
+++ b/src/llm-manifest-taxonomy.js
@@ -228,6 +228,7 @@ const OPENAPI_TAG_DOMAIN_MAP = {
   'Investment Planning': 'grid-planning',
   Jobs: 'platform',
   'Knowledge RAG': 'platform',
+  'MCP Server': 'platform',
   'MaStR Monitor': 'grid-ops',
   'MaStR Data Quality': 'grid-ops',
   VNBMonitor: 'grid-ops',

--- a/src/mcp-auth.js
+++ b/src/mcp-auth.js
@@ -1,0 +1,93 @@
+'use strict';
+
+/**
+ * Resolves an MCP session's identity from its `Authorization: Bearer <token>`
+ * header, mirroring `services/api.service.js`'s `onBeforeCall` token
+ * resolution (ck_ API token / csess_ session token / legacy passthrough) so
+ * that `ctx.meta` looks the same whether an action was reached via the REST
+ * gateway or via `/api/mcp`. Kept as a standalone module (rather than
+ * importing from api.service.js, which doesn't export this logic) to avoid
+ * touching that file — see src/mcp-rbac-gate.js for why parity matters here.
+ */
+
+const { mapRolesFromLegacyToken } = require('./auth/rbac');
+
+function extractBearerToken(authorizationHeader) {
+  if (!authorizationHeader || !authorizationHeader.startsWith('Bearer ')) return null;
+  const token = authorizationHeader.substring(7).trim();
+  return token || null;
+}
+
+async function resolveMcpAuth(broker, authorizationHeader) {
+  const token = extractBearerToken(authorizationHeader);
+  if (!token) {
+    return { ok: false, status: 401, message: 'Missing Authorization: Bearer <token> header' };
+  }
+
+  if (token.startsWith('ck_')) {
+    const verification = await broker.call('token-manager.verify', {
+      token,
+      method: 'POST',
+      path: '/api/mcp',
+      trackUsage: true,
+    });
+    if (!verification?.valid) {
+      const status = verification?.reason === 'SCOPE_VIOLATION' ? 403 : 401;
+      return { ok: false, status, message: 'Invalid, revoked, or scope-restricted API token' };
+    }
+    const roles = mapRolesFromLegacyToken(verification.scope, verification.scopes);
+    const meta = {
+      mcpBearerToken: token,
+      apiToken: {
+        id: verification.tokenId,
+        name: verification.name,
+        scope: verification.scope,
+        scopes: verification.scopes || [],
+        tenantId: verification.tenantId || null,
+        userId: verification.userId || null,
+        legacy: Boolean(verification.legacy),
+      },
+      authUser: {
+        authType: 'legacy-token',
+        userId: verification.userId || verification.tokenId || null,
+        tenantId: verification.tenantId || null,
+        groups: [],
+        idpClaims: null,
+        roles,
+      },
+      tenantId: verification.tenantId || null,
+    };
+    return { ok: true, meta };
+  }
+
+  if (token.startsWith('csess_')) {
+    const verification = await broker.call('auth.verify', { token, trackUsage: true });
+    if (!verification?.valid) {
+      return { ok: false, status: 401, message: 'Invalid or expired session token' };
+    }
+    const roles = Array.isArray(verification.roles) ? verification.roles : [];
+    const meta = {
+      mcpBearerToken: token,
+      authSession: { id: verification.sessionId, expiresAt: verification.expiresAt || null },
+      authUser: {
+        authType: 'session',
+        userId: verification.userId || null,
+        tenantId: verification.tenantId || null,
+        groups: Array.isArray(verification.groups) ? verification.groups : [],
+        idpClaims: verification.idpClaims || null,
+        roles,
+      },
+      tenantId: verification.tenantId || null,
+    };
+    return { ok: true, meta };
+  }
+
+  // Legacy plain Bearer token passthrough — matches onBeforeCall's `else`
+  // branch, which never calls enforceRbacForPath either.
+  return {
+    ok: true,
+    meta: { mcpBearerToken: token, cernionToken: token, bypassRbac: true, authUser: null },
+  };
+}
+
+module.exports = { resolveMcpAuth };

--- a/src/mcp-execute-read-policy.js
+++ b/src/mcp-execute-read-policy.js
@@ -1,0 +1,77 @@
+'use strict';
+
+/**
+ * Safety gate for `cernion_execute_read` (MCP meta-tool #4).
+ *
+ * `execute_read` reaches the ~1,100+ REST operations catalogued by
+ * `agent-manifest.listOperations` through a loopback HTTP call rather than
+ * re-deriving moleculer-web's alias→action routing table itself — the
+ * gateway's own auth/RBAC/tenant-scoping/rate-limiting in
+ * `services/api.service.js`'s `onBeforeCall` already implements that
+ * resolution correctly and re-implementing it here would risk silently
+ * diverging from it. This module is the one extra gate layered in front of
+ * that loopback: GET is read by HTTP convention (mirrors
+ * `src/gateway-request-classifiers.js`'s `isReadMethod`), a short allowlist
+ * covers POST endpoints that are read/dry-run despite the verb, and a short
+ * denylist keeps admin/secret-bearing surfaces out of MCP reach regardless
+ * of method (per the concept doc's "Nicht exponieren" list).
+ */
+
+const { isReadMethod } = require('./gateway-request-classifiers');
+
+// Paths (relative to /api) that must never be reachable via execute_read,
+// even as GET — admin/system/credential surfaces, not agent-facing data.
+const DENYLIST_PATH_PATTERNS = [
+  /^\/backup(\/|$)/,
+  /^\/restore(\/|$)/,
+  /^\/system\/admin(\/|$)/,
+  /^\/domain-routes\/reload$/,
+  /^\/token-manager(\/|$)/,
+  /^\/auth(\/|$)/,
+  /^\/tenant-quotas?(\/|$)/,
+];
+
+// POST endpoints that are read-only or dry-run in effect despite the verb.
+const POST_ALLOWLIST_PATH_PATTERNS = [
+  /^\/evidence-router\/route$/,
+  /^\/knowledge-rag\/(query|semantic|federated-search)$/,
+  /^\/agent-receipts\/select$/,
+  /^\/agent-receipts\/(evaluate|test|explain)$/,
+  /^\/agent-receipts\/[^/]+\/(evaluate|test|explain)$/,
+  /^\/cookbook\/(search|validate)$/,
+  /^\/copilot\/(ask-cernion-agent|answer-dossier)$/,
+];
+
+function stripApiPrefix(path) {
+  const normalized = String(path || '').split('?')[0];
+  return normalized.startsWith('/api') ? normalized.slice(4) || '/' : normalized;
+}
+
+function isDenied(relativePath) {
+  return DENYLIST_PATH_PATTERNS.some((pattern) => pattern.test(relativePath));
+}
+
+/**
+ * @param {string} method - HTTP method as catalogued by agent-manifest (e.g. "GET").
+ * @param {string} path - Full or /api-relative path, may include the `/api` prefix.
+ * @returns {{ allowed: boolean, reason?: string }}
+ */
+function checkExecuteReadPolicy(method, path) {
+  const relativePath = stripApiPrefix(path);
+  if (isDenied(relativePath)) {
+    return { allowed: false, reason: 'ADMIN_SURFACE_NOT_EXPOSED' };
+  }
+  const upperMethod = String(method || '').toUpperCase();
+  if (isReadMethod(upperMethod)) {
+    return { allowed: true };
+  }
+  if (
+    upperMethod === 'POST' &&
+    POST_ALLOWLIST_PATH_PATTERNS.some((pattern) => pattern.test(relativePath))
+  ) {
+    return { allowed: true };
+  }
+  return { allowed: false, reason: 'NOT_READ_ONLY' };
+}
+
+module.exports = { checkExecuteReadPolicy };

--- a/src/mcp-rbac-gate.js
+++ b/src/mcp-rbac-gate.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * Mirrors the one RBAC rule from `services/api.service.js`'s
+ * `enforceRbacForPath` that matters for MCP meta-tools: any mutating call
+ * (`ask`, `prepare_process`, `execute_process`, `run_receipt` mode=run)
+ * requires the `full-access` role, exactly as it would if the caller hit
+ * the equivalent REST endpoint directly. The MCP transport bypasses
+ * moleculer-web's `onBeforeCall` entirely (see src/mcp-transport.js), so
+ * without this gate a valid-but-unprivileged token (e.g. a `read-only`
+ * scoped API token) could reach writes through MCP that it cannot reach
+ * through REST. Legacy plain-Bearer tokens are exempt here too, because
+ * `onBeforeCall`'s own legacy branch never calls `enforceRbacForPath`
+ * either (see the `else { ctx.meta.cernionToken = ... }` branch there) —
+ * `src/mcp-auth.js` sets `bypassRbac: true` for that case to match.
+ */
+
+const { hasRole } = require('./auth/rbac');
+const { MoleculerClientError } = require('moleculer').Errors;
+
+function assertFullAccessForWrite(meta) {
+  if (meta?.bypassRbac) return;
+  const roles = meta?.authUser?.roles || [];
+  if (!hasRole(roles, 'full-access')) {
+    throw new MoleculerClientError('Role required: full-access.', 403, 'ROLE_REQUIRED');
+  }
+}
+
+module.exports = { assertFullAccessForWrite };

--- a/src/mcp-transport.js
+++ b/src/mcp-transport.js
@@ -1,0 +1,367 @@
+'use strict';
+
+/**
+ * The real MCP protocol endpoint (`POST/GET/DELETE /api/mcp`, JSON-RPC 2.0
+ * over the streamable-HTTP transport). This is the only place in the repo
+ * that speaks MCP wire protocol — everything it does is delegate to the
+ * `mcp-server` Moleculer service's 9 actions (services/mcp-server.service.js)
+ * for actual behavior.
+ *
+ * One MCP session = one `StreamableHTTPServerTransport` + one dedicated
+ * `McpServer` whose 9 tool callbacks are closed over that session's resolved
+ * auth (`src/mcp-auth.js`), captured once at session-initialize time. This
+ * avoids re-verifying the bearer token on every tool call while still
+ * gating writes correctly (src/mcp-rbac-gate.js runs inside the downstream
+ * `mcp-server.*` actions using that captured `ctx.meta`).
+ *
+ * Registered as raw (non-aliased) handlers on the `/api` route in
+ * services/api.service.js, the same pattern already used there for
+ * `/metrics` and the datasource upload endpoints — raw handlers get the
+ * native Node req/res and bypass `onBeforeCall`'s token resolution, which is
+ * why auth is done here explicitly via `resolveMcpAuth` instead.
+ */
+
+const { randomUUID } = require('crypto');
+const { z } = require('zod');
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+const {
+  StreamableHTTPServerTransport,
+} = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+const { isInitializeRequest } = require('@modelcontextprotocol/sdk/types.js');
+const { resolveMcpAuth } = require('./mcp-auth');
+const { version: packageVersion } = require('../package.json');
+
+const SERVER_INFO = { name: 'cernion-energy-tools', version: packageVersion };
+const MAX_BODY_BYTES = 10 * 1024 * 1024; // generous for tool-call payloads (e.g. receipt inputs)
+
+const anyObject = () => z.record(z.string(), z.any()).optional();
+
+// One entry per meta-tool from docs/mcp-server.md. `annotations` follow the
+// convention already used by src/energy-sidecar-mcp-bridge.js's
+// toMcpTool() (safetyClass/sideEffects-style hints), translated to the
+// MCP-standard ToolAnnotations fields.
+const TOOL_DEFS = [
+  {
+    name: 'cernion_ask',
+    action: 'mcp-server.ask',
+    title: 'Ask Cernion',
+    description:
+      'Standard factual question about the energy domain (grid, market, regulatory). CET routes ' +
+      'internally and answers directly with evidence, guardrails, and process context. Try this first ' +
+      '— it covers most requests without needing search/describe/execute_read.',
+    annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+    inputSchema: {
+      question: z.string().min(1).max(8000),
+      context: anyObject(),
+      sessionId: z.string().optional(),
+      domain: z.string().optional(),
+      mode: z.string().optional(),
+      format: z.enum(['compact', 'dossier']).optional(),
+      maxEvidence: z.number().min(1).max(12).optional(),
+      parentDossierId: z.string().optional(),
+    },
+  },
+  {
+    name: 'cernion_search',
+    action: 'mcp-server.search',
+    title: 'Search Cernion catalogue',
+    description:
+      'Unified search over capabilities, REST operations, agent receipts, blueprints, and cookbook ' +
+      'recipes. Returns compact typed refs (cernion://{kind}/{id}) — use cernion_describe for full detail.',
+    annotations: { readOnlyHint: true, openWorldHint: true },
+    inputSchema: {
+      query: z.string().min(1).max(500),
+      kind: z.enum(['capability', 'operation', 'receipt', 'blueprint', 'recipe']).optional(),
+      domain: z.string().optional(),
+      limit: z.number().min(1).max(50).optional(),
+    },
+  },
+  {
+    name: 'cernion_describe',
+    action: 'mcp-server.describe',
+    title: 'Describe a Cernion ref',
+    description:
+      'Full detail for any ref returned by cernion_search: operation schema/policy, receipt payload ' +
+      'plus dry-run explanation, blueprint definition and lifecycle status, or recipe steps.',
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      ref: z.string().optional(),
+      kind: z.enum(['capability', 'operation', 'receipt', 'blueprint', 'recipe']).optional(),
+      id: z.string().optional(),
+    },
+  },
+  {
+    name: 'cernion_execute_read',
+    action: 'mcp-server.executeRead',
+    title: 'Execute a read-only operation',
+    description:
+      'Executes a read-only REST operation selected via ref (from cernion_search/describe) or an ' +
+      'explicit method+path. Server-side allowlist enforced — refused if the operation is not GET or ' +
+      'on the small read-classified POST allowlist (evidence-router, knowledge-rag, receipt dry-runs).',
+    annotations: { readOnlyHint: true, openWorldHint: true },
+    inputSchema: {
+      ref: z.string().optional(),
+      operationId: z.string().optional(),
+      method: z.string().optional(),
+      path: z.string().optional(),
+      pathParams: anyObject(),
+      query: anyObject(),
+      body: anyObject(),
+    },
+  },
+  {
+    name: 'cernion_run_receipt',
+    action: 'mcp-server.runReceipt',
+    title: 'Run a curated agent receipt',
+    description:
+      'Plans (mode=plan, default) or runs (mode=run) a curated playbook receipt. mode=run never writes ' +
+      'directly — if the plan is executable it creates a confirmation intent via the same path as ' +
+      'cernion_prepare_process, which cernion_execute_process must then confirm.',
+    annotations: { readOnlyHint: false, destructiveHint: false },
+    inputSchema: {
+      id: z.string().optional(),
+      receipt: anyObject(),
+      context: anyObject(),
+      input: anyObject(),
+      mode: z.enum(['plan', 'run']).optional(),
+    },
+  },
+  {
+    name: 'cernion_prepare_process',
+    action: 'mcp-server.prepareProcess',
+    title: 'Prepare a process intent',
+    description:
+      'Prepares any mutation (business write or governance action) as a pending_confirmation intent. ' +
+      'Never writes by itself. Returns a cernion://intent/{id} ref for cernion_execute_process.',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    inputSchema: {
+      operationFamily: z.string().min(1).max(64),
+      proposedAction: z.string().min(1).max(200),
+      targetType: z.string().optional(),
+      targetId: z.string().optional(),
+      inputSummary: z.string().max(500).optional(),
+      payload: anyObject(),
+      risk: z.enum(['low', 'medium', 'high']).optional(),
+      reason: z.string().max(500).optional(),
+      correlationId: z.string().optional(),
+      decisionFrameId: z.string().optional(),
+    },
+  },
+  {
+    name: 'cernion_execute_process',
+    action: 'mcp-server.executeProcess',
+    title: 'Execute or reject a process intent',
+    description:
+      'Executes (action=execute, default) or rejects (action=reject) a pending_confirmation intent by ' +
+      'id/ref. Deliberately a separate tool call from cernion_prepare_process so a client cannot ' +
+      'prepare-and-execute in one shot. NOTE: intents created with a domain-agnostic operationFamily ' +
+      'have no wired auto-execution (by design — see docs/mcp-server.md) and will fail execute with a ' +
+      'clear error; reject still works for those.',
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
+    inputSchema: {
+      ref: z.string().optional(),
+      intentId: z.string().optional(),
+      action: z.enum(['execute', 'reject']).optional(),
+      reason: z.string().optional(),
+      executedBy: z.string().optional(),
+      rejectedBy: z.string().optional(),
+      correlationId: z.string().optional(),
+    },
+  },
+  {
+    name: 'cernion_process_status',
+    action: 'mcp-server.processStatus',
+    title: 'Check process/job/HITL status',
+    description:
+      'Unified status for anything in flight: a process intent, an async job, or a HITL item — by ref, ' +
+      'or list="open" for an overview of pending intents and HITL items.',
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      ref: z.string().optional(),
+      kind: z.enum(['intent', 'job', 'hitl']).optional(),
+      id: z.string().optional(),
+      list: z.enum(['open']).optional(),
+    },
+  },
+  {
+    name: 'cernion_get_context',
+    action: 'mcp-server.getContext',
+    title: 'Get session context',
+    description:
+      'Tenant/session context at the start of a conversation: sidecar descriptor and (if a tenantId is ' +
+      'known) quota snapshot. Optional — call this to make cernion_ask more precise up front.',
+    annotations: { readOnlyHint: true },
+    inputSchema: { tenantId: z.string().optional() },
+  },
+];
+
+function toolSuccessResult(payload) {
+  return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
+}
+
+function toolErrorResult(err) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          { error: err.message, type: err.type || err.name || 'Error', data: err.data },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let bytes = 0;
+    req.on('data', (chunk) => {
+      bytes += chunk.length;
+      if (bytes > MAX_BODY_BYTES) {
+        reject(new Error('MCP request body exceeds size limit'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      if (chunks.length === 0) {
+        resolve(undefined);
+        return;
+      }
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function buildSessionMcpServer(broker, sessionMeta) {
+  const server = new McpServer(SERVER_INFO, { capabilities: { tools: {} } });
+  for (const def of TOOL_DEFS) {
+    server.registerTool(
+      def.name,
+      {
+        title: def.title,
+        description: def.description,
+        inputSchema: def.inputSchema,
+        annotations: def.annotations,
+      },
+      async (args) => {
+        try {
+          const result = await broker.call(def.action, args || {}, { meta: { ...sessionMeta } });
+          return toolSuccessResult(result);
+        } catch (err) {
+          return toolErrorResult(err);
+        }
+      }
+    );
+  }
+  return server;
+}
+
+function writeJsonError(res, status, message) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: message }));
+}
+
+/**
+ * @param {import('moleculer').ServiceBroker} broker
+ */
+function createMcpHttpHandlers(broker) {
+  // sessionId -> { transport, server }. Single-process, in-memory — matches
+  // job-store/rate-quota-store's own in-memory-only conventions elsewhere
+  // in this codebase; MCP sessions are short-lived (one client connection).
+  const sessions = new Map();
+
+  async function post(req, res) {
+    const sessionId = req.headers['mcp-session-id'];
+    // Behind services/api.service.js's `/api` route, moleculer-web's own
+    // bodyParsers middleware already consumes and parses the JSON body into
+    // `req.body` before this raw alias handler runs (same as the
+    // `POST /datasources/uploads` raw handler on that route) — re-reading
+    // the stream here would hang. Fall back to reading it ourselves only
+    // when nothing pre-parsed it (e.g. this handler mounted standalone, as
+    // tests/mcp-transport.test.js does).
+    let body = req.body;
+    if (body === undefined) {
+      try {
+        body = await readJsonBody(req);
+      } catch (err) {
+        writeJsonError(res, 400, `Invalid JSON-RPC body: ${err.message}`);
+        return;
+      }
+    }
+
+    if (sessionId && sessions.has(sessionId)) {
+      await sessions.get(sessionId).transport.handleRequest(req, res, body);
+      return;
+    }
+
+    if (!sessionId && isInitializeRequest(body)) {
+      const auth = await resolveMcpAuth(broker, req.headers['authorization']);
+      if (!auth.ok) {
+        writeJsonError(res, auth.status, auth.message);
+        return;
+      }
+
+      const server = buildSessionMcpServer(broker, auth.meta);
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (newSessionId) => {
+          sessions.set(newSessionId, { transport, server });
+        },
+        onsessionclosed: (closedSessionId) => {
+          sessions.delete(closedSessionId);
+        },
+      });
+      transport.onclose = () => {
+        if (transport.sessionId) sessions.delete(transport.sessionId);
+      };
+
+      await server.connect(transport);
+      await transport.handleRequest(req, res, body);
+      return;
+    }
+
+    writeJsonError(
+      res,
+      400,
+      sessionId
+        ? 'Unknown or expired mcp-session-id'
+        : 'First request on a new MCP connection must be an "initialize" request'
+    );
+  }
+
+  async function get(req, res) {
+    const sessionId = req.headers['mcp-session-id'];
+    const session = sessionId && sessions.get(sessionId);
+    if (!session) {
+      writeJsonError(res, 400, 'Unknown or expired mcp-session-id');
+      return;
+    }
+    await session.transport.handleRequest(req, res);
+  }
+
+  async function del(req, res) {
+    const sessionId = req.headers['mcp-session-id'];
+    const session = sessionId && sessions.get(sessionId);
+    if (!session) {
+      writeJsonError(res, 400, 'Unknown or expired mcp-session-id');
+      return;
+    }
+    await session.transport.handleRequest(req, res);
+    sessions.delete(sessionId);
+  }
+
+  return { post, get, delete: del };
+}
+
+module.exports = { createMcpHttpHandlers, TOOL_DEFS };

--- a/src/mcp-uri.js
+++ b/src/mcp-uri.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Typed reference URIs shared by the inbound MCP server's meta-tools
+ * (`cernion://{kind}/{id}`) — see docs/mcp-server.md design principle #2.
+ * `search`/`describe` emit these; `execute_read`/`run_receipt`/
+ * `prepare_process`/`process_status` accept them back.
+ */
+
+const SCHEME = 'cernion';
+
+const KINDS = new Set([
+  'operation',
+  'capability',
+  'receipt',
+  'blueprint',
+  'recipe',
+  'intent',
+  'job',
+  'hitl',
+]);
+
+function buildRef(kind, id) {
+  if (!KINDS.has(kind)) {
+    throw new Error(`mcp-uri: unknown kind "${kind}"`);
+  }
+  if (id === undefined || id === null || id === '') {
+    throw new Error('mcp-uri: id is required');
+  }
+  return `${SCHEME}://${kind}/${encodeURIComponent(String(id))}`;
+}
+
+/**
+ * Parses a `cernion://{kind}/{id}` ref. Returns `null` if `input` isn't a
+ * ref at all (callers use this to fall back to treating `input` as a bare
+ * id + separately-supplied `kind`).
+ */
+function parseRef(input) {
+  if (typeof input !== 'string') return null;
+  const match = /^cernion:\/\/([a-z]+)\/(.+)$/.exec(input.trim());
+  if (!match) return null;
+  const [, kind, rawId] = match;
+  if (!KINDS.has(kind)) return null;
+  let id;
+  try {
+    id = decodeURIComponent(rawId);
+  } catch {
+    id = rawId;
+  }
+  return { kind, id };
+}
+
+module.exports = { buildRef, parseRef, KINDS };

--- a/tests/mcp-server.service.test.js
+++ b/tests/mcp-server.service.test.js
@@ -1,0 +1,514 @@
+'use strict';
+
+const { ServiceBroker } = require('moleculer');
+const McpServerService = require('../services/mcp-server.service');
+
+describe('MCP Server meta-tools', () => {
+  let broker;
+
+  beforeAll(async () => {
+    broker = new ServiceBroker({ logger: false });
+
+    broker.createService({
+      name: 'agent-manifest',
+      actions: {
+        listCapabilities: {
+          params: { domain: { type: 'string', optional: true } },
+          handler(ctx) {
+            const rows = [
+              {
+                capability: 'redispatch_asset_register',
+                domain: 'redispatch',
+                intent: 'List assets',
+              },
+            ];
+            return {
+              success: true,
+              data: ctx.params.domain ? rows.filter((r) => r.domain === ctx.params.domain) : rows,
+            };
+          },
+        },
+        getCapability: {
+          params: { name: { type: 'string' } },
+          handler(ctx) {
+            if (ctx.params.name !== 'redispatch_asset_register') {
+              throw new (require('moleculer').Errors.MoleculerClientError)('not found', 404);
+            }
+            return { success: true, data: { capability: ctx.params.name, intent: 'List assets' } };
+          },
+        },
+        listOperations: {
+          params: { domain: { type: 'string', optional: true } },
+          handler() {
+            return {
+              success: true,
+              data: [
+                {
+                  method: 'GET',
+                  path: '/api/energy-market/prices',
+                  operationId: 'getPrices',
+                  summary: 'Prices',
+                  tags: [],
+                },
+                {
+                  method: 'POST',
+                  path: '/api/copilot-process/intents',
+                  operationId: 'prepareProcessIntent',
+                  summary: 'Prepare intent',
+                  tags: [],
+                },
+              ],
+            };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'personal-agent',
+      actions: {
+        askCernionAgent: {
+          params: { question: { type: 'string' } },
+          handler(ctx) {
+            return {
+              sessionId: 's1',
+              question: ctx.params.question,
+              shortAnswer: 'answer',
+              evidence: [],
+            };
+          },
+        },
+        answerDossier: {
+          params: { question: { type: 'string' } },
+          handler(ctx) {
+            return { sessionId: 's1', question: ctx.params.question, dossierMarkdown: '# dossier' };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'evidence-router',
+      actions: {
+        route: {
+          params: { question: { type: 'string' } },
+          handler() {
+            return { success: true, resolved: { kind: 'evidence_plan' } };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'agent-receipts',
+      actions: {
+        list: {
+          params: {
+            domain: { type: 'string', optional: true },
+            limit: { type: 'number', optional: true },
+          },
+          handler() {
+            return {
+              success: true,
+              data: [
+                {
+                  receiptId: 'bess-screening-v1',
+                  title: 'BESS screening',
+                  description: 'storage receipt',
+                  tags: ['bess'],
+                },
+              ],
+            };
+          },
+        },
+        get: {
+          params: { id: { type: 'string' } },
+          handler(ctx) {
+            return { success: true, data: { receiptId: ctx.params.id, title: 'BESS screening' } };
+          },
+        },
+        explainStored: {
+          params: { id: { type: 'string' } },
+          handler() {
+            return { success: true, data: { summary: 'would run 1 step' } };
+          },
+        },
+        test: {
+          params: {
+            id: { type: 'string', optional: true },
+            receipt: { type: 'object', optional: true },
+            context: { type: 'object', optional: true },
+            input: { type: 'object', optional: true },
+          },
+          handler(ctx) {
+            const executable = ctx.params.input && ctx.params.input.gridOperator === 'Netze BW';
+            return {
+              success: true,
+              data: {
+                receiptId: ctx.params.id || 'inline-receipt',
+                executable: !!executable,
+                plan: { steps: [{ action: 'grid-operations.marketPartners', params: {} }] },
+                missingRequiredInputs: executable ? [] : ['gridOperator'],
+                warnings: [],
+                errors: [],
+              },
+            };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'blueprint-management',
+      actions: {
+        list: {
+          handler() {
+            return {
+              success: true,
+              data: [
+                {
+                  blueprintId: 'ev-charging-co2-optimization-v1',
+                  title: 'EV CO2',
+                  description: 'charging',
+                },
+              ],
+            };
+          },
+        },
+        get: {
+          params: { id: { type: 'string' } },
+          handler(ctx) {
+            return { success: true, data: { blueprintId: ctx.params.id, title: 'EV CO2' } };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'cookbook',
+      actions: {
+        search: {
+          params: { query: { type: 'string' }, limit: { type: 'number', optional: true } },
+          handler() {
+            return {
+              success: true,
+              data: [{ id: 'vnb-assets-from-name', title: 'VNB assets', description: 'lookup' }],
+            };
+          },
+        },
+        get: {
+          params: { id: { type: 'string' } },
+          handler(ctx) {
+            return { success: true, data: { id: ctx.params.id, title: 'VNB assets' } };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'copilot-process',
+      actions: {
+        prepareProcessIntent: {
+          params: { operationFamily: { type: 'string' }, proposedAction: { type: 'string' } },
+          handler(ctx) {
+            return {
+              success: true,
+              resolved: { kind: 'process_intake' },
+              receipt: {
+                intentId: 'intent-1',
+                operationFamily: ctx.params.operationFamily,
+                proposedAction: ctx.params.proposedAction,
+                status: 'pending_confirmation',
+              },
+              executeVia: { operationId: 'executeProcessIntent', note: 'human executes' },
+            };
+          },
+        },
+        getProcessIntent: {
+          params: { intentId: { type: 'string' } },
+          handler(ctx) {
+            return { intentId: ctx.params.intentId, status: 'pending_confirmation' };
+          },
+        },
+        listProcessIntents: {
+          handler() {
+            return {
+              count: 1,
+              intents: [{ intentId: 'intent-1', status: 'pending_confirmation' }],
+            };
+          },
+        },
+        executeProcessIntent: {
+          params: { intentId: { type: 'string' } },
+          handler(ctx) {
+            if (ctx.params.intentId === 'generic-intent') {
+              const err = new (require('moleculer').Errors.MoleculerClientError)(
+                'Unknown operationFamily',
+                400,
+                'UNKNOWN_OPERATION_FAMILY'
+              );
+              throw err;
+            }
+            return { intentId: ctx.params.intentId, status: 'executed' };
+          },
+        },
+        rejectProcessIntent: {
+          params: { intentId: { type: 'string' }, reason: { type: 'string' } },
+          handler(ctx) {
+            return { intentId: ctx.params.intentId, status: 'rejected', reason: ctx.params.reason };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'job-status',
+      actions: {
+        status: {
+          params: { jobId: { type: 'string' } },
+          handler(ctx) {
+            return {
+              jobId: ctx.params.jobId,
+              status: 'completed',
+              resultUrl: `/api/jobs/${ctx.params.jobId}/result`,
+            };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'hitl',
+      actions: {
+        get: {
+          params: { id: { type: 'string' } },
+          handler(ctx) {
+            return { success: true, item: { id: ctx.params.id, status: 'pending' } };
+          },
+        },
+        list: {
+          handler() {
+            return { success: true, count: 1, items: [{ id: 'hitl-1', status: 'pending' }] };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'agent-sidecar',
+      actions: {
+        descriptor: {
+          handler() {
+            return { name: 'cernion', tools: [] };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'tenant-quota',
+      actions: {
+        getQuotas: {
+          params: { id: { type: 'string' } },
+          handler(ctx) {
+            return { success: true, data: { tenantId: ctx.params.id, limits: {} } };
+          },
+        },
+      },
+    });
+
+    broker.createService(McpServerService);
+    await broker.start();
+  });
+
+  afterAll(() => broker.stop());
+
+  const FULL_ACCESS_META = { authUser: { roles: ['full-access'] } };
+
+  test('ask (compact) delegates to personal-agent.askCernionAgent', async () => {
+    const res = await broker.call(
+      'mcp-server.ask',
+      { question: 'Wieviel PV in Bayern?' },
+      { meta: FULL_ACCESS_META }
+    );
+    expect(res.success).toBe(true);
+    expect(res.shortAnswer).toBe('answer');
+  });
+
+  test('ask (dossier) delegates to personal-agent.answerDossier', async () => {
+    const res = await broker.call(
+      'mcp-server.ask',
+      { question: 'Frage', format: 'dossier' },
+      { meta: FULL_ACCESS_META }
+    );
+    expect(res.dossierMarkdown).toBe('# dossier');
+  });
+
+  test('ask refuses a caller without the full-access role', async () => {
+    await expect(
+      broker.call(
+        'mcp-server.ask',
+        { question: 'Frage' },
+        { meta: { authUser: { roles: ['read-only'] } } }
+      )
+    ).rejects.toMatchObject({ type: 'ROLE_REQUIRED' });
+  });
+
+  test('ask allows a legacy bearer token (bypassRbac, matches REST gateway parity)', async () => {
+    const res = await broker.call(
+      'mcp-server.ask',
+      { question: 'Frage' },
+      { meta: { bypassRbac: true, authUser: null } }
+    );
+    expect(res.success).toBe(true);
+  });
+
+  test('search fans out across kinds and filters by query', async () => {
+    const res = await broker.call('mcp-server.search', { query: 'bess' });
+    expect(res.success).toBe(true);
+    expect(
+      res.results.some(
+        (r) => r.kind === 'receipt' && r.ref === 'cernion://receipt/bess-screening-v1'
+      )
+    ).toBe(true);
+  });
+
+  test('search with kind filter only queries that kind', async () => {
+    const res = await broker.call('mcp-server.search', { query: 'ev-charging', kind: 'blueprint' });
+    expect(res.results).toHaveLength(1);
+    expect(res.results[0].kind).toBe('blueprint');
+  });
+
+  test('describe resolves a receipt ref', async () => {
+    const res = await broker.call('mcp-server.describe', {
+      ref: 'cernion://receipt/bess-screening-v1',
+    });
+    expect(res.success).toBe(true);
+    expect(res.data.receipt.receiptId).toBe('bess-screening-v1');
+    expect(res.data.explanation.summary).toBe('would run 1 step');
+  });
+
+  test('describe an operation includes execute-read policy', async () => {
+    const res = await broker.call('mcp-server.describe', { kind: 'operation', id: 'getPrices' });
+    expect(res.data.executeReadPolicy.allowed).toBe(true);
+  });
+
+  test('executeRead refuses a non-allowlisted write operation', async () => {
+    await expect(
+      broker.call(
+        'mcp-server.executeRead',
+        { operationId: 'prepareProcessIntent' },
+        { meta: { mcpBearerToken: 'tok' } }
+      )
+    ).rejects.toMatchObject({ type: 'MCP_EXECUTE_READ_FORBIDDEN' });
+  });
+
+  test('executeRead requires a bearer token', async () => {
+    await expect(
+      broker.call('mcp-server.executeRead', { operationId: 'getPrices' })
+    ).rejects.toMatchObject({
+      type: 'MCP_NO_BEARER_TOKEN',
+    });
+  });
+
+  test('runReceipt returns a plan when not executable', async () => {
+    const res = await broker.call('mcp-server.runReceipt', {
+      id: 'bess-screening-v1',
+      mode: 'run',
+    });
+    expect(res.mode).toBe('plan');
+    expect(res.plan.executable).toBe(false);
+  });
+
+  test('runReceipt mode=run creates a confirmation intent when executable', async () => {
+    const res = await broker.call(
+      'mcp-server.runReceipt',
+      { id: 'bess-screening-v1', mode: 'run', input: { gridOperator: 'Netze BW' } },
+      { meta: FULL_ACCESS_META }
+    );
+    expect(res.mode).toBe('run');
+    expect(res.intent.intentId).toBe('intent-1');
+    expect(res.intent.operationFamily).toBe('agent-receipt');
+  });
+
+  test('runReceipt mode=run refuses a caller without full-access when executable', async () => {
+    await expect(
+      broker.call(
+        'mcp-server.runReceipt',
+        { id: 'bess-screening-v1', mode: 'run', input: { gridOperator: 'Netze BW' } },
+        { meta: { authUser: { roles: ['read-only'] } } }
+      )
+    ).rejects.toMatchObject({ type: 'ROLE_REQUIRED' });
+  });
+
+  test('prepareProcess creates an intent and returns its ref', async () => {
+    const res = await broker.call(
+      'mcp-server.prepareProcess',
+      { operationFamily: 'customer_master_data_correction', proposedAction: 'correct_address' },
+      { meta: FULL_ACCESS_META }
+    );
+    expect(res.ref).toBe('cernion://intent/intent-1');
+  });
+
+  test('prepareProcess refuses a caller without the full-access role', async () => {
+    await expect(
+      broker.call(
+        'mcp-server.prepareProcess',
+        { operationFamily: 'customer_master_data_correction', proposedAction: 'correct_address' },
+        { meta: { authUser: { roles: ['read-only'] } } }
+      )
+    ).rejects.toMatchObject({ type: 'ROLE_REQUIRED' });
+  });
+
+  test('executeProcess rejects an intent when action=reject', async () => {
+    const res = await broker.call(
+      'mcp-server.executeProcess',
+      { intentId: 'intent-1', action: 'reject', reason: 'no longer needed' },
+      { meta: FULL_ACCESS_META }
+    );
+    expect(res.status).toBe('rejected');
+  });
+
+  test('executeProcess surfaces a friendly error for generic-family intents', async () => {
+    await expect(
+      broker.call(
+        'mcp-server.executeProcess',
+        { intentId: 'generic-intent' },
+        { meta: FULL_ACCESS_META }
+      )
+    ).rejects.toMatchObject({ type: 'MCP_INTENT_REQUIRES_MANUAL_EXECUTION' });
+  });
+
+  test('executeProcess refuses a caller without the full-access role', async () => {
+    await expect(
+      broker.call(
+        'mcp-server.executeProcess',
+        { intentId: 'intent-1' },
+        { meta: { authUser: { roles: ['read-only'] } } }
+      )
+    ).rejects.toMatchObject({ type: 'ROLE_REQUIRED' });
+  });
+
+  test('processStatus resolves an intent ref', async () => {
+    const res = await broker.call('mcp-server.processStatus', { ref: 'cernion://intent/intent-1' });
+    expect(res.data.status).toBe('pending_confirmation');
+  });
+
+  test('processStatus list=open merges intents and hitl items', async () => {
+    const res = await broker.call('mcp-server.processStatus', { list: 'open' });
+    expect(res.intents).toHaveLength(1);
+    expect(res.hitlItems).toHaveLength(1);
+  });
+
+  test('getContext includes descriptor and quotas when tenantId is known', async () => {
+    const res = await broker.call('mcp-server.getContext', { tenantId: 'stadtwerk-a' });
+    expect(res.descriptor.name).toBe('cernion');
+    expect(res.quotas.tenantId).toBe('stadtwerk-a');
+  });
+
+  test('getContext omits quotas gracefully when no tenantId is known', async () => {
+    const res = await broker.call('mcp-server.getContext', {});
+    expect(res.quotas).toBeNull();
+    expect(res.quotasNote).toBeTruthy();
+  });
+});

--- a/tests/mcp-transport.test.js
+++ b/tests/mcp-transport.test.js
@@ -1,0 +1,185 @@
+'use strict';
+
+const http = require('http');
+const { ServiceBroker } = require('moleculer');
+const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+const {
+  StreamableHTTPClientTransport,
+} = require('@modelcontextprotocol/sdk/client/streamableHttp.js');
+const McpServerService = require('../services/mcp-server.service');
+const { createMcpHttpHandlers } = require('../src/mcp-transport');
+
+describe('MCP transport (real streamable-HTTP round trip)', () => {
+  let broker;
+  let httpServer;
+  let baseUrl;
+
+  beforeAll(async () => {
+    broker = new ServiceBroker({ logger: false });
+
+    broker.createService({
+      name: 'agent-manifest',
+      actions: {
+        listCapabilities: {
+          handler() {
+            return {
+              success: true,
+              data: [{ capability: 'redispatch_asset_register', intent: 'List assets' }],
+            };
+          },
+        },
+        listOperations: {
+          handler() {
+            return { success: true, data: [] };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'personal-agent',
+      actions: {
+        askCernionAgent: {
+          handler(ctx) {
+            return { sessionId: 's1', shortAnswer: `answered: ${ctx.params.question}` };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'copilot-process',
+      actions: {
+        prepareProcessIntent: {
+          handler() {
+            return {
+              success: true,
+              receipt: { intentId: 'intent-1', status: 'pending_confirmation' },
+              executeVia: { operationId: 'executeProcessIntent' },
+            };
+          },
+        },
+      },
+    });
+
+    broker.createService({
+      name: 'token-manager',
+      actions: {
+        verify: {
+          handler(ctx) {
+            if (ctx.params.token === 'ck_full') {
+              return { valid: true, tokenId: 't1', scope: 'full-access', scopes: [] };
+            }
+            if (ctx.params.token === 'ck_readonly') {
+              return { valid: true, tokenId: 't2', scope: 'read-only', scopes: [] };
+            }
+            return { valid: false, reason: 'INVALID' };
+          },
+        },
+      },
+    });
+
+    broker.createService(McpServerService);
+    await broker.start();
+
+    const handlers = createMcpHttpHandlers(broker);
+    httpServer = http.createServer(async (req, res) => {
+      if (req.url !== '/mcp') {
+        res.writeHead(404).end();
+        return;
+      }
+      if (req.method === 'POST') return handlers.post(req, res);
+      if (req.method === 'GET') return handlers.get(req, res);
+      if (req.method === 'DELETE') return handlers.delete(req, res);
+      res.writeHead(405).end();
+    });
+
+    await new Promise((resolve) => httpServer.listen(0, resolve));
+    baseUrl = `http://127.0.0.1:${httpServer.address().port}/mcp`;
+  });
+
+  afterAll(async () => {
+    await broker.stop();
+    await new Promise((resolve) => httpServer.close(resolve));
+  });
+
+  async function connectClient(bearerToken) {
+    const transport = new StreamableHTTPClientTransport(new URL(baseUrl), {
+      requestInit: { headers: { Authorization: `Bearer ${bearerToken}` } },
+    });
+    const client = new Client({ name: 'test-client', version: '0.0.1' });
+    await client.connect(transport);
+    return client;
+  }
+
+  test('lists exactly the 9 documented meta-tools', async () => {
+    const client = await connectClient('legacy-plain-token');
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual(
+      [
+        'cernion_ask',
+        'cernion_describe',
+        'cernion_execute_process',
+        'cernion_execute_read',
+        'cernion_get_context',
+        'cernion_prepare_process',
+        'cernion_process_status',
+        'cernion_run_receipt',
+        'cernion_search',
+      ].sort()
+    );
+    await client.close();
+  });
+
+  test('cernion_search works over a legacy bearer token', async () => {
+    const client = await connectClient('legacy-plain-token');
+    const result = await client.callTool({
+      name: 'cernion_search',
+      arguments: { query: 'redispatch', kind: 'capability' },
+    });
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.results[0].ref).toBe('cernion://capability/redispatch_asset_register');
+    await client.close();
+  });
+
+  test('cernion_ask works over a legacy bearer token (RBAC bypass parity)', async () => {
+    const client = await connectClient('legacy-plain-token');
+    const result = await client.callTool({
+      name: 'cernion_ask',
+      arguments: { question: 'Wieviel PV?' },
+    });
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.shortAnswer).toBe('answered: Wieviel PV?');
+    await client.close();
+  });
+
+  test('cernion_prepare_process succeeds for a full-access ck_ token', async () => {
+    const client = await connectClient('ck_full');
+    const result = await client.callTool({
+      name: 'cernion_prepare_process',
+      arguments: { operationFamily: 'test_family', proposedAction: 'do_thing' },
+    });
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.ref).toBe('cernion://intent/intent-1');
+    await client.close();
+  });
+
+  test('cernion_prepare_process is refused for a read-only ck_ token', async () => {
+    const client = await connectClient('ck_readonly');
+    const result = await client.callTool({
+      name: 'cernion_prepare_process',
+      arguments: { operationFamily: 'test_family', proposedAction: 'do_thing' },
+    });
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.type).toBe('ROLE_REQUIRED');
+    await client.close();
+  });
+
+  test('a bad ck_ token is refused at session initialization', async () => {
+    await expect(connectClient('ck_bogus')).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a real MCP server (JSON-RPC 2.0 over streamable-HTTP, `POST/GET/DELETE /api/mcp`) exposing 9 layer-based meta-tools instead of a 1:1 mapping over the platform's ~1,100 REST operations: `cernion_ask`, `cernion_search`, `cernion_describe`, `cernion_execute_read`, `cernion_run_receipt`, `cernion_prepare_process`, `cernion_execute_process`, `cernion_process_status`, `cernion_get_context`. Authenticates with the same Bearer tokens as the REST API.

- Full design + explicit deviations from the original design concept (found while wiring against the real codebase — no `confirmation_token` exists server-side, generic process intents have no wired auto-execution by design, agent receipts have no direct execution path): `docs/mcp-server.md`
- Bumps `package.json` to `0.99.2` and adds the `CHANGELOG.md` entry for this release.

## Why the extra `src/mcp-auth.js` / `src/mcp-rbac-gate.js` / `src/mcp-execute-read-policy.js`

`/api/mcp` is registered as a raw route (same pattern as `/metrics` and the datasource upload endpoints already on `services/api.service.js`'s `/api` route), which bypasses `onBeforeCall`'s bearer-token resolution and RBAC enforcement entirely. Without replicating the relevant parts of that logic, a `read-only`-scoped API token could reach writes through MCP that it can't reach through REST — a real gap, closed here rather than left open. `cernion_execute_read` instead reaches operations via an authenticated HTTP loopback into the real gateway, reusing its actual auth/RBAC/rate-limiting rather than re-implementing the alias→action routing table a second time.

## Test plan

- [x] `tests/mcp-server.service.test.js` (22 tests) — the 9 actions against stubbed dependency services, including RBAC gate allow/deny paths
- [x] `tests/mcp-transport.test.js` (6 tests) — real end-to-end round trip: real HTTP server, real `@modelcontextprotocol/sdk` client over `StreamableHTTPClientTransport`, `tools/list` returning exactly the 9 tools, both legacy-token and `ck_` full-access/read-only auth paths
- [x] Full existing suites for both touched core files pass with no regressions: `tests/api.service.test.js` (880 tests), `tests/agent.service.test.js` (590 tests)
- [x] `npm run lint` clean
- [x] `npm run check:llm`, `npm run check:operation-capability-index` — new operations mapped into the manifest taxonomy, generated artifacts regenerated and in sync
- [x] `npm run check:quality-gate`, `npm run audit:security` pass
- [x] Full local suite (7195 tests) — 7136 passed; the only 8 failures are pre-existing environmental noise on the shared dev sandbox unrelated to this change (a foreign `sandbox.stromdao.de` app answering on port 3000 instead of this service, and a LevelDB lock held by a concurrent process on this shared box) — will not reproduce on CI's clean checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)