### PR TITLE
feat(token-manager): add display-safe token signal queue

### DIFF
--- a/services/token-manager.service.js
+++ b/services/token-manager.service.js
@@ -426,7 +426,7 @@ module.exports = {
           };
           tokens[matchIndex] = updatedRecord;
           this.saveTokens(tokens);
-          if (usageSignal.signalStage) {
+          if (usageSignal.signalStage && typeof this.recordTokenSignal === 'function') {
             this.recordTokenSignal(updatedRecord, usageSignal.signalStage, {
               signalAt: usedAt,
               channel: usageSignal.channel,
@@ -569,11 +569,13 @@ module.exports = {
 
       tokens.push(record);
       this.saveTokens(tokens);
-      this.recordTokenSignal(record, 'token_registered', {
-        signalAt: createdAt,
-        channel: 'unknown',
-        source: 'token-manager',
-      });
+      if (typeof this.recordTokenSignal === 'function') {
+        this.recordTokenSignal(record, 'token_registered', {
+          signalAt: createdAt,
+          channel: 'unknown',
+          source: 'token-manager',
+        });
+      }
 
       return {
         success: true,

--- a/services/token-manager.service.js
+++ b/services/token-manager.service.js
@@ -18,6 +18,8 @@ const {
 } = require('../src/gateway-request-classifiers');
 
 const DEFAULT_STORAGE_FILE = process.env.TOKEN_STORAGE_FILE || './uploads/.api-tokens.json';
+const DEFAULT_SIGNAL_QUEUE_FILE =
+  process.env.TOKEN_SIGNAL_QUEUE_FILE || './uploads/.api-token-signals.json';
 const MAX_NAME_LENGTH = 60;
 const ALLOWED_EXTRA_SCOPES = new Set([
   'vnb-monitor',
@@ -84,6 +86,64 @@ function normalizeScopes(scope, requestedScopes = []) {
   return [...scopes];
 }
 
+function classifyTokenUsageSignal(method, requestPath) {
+  const normalizedPath = String(requestPath || '')
+    .split('?')[0]
+    .toLowerCase();
+  if (normalizedPath === '/api/mcp' || normalizedPath.startsWith('/api/mcp/')) {
+    return { channel: 'mcp', signalStage: 'first_mcp_call', source: 'mcp-transport' };
+  }
+  if (normalizedPath.startsWith('/v1/')) {
+    return { channel: 'rest', signalStage: 'first_api_call', source: 'openai-facade' };
+  }
+  if (normalizedPath.startsWith('/api/')) {
+    return { channel: 'rest', signalStage: 'first_api_call', source: 'rest-gateway' };
+  }
+  if (method) {
+    return { channel: 'rest', signalStage: 'first_api_call', source: 'rest-gateway' };
+  }
+  return { channel: 'unknown', signalStage: null, source: 'token-manager' };
+}
+
+function isEmail(value) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(value || ''));
+}
+
+function classifyContact(record) {
+  const identity = String(record.userId || record.name || '').trim();
+  const lower = identity.toLowerCase();
+  const internalPattern = /(stromdao|cernion|corrently|\btest\b|demo|^svc:|local|example)/i;
+  if (internalPattern.test(lower)) {
+    return {
+      contactEmail: null,
+      contactLabel: identity || null,
+      internalTest: true,
+      exclusionReason: 'internal_test',
+      followupStatus: 'excluded',
+    };
+  }
+  if (!isEmail(identity)) {
+    return {
+      contactEmail: null,
+      contactLabel: identity || null,
+      internalTest: false,
+      exclusionReason: 'no_business_contact',
+      followupStatus: 'excluded',
+    };
+  }
+  return {
+    contactEmail: identity,
+    contactLabel: identity,
+    internalTest: false,
+    exclusionReason: 'none',
+    followupStatus: 'none',
+  };
+}
+
+function buildQueueId(tokenId, signalStage) {
+  return `cetq_${sha256(`${tokenId}:${signalStage}`).slice(0, 16)}`;
+}
+
 // Tokens created before Issue #157 (tenant/user binding) have no userId on
 // record. They keep working but are flagged so callers can sunset them.
 function isLegacyToken(record) {
@@ -99,6 +159,7 @@ module.exports = {
 
   settings: {
     storageFile: DEFAULT_STORAGE_FILE,
+    signalQueueFile: DEFAULT_SIGNAL_QUEUE_FILE,
     maxTokensPerInstallation: 20,
   },
 
@@ -356,12 +417,22 @@ module.exports = {
         }
 
         if (trackUsage) {
-          tokens[matchIndex] = {
+          const usedAt = nowIso();
+          const usageSignal = classifyTokenUsageSignal(method, requestPath);
+          const updatedRecord = {
             ...record,
             usageCount: (record.usageCount || 0) + 1,
-            lastUsedAt: nowIso(),
+            lastUsedAt: usedAt,
           };
+          tokens[matchIndex] = updatedRecord;
           this.saveTokens(tokens);
+          if (usageSignal.signalStage) {
+            this.recordTokenSignal(updatedRecord, usageSignal.signalStage, {
+              signalAt: usedAt,
+              channel: usageSignal.channel,
+              source: usageSignal.source,
+            });
+          }
         }
 
         return {
@@ -375,6 +446,22 @@ module.exports = {
           userId: record.userId ?? null,
           legacy: isLegacyToken(record),
           active: true,
+        };
+      },
+    },
+
+    'signalQueue.list': {
+      handler(ctx) {
+        const { since, stage } = ctx.params || {};
+        const sinceTime = since ? Date.parse(since) : null;
+        const signals = this.loadTokenSignals()
+          .filter((entry) => !stage || entry.signalStage === stage)
+          .filter((entry) => !sinceTime || Date.parse(entry.signalAt) >= sinceTime)
+          .sort((a, b) => String(b.signalAt).localeCompare(String(a.signalAt)));
+        return {
+          success: true,
+          data: signals.map((entry) => this.toDisplaySafeSignal(entry)),
+          count: signals.length,
         };
       },
     },
@@ -482,6 +569,11 @@ module.exports = {
 
       tokens.push(record);
       this.saveTokens(tokens);
+      this.recordTokenSignal(record, 'token_registered', {
+        signalAt: createdAt,
+        channel: 'unknown',
+        source: 'token-manager',
+      });
 
       return {
         success: true,
@@ -500,6 +592,110 @@ module.exports = {
         message:
           'Token created. The plain token is shown only once. Copy it now and store it securely.',
       };
+    },
+
+    recordTokenSignal(record, signalStage, options = {}) {
+      const signalAt = options.signalAt || nowIso();
+      const channel = options.channel || 'unknown';
+      const source = options.source || 'token-manager';
+      const signals = this.loadTokenSignals();
+      const existingIndex = signals.findIndex(
+        (entry) => entry.tokenId === record.id && entry.signalStage === signalStage
+      );
+      if (existingIndex !== -1) {
+        const existing = signals[existingIndex];
+        signals[existingIndex] = {
+          ...existing,
+          usageCount: record.usageCount || existing.usageCount || 0,
+          lastUsedAt: record.lastUsedAt || existing.lastUsedAt || null,
+          updatedAt: signalAt,
+        };
+        this.saveTokenSignals(signals);
+        return signals[existingIndex];
+      }
+
+      const contact = classifyContact(record);
+      const signal = {
+        queueId: buildQueueId(record.id, signalStage),
+        tokenId: record.id,
+        tokenMasked: record.tokenMasked || null,
+        contactEmail: contact.contactEmail,
+        contactLabel: contact.contactLabel,
+        tenantId: record.tenantId || null,
+        source,
+        sourceEventId: `${record.id}:${signalStage}`,
+        signalAt,
+        signalStage,
+        channel,
+        restIndicator: channel === 'rest',
+        mcpIndicator: channel === 'mcp',
+        usageCount: record.usageCount || 0,
+        lastUsedAt: record.lastUsedAt || null,
+        crmContactId: null,
+        followupStatus: contact.followupStatus,
+        exclusionReason: record.active === false ? 'revoked' : contact.exclusionReason,
+        internalTest: contact.internalTest,
+        createdAt: signalAt,
+        updatedAt: signalAt,
+      };
+      signals.push(signal);
+      this.saveTokenSignals(signals);
+      return signal;
+    },
+
+    toDisplaySafeSignal(entry) {
+      return {
+        queueId: entry.queueId,
+        tokenId: entry.tokenId,
+        tokenMasked: entry.tokenMasked || null,
+        contactEmail: entry.contactEmail || null,
+        contactLabel: entry.contactLabel || null,
+        tenantId: entry.tenantId || null,
+        source: entry.source,
+        sourceEventId: entry.sourceEventId,
+        signalAt: entry.signalAt,
+        signalStage: entry.signalStage,
+        channel: entry.channel,
+        restIndicator: entry.restIndicator === true,
+        mcpIndicator: entry.mcpIndicator === true,
+        usageCount: entry.usageCount || 0,
+        lastUsedAt: entry.lastUsedAt || null,
+        crmContactId: entry.crmContactId || null,
+        followupStatus: entry.followupStatus || 'none',
+        exclusionReason: entry.exclusionReason || 'none',
+        internalTest: entry.internalTest === true,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+      };
+    },
+
+    loadTokenSignals() {
+      try {
+        const filePath = this.settings.signalQueueFile;
+        if (!fs.existsSync(filePath)) return [];
+        const raw = fs.readFileSync(filePath, 'utf8');
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch (err) {
+        this.logger.warn(
+          `Failed to load token signals from ${this.settings.signalQueueFile}: ${err.message}`
+        );
+        return [];
+      }
+    },
+
+    saveTokenSignals(signals) {
+      const filePath = this.settings.signalQueueFile;
+      ensureDirForFile(filePath);
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify(
+          signals.map((s) => this.toDisplaySafeSignal(s)),
+          null,
+          2
+        ),
+        'utf8'
+      );
     },
 
     loadTokens() {

--- a/tests/token-manager.service.test.js
+++ b/tests/token-manager.service.test.js
@@ -9,16 +9,19 @@ const TokenManagerService = require('../services/token-manager.service');
 describe('token-manager.service', () => {
   let broker;
   let storageFile;
+  let signalQueueFile;
 
   beforeAll(async () => {
     storageFile = path.join(os.tmpdir(), `token-manager-${Date.now()}.json`);
+    signalQueueFile = path.join(os.tmpdir(), `token-signals-${Date.now()}.json`);
     broker = new ServiceBroker({ logger: false });
     broker.createService({
       ...TokenManagerService,
       settings: {
         ...TokenManagerService.settings,
         storageFile,
-        maxTokensPerInstallation: 10,
+        signalQueueFile,
+        maxTokensPerInstallation: 50,
       },
     });
     await broker.start();
@@ -27,6 +30,7 @@ describe('token-manager.service', () => {
   afterAll(async () => {
     await broker.stop();
     if (fs.existsSync(storageFile)) fs.unlinkSync(storageFile);
+    if (fs.existsSync(signalQueueFile)) fs.unlinkSync(signalQueueFile);
   });
 
   it('creates a token and returns plaintext only once', async () => {
@@ -325,6 +329,155 @@ describe('token-manager.service', () => {
     expect(verified.tenantId).toBeNull();
     expect(verified.userId).toBeNull();
     expect(verified.legacy).toBe(true);
+  });
+
+  describe('Felix token signal queue', () => {
+    beforeEach(() => {
+      fs.writeFileSync(storageFile, '[]', 'utf8');
+      if (fs.existsSync(signalQueueFile)) fs.unlinkSync(signalQueueFile);
+    });
+
+    it('records token_registered without storing raw tokens or headers in the display-safe export', async () => {
+      const created = await broker.call('token-manager.create', {
+        name: 'Business Trial',
+        scope: 'read-only',
+        tenantId: 'stadtwerk-a',
+        userId: 'buyer@stadtwerk-a.de',
+      });
+
+      const queue = await broker.call('token-manager.signalQueue.list');
+      expect(queue.success).toBe(true);
+      expect(queue.data).toHaveLength(1);
+      expect(queue.data[0]).toMatchObject({
+        tokenId: created.data.id,
+        tokenMasked: expect.stringContaining('****'),
+        signalStage: 'token_registered',
+        channel: 'unknown',
+        source: 'token-manager',
+        contactEmail: 'buyer@stadtwerk-a.de',
+        followupStatus: 'none',
+        exclusionReason: 'none',
+        internalTest: false,
+      });
+
+      const serialized = JSON.stringify(queue.data);
+      expect(serialized).not.toContain(created.data.token);
+      expect(serialized).not.toMatch(/authorization|bearer|magic|prompt|payload|user-agent|ip/i);
+    });
+
+    it('records first_api_call for REST/OpenAI-compatible token usage only once', async () => {
+      const created = await broker.call('token-manager.create', {
+        name: 'OpenAI Facade',
+        scope: 'full-access',
+        tenantId: 'stadtwerk-a',
+        userId: 'api.buyer@utility.de',
+      });
+
+      await broker.call('token-manager.verify', {
+        token: created.data.token,
+        method: 'POST',
+        path: '/v1/chat/completions',
+        trackUsage: true,
+      });
+      await broker.call('token-manager.verify', {
+        token: created.data.token,
+        method: 'POST',
+        path: '/api/grid-operations/vnb-lookup',
+        trackUsage: true,
+      });
+
+      const queue = await broker.call('token-manager.signalQueue.list');
+      const apiSignals = queue.data.filter((entry) => entry.signalStage === 'first_api_call');
+      expect(apiSignals).toHaveLength(1);
+      expect(apiSignals[0]).toMatchObject({
+        tokenId: created.data.id,
+        channel: 'rest',
+        restIndicator: true,
+        mcpIndicator: false,
+        source: 'openai-facade',
+      });
+    });
+
+    it('records first_mcp_call separately and idempotently for /api/mcp usage', async () => {
+      const created = await broker.call('token-manager.create', {
+        name: 'MCP Client',
+        scope: 'full-access',
+        tenantId: 'stadtwerk-a',
+        userId: 'mcp.buyer@utility.de',
+      });
+
+      await broker.call('token-manager.verify', {
+        token: created.data.token,
+        method: 'POST',
+        path: '/api/mcp',
+        trackUsage: true,
+      });
+      await broker.call('token-manager.verify', {
+        token: created.data.token,
+        method: 'POST',
+        path: '/api/mcp',
+        trackUsage: true,
+      });
+
+      const queue = await broker.call('token-manager.signalQueue.list');
+      const mcpSignals = queue.data.filter((entry) => entry.signalStage === 'first_mcp_call');
+      expect(mcpSignals).toHaveLength(1);
+      expect(mcpSignals[0]).toMatchObject({
+        tokenId: created.data.id,
+        channel: 'mcp',
+        restIndicator: false,
+        mcpIndicator: true,
+        source: 'mcp-transport',
+      });
+    });
+
+    it('excludes internal/test/no-business contacts while keeping only display-safe fields', async () => {
+      const created = await broker.call('token-manager.createCli', {
+        name: 'Demo Smoke Token',
+        tenantId: 'stadtwerk-a',
+        userId: 'svc:cernion-demo',
+      });
+
+      await broker.call('token-manager.verify', {
+        token: created.data.token,
+        method: 'GET',
+        path: '/api/assets/list',
+        trackUsage: true,
+      });
+
+      const queue = await broker.call('token-manager.signalQueue.list');
+      expect(queue.data).toHaveLength(2);
+      for (const entry of queue.data) {
+        expect(entry.contactEmail).toBeNull();
+        expect(entry.internalTest).toBe(true);
+        expect(entry.exclusionReason).toBe('internal_test');
+        expect(Object.keys(entry).sort()).toEqual(
+          [
+            'channel',
+            'contactEmail',
+            'contactLabel',
+            'createdAt',
+            'crmContactId',
+            'exclusionReason',
+            'followupStatus',
+            'internalTest',
+            'lastUsedAt',
+            'mcpIndicator',
+            'queueId',
+            'restIndicator',
+            'signalAt',
+            'signalStage',
+            'source',
+            'sourceEventId',
+            'tenantId',
+            'tokenId',
+            'tokenMasked',
+            'updatedAt',
+            'usageCount',
+          ].sort()
+        );
+      }
+    });
   });
 
   describe('createCli action (permanent CLI path)', () => {


### PR DESCRIPTION
## Summary
- Add a separate, display-safe token signal queue store for Felix follow-up signals.
- Record `token_registered` from successful token creation and split first usage into `first_api_call` vs `first_mcp_call` via request path classification.
- Keep the queue idempotent per `tokenId + signalStage` and mark internal/test/no-business contacts as excluded.
- Expose only an internal Moleculer action (`token-manager.signalQueue.list`) with redacted/display-safe fields; no REST route, no raw tokens, headers, prompts, payloads, IPs, or user agents.

## Test plan
- `node --check services/token-manager.service.js`
- `npx jest tests/token-manager.service.test.js --runInBand --forceExit --coverage=false`
- `npx eslint services/token-manager.service.js tests/token-manager.service.test.js`
- `git diff --cached --check` before commit / `git diff --check` after commit

## Safety / boundaries
- No production deploy, PM2 restart, server mutation, or CRM autowrite included.
- Queue export is read-only and display-safe by default.
- Implemented after HITL unblock on Kanban task `t_57533bff`.
