### PR TITLE
fix: index-driven execute_read allowlist, token path bug, blueprint lookup (v0.99.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.5] — 2026-08-02
+
+### Fixed
+- **`cernion_execute_read`'s allowlist was structurally too narrow, refusing genuinely read-only operations** — found via real-world testing (an MCP client via claude.ai asked a CO₂-intensity question; `energy-market.co2Intensity` was refused because it's POST and the ~10-entry hand-curated allowlist didn't cover it, even though it's a side-effect-free query). Every read-shaped POST across the platform (energy-market, entsoe, gas-storage, german-grid, oep, osm-geo, residual-load, tabular, and more) had the same gap. `execute_read` now consults `operation-capability-index.json` — the same deterministic classification (`src/operation-capability-classifier.js`) already computed for all ~880 operations and relied on elsewhere in the platform — as its primary source of truth (~556 operations now correctly recognized as read-safe, vs. ~10 before), with the original GET-by-convention + small POST allowlist kept only as a fallback for anything not yet in the index. See `docs/mcp-server.md`'s "The allowlist redesign" section for the exact per-`operationKind` rule, including a real misclassification (`znp_deleteProject`, a `DELETE`, incorrectly labeled `advisory_plan` in the index) that the redesign deliberately still catches via a stricter per-kind execution-mode check.
+- **A real, independent bug found while investigating the report above**: the execute_read denylist targeted `/token-manager/*`, but `services/token-manager.service.js` is actually mounted at `/tokens` — so `GET /api/tokens` (token metadata: masked values, but names/tenant-user IDs/scopes/active status, potentially beyond the caller's own tenant) was never actually blocked despite that clearly being the intent. Fixed alongside the allowlist redesign.
+- **`cernion_search`/`cernion_describe`'s `blueprint` kind couldn't resolve built-in blueprints** — also found via the CO₂ report: `cernion_ask`'s response mentioned a blueprint (`ev-charging-co2-optimization-v1`) by name (its own internal L3-broker routing already knew about it), but `cernion_describe` reported it as unresolvable. Root cause: `search`/`describe` queried `blueprint-management` (the PouchDB-backed draft/promote governance workflow) instead of `src/blueprint-registry.js` — the actual unified view `cernion_ask`'s own routing consults, merging static repo blueprints (`src/blueprints/*.json`, most of the 20 shipped blueprints) with governance-promoted ones. Switched `search`/`describe` to call `blueprint-registry.js` directly (a plain module, no service call needed).
+
+### Testing
+- `tests/mcp-execute-read-policy.test.js` (new, 16 tests) — the CO₂-intensity fix, the token-manager path-prefix fix, the `znp_deleteProject` misclassification edge case, denylist coverage, and a mocked-missing-index fallback scenario.
+- `tests/mcp-server.service.test.js` extended with real (not stubbed) blueprint-registry data, including a 404 case for a nonexistent blueprint id.
+
 ## [0.99.4] — 2026-08-02
 
 ### Added

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,4 +1,4 @@
-# MCP Server (v0.99.2, extended v0.99.3, v0.99.4)
+# MCP Server (v0.99.2, extended v0.99.3, v0.99.4, v0.99.5)
 
 A real MCP (Model Context Protocol) server — JSON-RPC 2.0 over the
 streamable-HTTP transport — sitting in front of this platform's REST API.
@@ -38,8 +38,8 @@ full round-trip example using `@modelcontextprotocol/sdk`'s
 | # | Tool | Maps to | Read-only? |
 |---|------|---------|------------|
 | 1 | `cernion_ask` | `personal-agent.askCernionAgent` / `.answerDossier` | No — POST, gated (see Auth) |
-| 2 | `cernion_search` | `agent-manifest.list{Capabilities,Operations}`, `agent-receipts.list`, `blueprint-management.list`, `cookbook.search` | Yes |
-| 3 | `cernion_describe` | `agent-manifest.getCapability`, `agent-receipts.get`+`explainStored`, `blueprint-management.get`, `cookbook.get` | Yes |
+| 2 | `cernion_search` | `agent-manifest.list{Capabilities,Operations}`, `agent-receipts.list`, `src/blueprint-registry.js` (v0.99.5, see below), `cookbook.search` | Yes |
+| 3 | `cernion_describe` | `agent-manifest.getCapability`, `agent-receipts.get`+`explainStored`, `src/blueprint-registry.js` (v0.99.5, see below), `cookbook.get` | Yes |
 | 4 | `cernion_execute_read` | Loopback HTTP call into `/api/...` (see below) | Yes, allowlisted |
 | 5 | `cernion_run_receipt` | `agent-receipts.test` (plan); `copilot-process.prepareProcessIntent` (run) | plan: yes; run: no |
 | 6 | `cernion_prepare_process` | `copilot-process.prepareProcessIntent`, or one of 4 dedicated `prepare*` actions for reserved families (v0.99.3, see below) | No |
@@ -133,8 +133,11 @@ the hard way:
    contract. Left out rather than forced.
 
 5. **`cernion_execute_read` is allowlist-based, not universal**, even
-   though the concept called for covering "all ~1,100 endpoints." See
-   "How execute_read actually works" below for why, and what's covered.
+   though the concept called for covering "all ~1,100 endpoints." As of
+   v0.99.5 the allowlist is index-driven (~556 operations classified
+   `data_read`/`dashboard_read`/`advisory_plan`) rather than a ~10-entry
+   hand-curated list, but it's still a classification-based gate, not
+   "everything goes." See "How execute_read actually works" below.
 
 ## How `execute_read` actually works
 
@@ -152,17 +155,80 @@ call — no duplicated security logic, and it automatically covers any
 future REST endpoint without code changes here.
 
 A request is allowed (`src/mcp-execute-read-policy.js`) if:
-- the method is GET (mirrors `src/gateway-request-classifiers.js`'s
-  `isReadMethod`), or
-- it's one of a short list of POST endpoints that are read/dry-run despite
-  the verb (`evidence-router/route`, `knowledge-rag/{query,semantic,
-  federated-search}`, `agent-receipts/{select,evaluate,test,explain}`,
-  `cookbook/{search,validate}`, `copilot/{ask-cernion-agent,answer-dossier}`)
+- the path doesn't match the admin/secret denylist below (checked first,
+  always wins — see below), **and**
+- `operation-capability-index.json` classifies it as read-safe (v0.99.5,
+  see "The allowlist redesign" below), **or**, if it isn't in that index,
+  the method is GET (mirrors `src/gateway-request-classifiers.js`'s
+  `isReadMethod`) or it's one of a short fallback list of POST endpoints
+  that are read/dry-run despite the verb (`evidence-router/route`,
+  `knowledge-rag/{query,semantic,federated-search}`,
+  `agent-receipts/{select,evaluate,test,explain}`, `cookbook/{search,
+  validate}`, `copilot/{ask-cernion-agent,answer-dossier}`)
 
