### PR TITLE
fix: steer MCP tool selection to structured operations over RAG fallback (v0.99.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.6] — 2026-08-03
+
+### Changed
+- **Tool-selection steering for structured/quantitative questions** — found via a third real-world report (after Syna GmbH's BDEW/EIC code and a CO₂-intensity question): "wie voll im Augenblick die Gasspeicher sind" was answered by `cernion_ask` falling back to generic document/knowledge-RAG search instead of finding the matching structured operation (`gas-storage.countryStorage`), even though that operation is correctly classified and reachable — verified directly: `checkExecuteReadPolicy('POST', '/api/gas-storage/country-storage')` returns `{ allowed: true }`, and the operation is `data_read`/`agentable=true` in `operation-capability-index.json`. The routing decision itself (`personal-agent.service.js`'s internal RAG-vs-tool arbitration) is out of MCP-server scope and untouched; the only lever available here is steering which *MCP tool* an external client picks in the first place. Reworded `cernion_ask`, `cernion_search`, and `cernion_execute_read`'s tool descriptions in `src/mcp-transport.js` so an MCP client is explicitly pointed at `cernion_search` (kind=operation) + `cernion_execute_read` first for a specific structured data point tied to a known entity, falling back to `cernion_ask` only when no matching operation exists or the question is genuinely open-ended/explanatory. Also refreshed `cernion_execute_read`'s description, which still referenced the pre-v0.99.5 "small allowlist" instead of the current index-driven (~556 operation) classification. See `docs/mcp-server.md`'s "Tool-selection steering" section.
+
+### Testing
+- No behavioral/runtime code changed (description-text only); existing `tests/mcp-transport.test.js` and `tests/mcp-server.service.test.js` (45 tests) re-run clean against the updated tool definitions.
+
 ## [0.99.5] — 2026-08-02
 
 ### Fixed

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,4 +1,4 @@
-# MCP Server (v0.99.2, extended v0.99.3, v0.99.4, v0.99.5)
+# MCP Server (v0.99.2, extended v0.99.3, v0.99.4, v0.99.5, v0.99.6)
 
 A real MCP (Model Context Protocol) server — JSON-RPC 2.0 over the
 streamable-HTTP transport — sitting in front of this platform's REST API.
@@ -229,6 +229,32 @@ now call `listBlueprints()`/`loadBlueprint()` from that module directly
 `blueprint-management.list`/`.get`. Scope note: not-yet-promoted **drafts**
 are intentionally excluded — those are governance-workflow-internal, not
 part of what `cernion_ask` can actually route to yet.
+
+## Tool-selection steering: cernion_ask vs. cernion_search+execute_read (v0.99.6)
+
+A third real-world report (claude.ai asking for the current German gas
+storage fill level) found the same pattern as the CO₂ report above, but
+this time the underlying data path was already correct
+(`gas-storage.countryStorage` classifies `data_read`/agentable, reachable
+via `execute_read` since v0.99.5's redesign) — the gap was purely which
+tool got called. `cernion_ask`'s internal routing
+(`personal-agent.askCernionAgent`, a much larger system this MCP layer
+doesn't touch) sometimes falls back to generic knowledge-RAG document
+search for a specific structured data point tied to a named entity,
+instead of recognizing it as a request for a matching operation.
+
+Nothing to fix in `askCernionAgent` itself from here — but `cernion_ask`'s
+tool description previously said "try this first... covers most requests
+without needing search/describe/execute_read", which actively steered
+MCP clients away from the more reliable path for exactly this question
+shape. `cernion_ask`, `cernion_search`, and `cernion_execute_read`'s
+descriptions now explicitly point structured/quantitative questions
+(prices, fill levels, forecasts, a named entity's code) at
+`cernion_search` (kind=operation) + `cernion_execute_read` first, and
+reserve `cernion_ask` for open-ended/explanatory questions or as a
+fallback when no matching operation exists. A prompt-engineering-level
+fix, not a code fix — worth knowing if `askCernionAgent`'s own routing
+improves later, since these descriptions would then be overly cautious.
 
 ## Reserved operation families (v0.99.3)
 

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.5
-- changelog_latest_release: 0.99.5
+- version: 0.99.6
+- changelog_latest_release: 0.99.6
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -246,12 +246,12 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: 987ba0eb515cc65e8c4cb763782fc2c01eedc8d5f39e14fff6a8b39e604c92c8
+- CHANGELOG.md: 247a474e30ae26993e3a76446cd7a2f8cb2c56d2375bfdcdcd678da3bff61148
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: f4611e17803b842eaecc65485055684468d4317247fe922038d7b702b3d72e97
+- openapi-export.json: 3e303b519aea14e06040f8a24e6c4b62743710db3d1e64d1e243b1c77fdb7ce8
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 1021
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 7abadff05bc52cf7d2db0b81048a669f6c728fedfec3d930c80966eef4fbb23e
+- llm_txt_sha256: d97a4f50cabdb658d7ba4986ebeb3c1ed22744ddf068b40785975475096fec79

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.5",
+    "version": "0.99.6",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -2470,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.5",
+  "x-version": "0.99.6",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.5",
+    "version": "0.99.6",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -91084,5 +91084,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.5"
+  "x-version": "0.99.6"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.5",
-  "sourceOpenApiHash": "f4611e17803b842eaecc65485055684468d4317247fe922038d7b702b3d72e97",
+  "packageVersion": "0.99.6",
+  "sourceOpenApiHash": "3e303b519aea14e06040f8a24e6c4b62743710db3d1e64d1e243b1c77fdb7ce8",
   "coverage": {
     "rawOperationCount": 1133,
     "operationCount": 877,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.5",
+  "version": "0.99.6",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {

--- a/src/mcp-transport.js
+++ b/src/mcp-transport.js
@@ -46,9 +46,15 @@ const TOOL_DEFS = [
     action: 'mcp-server.ask',
     title: 'Ask Cernion',
     description:
-      'Standard factual question about the energy domain (grid, market, regulatory). CET routes ' +
-      'internally and answers directly with evidence, guardrails, and process context. Try this first ' +
-      '— it covers most requests without needing search/describe/execute_read.',
+      'Open-ended factual/regulatory question (grid, market, process, compliance). CET routes ' +
+      'internally and answers with evidence, guardrails, and process context — good for explanatory ' +
+      'or document-grounded questions. NOT reliable yet for a specific structured data point tied to ' +
+      'a known entity (e.g. "what is the gas storage fill level", "what is the BDEW/EIC code of ' +
+      'company X", "what is the CO2 intensity forecast for postal code Y") — internal routing ' +
+      'sometimes falls back to generic document search for these instead of the matching structured ' +
+      'operation, even though one exists and works. For that shape of question, try cernion_search ' +
+      '(kind=operation) + cernion_execute_read FIRST; fall back to cernion_ask only if no matching ' +
+      'operation is found, or for genuinely open-ended/explanatory questions.',
     annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
     inputSchema: {
       question: z.string().min(1).max(8000),
@@ -67,7 +73,11 @@ const TOOL_DEFS = [
     title: 'Search Cernion catalogue',
     description:
       'Unified search over capabilities, REST operations, agent receipts, blueprints, and cookbook ' +
-      'recipes. Returns compact typed refs (cernion://{kind}/{id}) — use cernion_describe for full detail.',
+      'recipes. Returns compact typed refs (cernion://{kind}/{id}) — use cernion_describe for full ' +
+      'detail, cernion_execute_read to run a read-classified operation directly. Prefer this ' +
+      '(kind=operation) + cernion_execute_read over cernion_ask when the question wants one specific ' +
+      "structured data point (a price, a fill level, a company's BDEW/EIC code, a forecast value) " +
+      "rather than an open-ended explanation — cernion_ask's internal routing is less reliable for that shape of question.",
     annotations: { readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       query: z.string().min(1).max(500),
@@ -96,8 +106,10 @@ const TOOL_DEFS = [
     title: 'Execute a read-only operation',
     description:
       'Executes a read-only REST operation selected via ref (from cernion_search/describe) or an ' +
-      'explicit method+path. Server-side allowlist enforced — refused if the operation is not GET or ' +
-      'on the small read-classified POST allowlist (evidence-router, knowledge-rag, receipt dry-runs).',
+      'explicit method+path. Server-side classification enforced (~556 operations recognized as ' +
+      'read-safe regardless of HTTP verb) — refused if the operation is a genuine write, or an ' +
+      'admin/secret surface. Use this + cernion_search for a specific structured data point instead ' +
+      "of cernion_ask — see cernion_ask's description for why.",
     annotations: { readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       ref: z.string().optional(),


### PR DESCRIPTION
## Summary
- Third real-world report of `cernion_ask` falling back to generic knowledge-RAG for a structured, entity-specific data point ("wie voll im Augenblick die Gasspeicher sind") instead of finding the matching, already-working operation (`gas-storage.countryStorage` — confirmed classified `data_read`/`agentable=true` and `execute_read`-allowed).
- `personal-agent.service.js`'s internal RAG-vs-tool routing is out of MCP-server scope and untouched; the only in-scope lever is which MCP tool an external client picks. Reworded `cernion_ask`, `cernion_search`, and `cernion_execute_read`'s tool descriptions in `src/mcp-transport.js` to steer clients toward `cernion_search` (kind=operation) + `cernion_execute_read` first for a specific structured data point, falling back to `cernion_ask` only for genuinely open-ended/explanatory questions.
- Also refreshed `cernion_execute_read`'s description, which still referenced the pre-v0.99.5 "small allowlist" instead of the current index-driven (~556 operation) classification.
- No runtime/behavioral code changed — description text only. Artifacts regenerated (llm.txt, openapi-export.json, operation-capability-index.json, openapi-copilot.json), hash sync verified.

## Test plan
- [x] `node -e "require('./src/mcp-transport.js')"` loads clean
- [x] `eslint` clean on `src/mcp-transport.js`
- [x] `tests/mcp-transport.test.js` + `tests/mcp-server.service.test.js` (45 tests) pass
- [x] `npm run audit:openapi` — 0 issues (pre-existing unrelated warnings only)
- [x] `npm run check:quality-gate` — success
- [x] `npm run audit:security` — no critical findings
- [x] `operation-capability-index.json` sourceOpenApiHash verified against fresh sha256 of `openapi-export.json`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>