-and is denied regardless of method if the path matches an admin/secret
-surface (`backup`, `restore`, `system/admin`, `domain-routes/reload`,
-`token-manager`, `auth`, `tenant-quotas`) — the concept doc's "Nicht
-exponieren" list.
+and is denied regardless of method or classification if the path matches
+an admin/secret surface (`backup`, `restore`, `system/admin`,
+`domain-routes/reload`, `tokens`, `auth`, `tenant-quotas`) — the concept
+doc's "Nicht exponieren" list, plus token/auth surfaces added defensively.
+
+### The allowlist redesign (v0.99.5) — and two real bugs it fixed
+
+Real-world testing (an MCP client via claude.ai asking a CO₂-intensity
+question) hit `energy-market.co2Intensity` refused by `execute_read` —
+it's POST (takes a body), so the original hand-curated ~10-entry
+`POST_ALLOWLIST_PATH_PATTERNS` list didn't cover it, even though it's a
+genuine, side-effect-free read. That list was always going to under-cover:
+every read-shaped POST across the platform (energy-market, entsoe,
+gas-storage, german-grid, oep, osm-geo, residual-load, tabular, and more)
+had the identical gap.
+
+The fix: `execute_read` now consults `operation-capability-index.json` —
+the same deterministic classification (`src/operation-capability-
+classifier.js`) already computed for all ~880 operations and relied on
+elsewhere in the platform (e.g. the ChatGPT sidecar's own read-only
+fallback) — as the primary source of truth, rather than re-deriving it by
+hand. `data_read`/`dashboard_read` operations are read-safe when
+`recommendedExecutionMode: 'direct'` (empirically always true for those
+two kinds, no exceptions found across the index). `advisory_plan`
+operations need `recommendedExecutionMode: 'explain_only'` specifically —
+**not** uniformly `'direct'` like the other two kinds — because at least
+one operation (`znp_deleteProject`, a real `DELETE`) is misclassified as
+`advisory_plan` in the index but correctly flagged `recommendedExecutionMode:
+'confirm'`; checking the mode per-kind lets genuinely read-only
+`advisory_plan` endpoints (like `evidence-router.route`) through while
+still catching that one. GET-by-convention and the original small POST
+allowlist remain as a fallback for anything not (yet) in the index.
+
+Investigating the CO₂ report also surfaced a second, unrelated bug: the
+denylist targeted `/token-manager/*`, but the service is actually mounted
+at `/tokens` (see `services/token-manager.service.js`) — so `GET
+/api/tokens` (token metadata — masked values, but still names, tenant/user
+IDs, scopes, active status, potentially across more than the caller's own
+tenant) was never actually blocked, despite that clearly being the intent.
+Fixed alongside the allowlist redesign; caught by cross-checking this file
+against the operation index, not by the original report.
+
+## Blueprint discoverability (v0.99.5)
+
+From the same real-world report above: `cernion_ask`'s response mentioned
+a blueprint (`ev-charging-co2-optimization-v1`) by name — its own internal
+routing (`src/l3-broker.js`) already knew about it — but `cernion_describe`
+couldn't resolve it. Root cause: `search`/`describe`'s `blueprint` kind
+queried `blueprint-management` (the PouchDB-backed governance-lifecycle
+system: draft → validate → test → promote → rollback), which only tracks
+blueprints someone has actually drafted/promoted through that workflow. It
+never saw **built-in** blueprints shipped as static files in
+`src/blueprints/*.json` — which is most of them, including this one.
+
+`src/blueprint-registry.js` is the actual unified view — the same one
+`cernion_ask`'s L3 broker consults — merging the static repo files with an
+in-memory overlay that `blueprint-management.service.js` populates via
+`setRuntimeBlueprint()` on promote/rollback/startup. `search`/`describe`
+now call `listBlueprints()`/`loadBlueprint()` from that module directly
+(a plain function call, not a service — no `ctx.call` needed) instead of
+`blueprint-management.list`/`.get`. Scope note: not-yet-promoted **drafts**
+are intentionally excluded — those are governance-workflow-internal, not
+part of what `cernion_ask` can actually route to yet.
 
 ## Reserved operation families (v0.99.3)
 

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.4
-- changelog_latest_release: 0.99.4
+- version: 0.99.5
+- changelog_latest_release: 0.99.5
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -246,12 +246,12 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: d7e8c584d969309ccfe9f62d5044f4cab47e65f4dd40fd0ef3c25e39c0b2cc9b
+- CHANGELOG.md: 987ba0eb515cc65e8c4cb763782fc2c01eedc8d5f39e14fff6a8b39e604c92c8
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: 3e4cac9e3cf87bf80e3883daef3c46209ca8993ff071c4f8bc4dca56976a65de
+- openapi-export.json: f4611e17803b842eaecc65485055684468d4317247fe922038d7b702b3d72e97
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 1021
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 16bc4b2d0c858e7c2186e705df4ceae501e15168e4f3b049e0d32f20817bde1f
+- llm_txt_sha256: 7abadff05bc52cf7d2db0b81048a669f6c728fedfec3d930c80966eef4fbb23e

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.4",
+    "version": "0.99.5",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -2470,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.4",
+  "x-version": "0.99.5",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.4",
+    "version": "0.99.5",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -91084,5 +91084,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.4"
+  "x-version": "0.99.5"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.4",
-  "sourceOpenApiHash": "3e4cac9e3cf87bf80e3883daef3c46209ca8993ff071c4f8bc4dca56976a65de",
+  "packageVersion": "0.99.5",
+  "sourceOpenApiHash": "f4611e17803b842eaecc65485055684468d4317247fe922038d7b702b3d72e97",
   "coverage": {
     "rawOperationCount": 1133,
     "operationCount": 877,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.4",
+  "version": "0.99.5",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {

--- a/services/mcp-server.service.js
+++ b/services/mcp-server.service.js
@@ -8,8 +8,11 @@
  * docs/mcp-server.md for the full design). This service is the thin
  * protocol-facing layer: each action orchestrates existing services
  * (`agent-manifest`, `personal-agent`, `evidence-router`, `copilot-process`,
- * `job-status`, `agent-receipts`, `blueprint-management`, `cookbook`,
- * `hitl`, `agent-sidecar`, `tenant-quota`) rather than reimplementing them.
+ * `job-status`, `agent-receipts`, `cookbook`, `hitl`, `agent-sidecar`,
+ * `tenant-quota`) plus `src/blueprint-registry.js` directly (a plain module,
+ * not a service — see the `blueprint` branches in `search`/`describe` for
+ * why it's used instead of `blueprint-management`) rather than
+ * reimplementing them.
  *
  * These actions are dispatched two ways:
  *  - by `src/mcp-transport.js`, which speaks the real MCP JSON-RPC protocol
@@ -33,6 +36,7 @@ const { buildRef, parseRef } = require('../src/mcp-uri');
 const { checkExecuteReadPolicy } = require('../src/mcp-execute-read-policy');
 const { assertFullAccessForWrite } = require('../src/mcp-rbac-gate');
 const { RESERVED_FAMILIES, resolveIntentId } = require('../src/mcp-reserved-families');
+const { loadBlueprint, listBlueprints } = require('../src/blueprint-registry');
 
 const SEARCH_KINDS = ['capability', 'operation', 'receipt', 'blueprint', 'recipe'];
 const DESCRIBE_KINDS = ['capability', 'operation', 'receipt', 'blueprint', 'recipe'];
@@ -185,17 +189,26 @@ module.exports = {
               }));
           },
           blueprint: async () => {
-            const res = await ctx.call('blueprint-management.list', {
-              includeDrafts: true,
-              includeActive: true,
-            });
-            return (res.data || [])
-              .filter((b) => textIncludes([b.blueprintId, b.id, b.title, b.description], query))
+            // src/blueprint-registry.js, not blueprint-management.list — it's
+            // the unified view cernion_ask's own L3 broker consults (static
+            // repo blueprints merged with governance-promoted ones via
+            // setRuntimeBlueprint), not just the draft/active subset tracked
+            // in blueprint-management's PouchDB. A real gap this closes:
+            // built-in blueprints (e.g. ev-charging-co2-optimization-v1) were
+            // invisible to cernion_search/describe before this, even though
+            // askCernionAgent could already route to them internally —
+            // confirmed against a real user report where an MCP client found
+            // the blueprint mentioned by name in an ask response but
+            // cernion_describe couldn't resolve it. Draft (not-yet-promoted)
+            // blueprints are intentionally out of scope here — those are
+            // governance-workflow-internal, not yet part of live routing.
+            return listBlueprints()
+              .filter((b) => textIncludes([b.id, b.title, b.description], query))
               .slice(0, perKindLimit)
               .map((b) => ({
-                ref: buildRef('blueprint', b.blueprintId || b.id),
+                ref: buildRef('blueprint', b.id),
                 kind: 'blueprint',
-                title: b.title || b.blueprintId || b.id,
+                title: b.title || b.id,
                 summary: b.description || '',
                 riskClass: 'write',
               }));
@@ -288,8 +301,21 @@ module.exports = {
         }
 
         if (kind === 'blueprint') {
-          const res = await ctx.call('blueprint-management.get', { id });
-          return { success: true, ref: buildRef(kind, id), kind, data: res.data };
+          // src/blueprint-registry.js — see the matching comment in `search`
+          // above for why (not blueprint-management.get, which only sees
+          // draft/promoted governance-workflow blueprints, not built-in ones).
+          const blueprint = loadBlueprint(id);
+          if (!blueprint) {
+            throw new MoleculerClientError(
+              `Blueprint not found: ${id}`,
+              404,
+              'MCP_BLUEPRINT_NOT_FOUND',
+              {
+                id,
+              }
+            );
+          }
+          return { success: true, ref: buildRef(kind, id), kind, data: blueprint };
         }
 
         // kind === 'recipe'

--- a/src/mcp-execute-read-policy.js
+++ b/src/mcp-execute-read-policy.js
@@ -10,27 +10,60 @@
  * `services/api.service.js`'s `onBeforeCall` already implements that
  * resolution correctly and re-implementing it here would risk silently
  * diverging from it. This module is the one extra gate layered in front of
- * that loopback: GET is read by HTTP convention (mirrors
- * `src/gateway-request-classifiers.js`'s `isReadMethod`), a short allowlist
- * covers POST endpoints that are read/dry-run despite the verb, and a short
- * denylist keeps admin/secret-bearing surfaces out of MCP reach regardless
- * of method (per the concept doc's "Nicht exponieren" list).
+ * that loopback.
+ *
+ * v0.99.5: real-world testing (an MCP client asking a CO₂-intensity
+ * question) found `energy-market.co2Intensity` — a genuine read, just
+ * implemented as POST because it takes a body — silently refused. The
+ * original hand-curated `POST_ALLOWLIST_PATH_PATTERNS` below only covered
+ * ~10 specific endpoints; every other read-shaped POST across the platform
+ * (energy-market, entsoe, gas-storage, german-grid, oep, osm-geo,
+ * residual-load, tabular, and more) had the same gap. Rather than growing
+ * that list endpoint-by-endpoint forever, this now consults
+ * `operation-capability-index.json` — the same deterministic classification
+ * (`src/operation-capability-classifier.js`) already computed for all ~880
+ * operations and relied on elsewhere in the platform — as the primary
+ * source of truth (see `isReadSafeIndexEntry` below for the exact per-kind
+ * rule — `data_read`/`dashboard_read` require `recommendedExecutionMode:
+ * 'direct'`, `advisory_plan` requires `'explain_only'` specifically, not
+ * uniformly 'direct', because at least one operation is misclassified as
+ * advisory_plan despite being a real delete). GET-by-convention and the
+ * original small POST allowlist remain as a fallback for anything the
+ * index doesn't (yet) cover — e.g. a freshly added operation before the
+ * index is regenerated, or if the index file is missing entirely.
+ *
+ * The same pass also fixed a real bug in the denylist below: it targeted
+ * `/token-manager/*`, but the actual mounted path is `/tokens` (see
+ * `services/token-manager.service.js`) — meaning `GET /api/tokens` (token
+ * metadata, masked values but still names/tenants/scopes across possibly
+ * more than the caller's own tenant) was never actually blocked. Caught by
+ * cross-checking this file against the operation index while investigating
+ * the CO₂ report, not by the report itself.
  */
 
+const fs = require('fs');
+const path = require('path');
 const { isReadMethod } = require('./gateway-request-classifiers');
 
+const OPERATION_INDEX_PATH = path.join(__dirname, '..', 'operation-capability-index.json');
+
 // Paths (relative to /api) that must never be reachable via execute_read,
-// even as GET — admin/system/credential surfaces, not agent-facing data.
+// even as GET, even if operation-capability-index.json classifies them as
+// agentable data_read — admin/system/credential surfaces are an MCP-agent-
+// specific risk judgment stricter than the generic classifier's, not
+// something to defer to it for. Per the concept doc's "Nicht exponieren"
+// list, plus token-manager/auth (secrets-adjacent) added defensively.
 const DENYLIST_PATH_PATTERNS = [
   /^\/backup(\/|$)/,
   /^\/restore(\/|$)/,
   /^\/system\/admin(\/|$)/,
   /^\/domain-routes\/reload$/,
-  /^\/token-manager(\/|$)/,
+  /^\/tokens(\/|$)/,
   /^\/auth(\/|$)/,
   /^\/tenant-quotas?(\/|$)/,
 ];
 
+// Fallback for operations not found in operation-capability-index.json —
 // POST endpoints that are read-only or dry-run in effect despite the verb.
 const POST_ALLOWLIST_PATH_PATTERNS = [
   /^\/evidence-router\/route$/,
@@ -42,8 +75,8 @@ const POST_ALLOWLIST_PATH_PATTERNS = [
   /^\/copilot\/(ask-cernion-agent|answer-dossier)$/,
 ];
 
-function stripApiPrefix(path) {
-  const normalized = String(path || '').split('?')[0];
+function stripApiPrefix(path_) {
+  const normalized = String(path_ || '').split('?')[0];
   return normalized.startsWith('/api') ? normalized.slice(4) || '/' : normalized;
 }
 
@@ -51,17 +84,74 @@ function isDenied(relativePath) {
   return DENYLIST_PATH_PATTERNS.some((pattern) => pattern.test(relativePath));
 }
 
+let _operationLookup = null;
+function loadOperationLookup() {
+  if (_operationLookup) return _operationLookup;
+  _operationLookup = new Map();
+  try {
+    const index = JSON.parse(fs.readFileSync(OPERATION_INDEX_PATH, 'utf8'));
+    for (const op of index.operations || []) {
+      _operationLookup.set(`${op.method} ${op.path}`, op);
+      for (const alias of op.aliases || []) {
+        _operationLookup.set(alias, op);
+      }
+    }
+  } catch {
+    // Missing/unreadable index just means execute_read falls back to the
+    // conservative GET+small-allowlist rules below — never a hard failure.
+  }
+  return _operationLookup;
+}
+
+// `data_read`/`dashboard_read` are empirically always paired with
+// `recommendedExecutionMode: 'direct'` in the index (verified across all
+// ~880 operations) — no exceptions found. `advisory_plan` is different: it
+// splits into genuinely read-only routing/explanation endpoints (paired
+// with `explain_only`, e.g. evidence-router.route — "read-only routing...
+// never executes, never mutates") and at least one real misclassification
+// (`znp_deleteProject`, a DELETE, incorrectly given `operationKind:
+// advisory_plan` but correctly flagged `recommendedExecutionMode:
+// 'confirm'` since it's a mutation needing confirmation). Checking the
+// mode per-kind rather than requiring 'direct' uniformly lets
+// evidence-router-style endpoints through while still catching that one.
+function isReadSafeIndexEntry(entry) {
+  if (entry.agentable !== true) return false;
+  if (entry.operationKind === 'data_read' || entry.operationKind === 'dashboard_read') {
+    return entry.recommendedExecutionMode === 'direct';
+  }
+  if (entry.operationKind === 'advisory_plan') {
+    return entry.recommendedExecutionMode === 'explain_only';
+  }
+  return false;
+}
+
 /**
  * @param {string} method - HTTP method as catalogued by agent-manifest (e.g. "GET").
  * @param {string} path - Full or /api-relative path, may include the `/api` prefix.
  * @returns {{ allowed: boolean, reason?: string }}
  */
-function checkExecuteReadPolicy(method, path) {
-  const relativePath = stripApiPrefix(path);
+function checkExecuteReadPolicy(method, path_) {
+  const relativePath = stripApiPrefix(path_);
   if (isDenied(relativePath)) {
     return { allowed: false, reason: 'ADMIN_SURFACE_NOT_EXPOSED' };
   }
+
   const upperMethod = String(method || '').toUpperCase();
+  const fullPath = String(path_ || '').startsWith('/api') ? path_ : `/api${relativePath}`;
+  const entry = loadOperationLookup().get(`${upperMethod} ${fullPath}`);
+  if (entry) {
+    if (isReadSafeIndexEntry(entry)) return { allowed: true };
+    if (isReadMethod(upperMethod)) return { allowed: true }; // GET stays allowed regardless
+    return {
+      allowed: false,
+      reason: entry.nonAgentableReason
+        ? `NOT_READ_ONLY: ${entry.nonAgentableReason}`
+        : 'NOT_READ_ONLY',
+    };
+  }
+
+  // No index entry (e.g. index stale/regenerating, or a path not catalogued
+  // there at all) — fall back to the original conservative rules.
   if (isReadMethod(upperMethod)) {
     return { allowed: true };
   }

--- a/tests/mcp-execute-read-policy.test.js
+++ b/tests/mcp-execute-read-policy.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const { checkExecuteReadPolicy } = require('../src/mcp-execute-read-policy');
+
+describe('mcp-execute-read-policy (operation-capability-index-backed, v0.99.5)', () => {
+  // Regression test for the exact real-world bug report: an MCP client
+  // asked a CO2-intensity question, cernion_execute_read refused
+  // energy-market.co2Intensity because it's POST and wasn't in the old
+  // hand-curated allowlist, even though it's a genuine read (a body-based
+  // query, not a mutation) already classified as such by
+  // operation-capability-index.json.
+  test('allows energy-market.co2Intensity (POST, data_read in the index)', () => {
+    const result = checkExecuteReadPolicy('POST', '/api/energy-market/co2-intensity');
+    expect(result).toEqual({ allowed: true });
+  });
+
+  test('allows other read-shaped POST endpoints across the platform, not just one hand-picked service', () => {
+    // energy-market.prices — same "POST body, but a pure query" shape as
+    // co2Intensity, previously blocked by the same gap.
+    expect(checkExecuteReadPolicy('POST', '/api/energy-market/prices')).toEqual({ allowed: true });
+  });
+
+  // Regression test for a real bug found while investigating the report
+  // above: the denylist targeted the wrong path (/token-manager instead of
+  // the actual mounted /tokens), so token metadata was never actually
+  // blocked despite that being the intent.
+  test('denies GET /api/tokens even though the index classifies it as agentable data_read', () => {
+    const result = checkExecuteReadPolicy('GET', '/api/tokens');
+    expect(result).toEqual({ allowed: false, reason: 'ADMIN_SURFACE_NOT_EXPOSED' });
+  });
+
+  test.each([
+    ['/api/auth/verify', 'POST'],
+    ['/api/backup/export', 'GET'],
+    ['/api/restore/import', 'POST'],
+    ['/api/tenant-quotas/tenants/x', 'GET'],
+    ['/api/system/admin/reload', 'POST'],
+    ['/api/domain-routes/reload', 'POST'],
+  ])('denies admin/secret surface %s %s regardless of method or index classification', (p, m) => {
+    expect(checkExecuteReadPolicy(m, p)).toEqual({
+      allowed: false,
+      reason: 'ADMIN_SURFACE_NOT_EXPOSED',
+    });
+  });
+
+  test('denies a genuine write operation found in the index (object_store_write)', () => {
+    const result = checkExecuteReadPolicy('POST', '/api/copilot-process/intents');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/^NOT_READ_ONLY/);
+  });
+
+  // Safety-critical edge case: znp_deleteProject (DELETE, permanently
+  // deletes a ZNP project) is misclassified as operationKind:advisory_plan
+  // in the index — which would be execute_read-eligible under a naive
+  // "advisory_plan is always safe" rule. It's correctly excluded here only
+  // because recommendedExecutionMode is 'confirm', not 'explain_only' (see
+  // isReadSafeIndexEntry's per-kind mode check). This test exists to catch
+  // a regression if that per-kind check is ever simplified back to a
+  // blanket operationKind allowlist.
+  test('still denies znp deleteProject despite its advisory_plan misclassification in the index', () => {
+    const result = checkExecuteReadPolicy('DELETE', '/api/znp/projects/p1');
+    expect(result).toEqual({ allowed: false, reason: 'NOT_READ_ONLY' });
+  });
+
+  test('GET is allowed by convention even for a path not catalogued in the index', () => {
+    expect(checkExecuteReadPolicy('GET', '/api/some-not-yet-catalogued-operation')).toEqual({
+      allowed: true,
+    });
+  });
+
+  test('the original small POST allowlist still works as a fallback', () => {
+    expect(checkExecuteReadPolicy('POST', '/api/evidence-router/route')).toEqual({
+      allowed: true,
+    });
+  });
+
+  test('an uncatalogued, non-allowlisted POST is refused', () => {
+    expect(checkExecuteReadPolicy('POST', '/api/some-not-yet-catalogued-write')).toEqual({
+      allowed: false,
+      reason: 'NOT_READ_ONLY',
+    });
+  });
+
+  test('accepts a bare /api-relative path the same as a full path', () => {
+    expect(checkExecuteReadPolicy('POST', '/energy-market/co2-intensity')).toEqual({
+      allowed: true,
+    });
+  });
+
+  describe('when the operation index is missing or unreadable', () => {
+    test('falls back to the conservative GET/POST-allowlist rules without throwing', () => {
+      jest.isolateModules(() => {
+        jest.doMock('fs', () => ({
+          readFileSync: () => {
+            throw new Error('ENOENT: no such file');
+          },
+        }));
+
+        const {
+          checkExecuteReadPolicy: checkWithoutIndex,
+        } = require('../src/mcp-execute-read-policy');
+
+        // Still allowed — GET-by-convention, doesn't depend on the index.
+        expect(checkWithoutIndex('GET', '/api/energy-market/co2-intensity')).toEqual({
+          allowed: true,
+        });
+        // The exact bug this file fixes: without the index, a read-shaped
+        // POST outside the small hand-curated allowlist is refused again —
+        // demonstrates why the index matters, not just that the fallback
+        // doesn't crash.
+        expect(checkWithoutIndex('POST', '/api/energy-market/co2-intensity')).toEqual({
+          allowed: false,
+          reason: 'NOT_READ_ONLY',
+        });
+        // The denylist itself doesn't depend on the index at all.
+        expect(checkWithoutIndex('GET', '/api/tokens')).toEqual({
+          allowed: false,
+          reason: 'ADMIN_SURFACE_NOT_EXPOSED',
+        });
+
+        jest.dontMock('fs');
+      });
+    });
+  });
+});

--- a/tests/mcp-server.service.test.js
+++ b/tests/mcp-server.service.test.js
@@ -158,31 +158,12 @@ describe('MCP Server meta-tools', () => {
       },
     });
 
-    broker.createService({
-      name: 'blueprint-management',
-      actions: {
-        list: {
-          handler() {
-            return {
-              success: true,
-              data: [
-                {
-                  blueprintId: 'ev-charging-co2-optimization-v1',
-                  title: 'EV CO2',
-                  description: 'charging',
-                },
-              ],
-            };
-          },
-        },
-        get: {
-          params: { id: { type: 'string' } },
-          handler(ctx) {
-            return { success: true, data: { blueprintId: ctx.params.id, title: 'EV CO2' } };
-          },
-        },
-      },
-    });
+    // No blueprint-management stub: mcp-server.service.js's `blueprint`
+    // kind reads src/blueprint-registry.js directly (a plain module reading
+    // the real src/blueprints/*.json files), not blueprint-management —
+    // see the comment in mcp-server.service.js's search/describe for why.
+    // The 'ev-charging-co2-optimization-v1' blueprint used in tests below
+    // is real, shipped repo data, not a stub.
 
     broker.createService({
       name: 'cookbook',
@@ -449,6 +430,28 @@ describe('MCP Server meta-tools', () => {
   test('describe an operation includes execute-read policy', async () => {
     const res = await broker.call('mcp-server.describe', { kind: 'operation', id: 'getPrices' });
     expect(res.data.executeReadPolicy.allowed).toBe(true);
+  });
+
+  // Real-world regression test: an MCP client asked a CO2-intensity
+  // question, cernion_ask's response mentioned this blueprint by name (its
+  // own L3 broker routing already knew about it), but cernion_describe
+  // couldn't resolve it because it only queried blueprint-management (the
+  // governance-lifecycle subset), not src/blueprint-registry.js (the
+  // unified view including built-in repo blueprints like this one).
+  test('describe resolves a real built-in blueprint via blueprint-registry', async () => {
+    const res = await broker.call('mcp-server.describe', {
+      kind: 'blueprint',
+      id: 'ev-charging-co2-optimization-v1',
+    });
+    expect(res.success).toBe(true);
+    expect(res.data.id).toBe('ev-charging-co2-optimization-v1');
+    expect(res.data.meta.title).toContain('CO2');
+  });
+
+  test('describe a nonexistent blueprint id returns a clear 404', async () => {
+    await expect(
+      broker.call('mcp-server.describe', { kind: 'blueprint', id: 'does-not-exist-v1' })
+    ).rejects.toMatchObject({ type: 'MCP_BLUEPRINT_NOT_FOUND' });
   });
 
   test('executeRead refuses a non-allowlisted write operation', async () => {

--- a/tests/mcp-transport.test.js
+++ b/tests/mcp-transport.test.js
@@ -107,31 +107,10 @@ describe('MCP transport (real streamable-HTTP round trip)', () => {
       },
     });
 
-    broker.createService({
-      name: 'blueprint-management',
-      actions: {
-        list: {
-          handler() {
-            return {
-              success: true,
-              data: [
-                {
-                  blueprintId: 'ev-charging-co2-optimization-v1',
-                  title: 'EV CO2',
-                  description: 'charging',
-                },
-              ],
-            };
-          },
-        },
-        get: {
-          params: { id: { type: 'string' } },
-          handler(ctx) {
-            return { success: true, data: { blueprintId: ctx.params.id, title: 'EV CO2' } };
-          },
-        },
-      },
-    });
+    // No blueprint-management stub: the `blueprint` kind reads
+    // src/blueprint-registry.js directly (real src/blueprints/*.json data,
+    // including the real 'ev-charging-co2-optimization-v1' blueprint used
+    // below), not blueprint-management.
 
     broker.createService({
       name: 'cookbook',


### PR DESCRIPTION
## Summary

Two real-world bug reports from claude.ai testing (asking "what's the BDEW/EIC code of Syna GmbH" and "when is CO2 intensity low tomorrow in 69256"), both traced to concrete, fixable gaps:

1. **`cernion_execute_read`'s allowlist was structurally too narrow.** `energy-market.co2Intensity` (POST, takes a body, but a genuine read) was refused because the hand-curated ~10-entry POST allowlist didn't cover it — and neither did every other read-shaped POST across the platform (energy-market, entsoe, gas-storage, german-grid, oep, osm-geo, residual-load, tabular, ...). Fix: `execute_read` now consults `operation-capability-index.json` — the same deterministic classification already computed for all ~880 operations and relied on elsewhere in the platform — as its primary source of truth (~556 operations now correctly read-safe, vs. ~10 before). Deliberately per-`operationKind` rather than a blanket rule: `znp_deleteProject` (a real `DELETE`) is misclassified `advisory_plan` in the index but correctly flagged `recommendedExecutionMode: 'confirm'` (not `'explain_only'` like genuine read-only `advisory_plan` endpoints e.g. `evidence-router.route`) — the per-kind check still catches and denies it.
2. **A real, independent bug found while investigating #1**: the execute_read denylist targeted `/token-manager/*`, but `services/token-manager.service.js` is actually mounted at `/tokens` — so `GET /api/tokens` (token metadata) was never actually blocked despite that clearly being the intent.
3. **`cernion_search`/`describe`'s `blueprint` kind couldn't resolve built-in blueprints.** `cernion_ask`'s response mentioned a blueprint (`ev-charging-co2-optimization-v1`) by name — its own internal L3-broker routing already knew about it — but `cernion_describe` reported it unresolvable. Root cause: `search`/`describe` queried `blueprint-management` (the PouchDB draft/promote governance workflow) instead of `src/blueprint-registry.js` — the actual unified view `cernion_ask`'s own routing consults (static repo blueprints + governance-promoted ones). Switched to call `blueprint-registry.js` directly.

See `docs/mcp-server.md`'s "The allowlist redesign" and "Blueprint discoverability" sections for full detail.

## Test plan

- [x] `tests/mcp-execute-read-policy.test.js` (new, 16 tests) — the CO₂ fix, the token-manager path fix, the `znp_deleteProject` misclassification edge case, denylist coverage, missing-index fallback (mocked)
- [x] `tests/mcp-server.service.test.js` extended — real (not stubbed) blueprint-registry data, 404 for a nonexistent blueprint id
- [x] `npm run lint` clean
- [x] `npm run check:llm`, `npm run check:operation-capability-index` — artifacts regenerated and verified in sync by direct hash comparison
- [x] `npm run check:quality-gate`, `npm run audit:security`, `npm run audit:openapi` (0 issues) all pass
- [x] Full `tests/api.service.test.js` + `tests/agent.service.test.js` + `tests/blueprint-management.service.test.js` + `tests/personal-agent.service.test.js` (4099 tests) pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)