### PR TITLE
fix: full MCP capability exposure — operation schema, VDMI writes, misclassified-write denial (v0.99.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.7] — 2026-08-04
+
+### Security
+- **Fixed a real gap: `cernion_execute_read` could silently execute 3 write operations misclassified as read-only.** Found while scoping "full capability exposure via MCP" (see below): `operation-capability-index.json`'s classifier heuristic treats any POST operation whose summary starts with "resolve" as a read query — correct for genuine cases (`chatgpt-sidecar.plan`: "Resolve a request to a route, no execution") but wrong for `vdmi.resolveFinding`, `interface-placeholder.resolveGap`, and `job-status.resolveAlarm`, which all persist real state changes. All 3 were classified `data_read`/`direct` and reachable through the supposedly read-only MCP tool before this fix. Not fixed in the shared classifier (used by other consumers beyond MCP) — overridden with an explicit deny in `src/mcp-execute-read-policy.js` the same way v0.99.5 handled `znp_deleteProject`'s misclassification. See `docs/mcp-server.md`'s "Full capability exposure" section.
+
+### Added
+- **Full parameter/request-body schema now surfaced by `cernion_describe(kind=operation)`.** Previously returned only `{method, path, operationId, summary, tags, aliases}` — no way for an MCP client to discover what to filter/pass before calling `execute_read`, even though the schema always existed in `openapi-export.json`. `services/agent-manifest.service.js`'s `loadOperations()`/`dedupeOperations()` now carry `description`, `parameters`, and `requestBody` through; `describe` already spread the full operation object, so no further change was needed there. `search` results are untouched (still lean, unaffected).
+- **2 new reserved `operationFamily` values for `cernion_prepare_process`/`execute_process`: `vdmiFindingMitigation` and `vdmiFindingResolution`** (`services/copilot-process.service.js`: `prepareVdmiFindingMitigation`, `prepareVdmiFindingResolution`, plus `_executeIntent` dispatch cases; `src/mcp-reserved-families.js`). The highest-value, lowest-risk pair of ~19 previously-unwired VDMI write operations — `vdmiFindingResolution` is also the proper write path for the operation flagged in the Security section above. The remaining VDMI write operations (and VDMI nomination, whose Phase 3 execute path isn't implemented server-side yet at all) are deliberately deferred to a future release with their own per-action review rather than wired in bulk — see `docs/mcp-server.md`'s "Full capability exposure" section for the full reasoning.
+
+### Testing
+- `tests/mcp-execute-read-policy.test.js` — regression tests for all 3 misclassified-write denials plus a sanity check that the override doesn't over-match unrelated `/resolve`-suffixed paths.
+- `tests/agent-manifest.service.test.js` (new) — parameter/requestBody/description exposure, run against the real generated `openapi-export.json`.
+- `tests/mcp-server.service.test.js`, `tests/copilot-process-phase3.service.test.js` — describe-schema pass-through, and full prepare→execute coverage for both new reserved families (intent creation, dispatch, 404s, missing-field validation, `x-openai-isConsequential: false`).
+
 ## [0.99.6] — 2026-08-03
 
 ### Changed

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,4 +1,4 @@
-# MCP Server (v0.99.2, extended v0.99.3, v0.99.4, v0.99.5, v0.99.6)
+# MCP Server (v0.99.2, extended v0.99.3, v0.99.4, v0.99.5, v0.99.6, v0.99.7)
 
 A real MCP (Model Context Protocol) server — JSON-RPC 2.0 over the
 streamable-HTTP transport — sitting in front of this platform's REST API.
@@ -95,26 +95,29 @@ the hard way:
 
 2. **Generic process intents don't auto-execute — by design, not a gap.**
    `copilot-process.js`'s `_executeIntent` dispatch table only has cases for
-   4 reserved operation families (`vdmi`, `gridConnection`, `znp`,
-   `connectionRejectionEvidence`), each with its own dedicated `prepare*`
-   REST action. Any intent created through the **generic**
-   `prepareProcessIntent` (which is what `cernion_run_receipt` mode=run
-   uses, and what `cernion_prepare_process` falls back to for any
-   `operationFamily` outside the 4 reserved ones) will get
+   6 reserved operation families (`vdmi`, `gridConnection`, `znp`,
+   `connectionRejectionEvidence`, and as of v0.99.7
+   `vdmiFindingMitigation`/`vdmiFindingResolution`), each with its own
+   dedicated `prepare*` REST action. Any intent created through the
+   **generic** `prepareProcessIntent` (which is what `cernion_run_receipt`
+   mode=run uses, and what `cernion_prepare_process` falls back to for any
+   `operationFamily` outside the reserved ones) will get
    `UNKNOWN_OPERATION_FAMILY` if you try to execute it — the docstring in
    `copilot-process.service.js` calls this "establishes the intake/
    classification/HITL boundary only." `cernion_execute_process` catches
    that specific error and rewraps it with a clearer message
    (`MCP_INTENT_REQUIRES_MANUAL_EXECUTION`) rather than a raw 400. Rejecting
    a generic intent still works fully.
-   **As of v0.99.3**, `cernion_prepare_process` routes the 4 reserved
-   `operationFamily` values to their dedicated `prepare*` actions instead
-   of the generic one (see "Reserved operation families" below) — those 4
-   now execute for real through `cernion_execute_process`, closing this
-   gap for the families that have one. Everything else still needs a
-   developer to add a reviewed dispatch case in `_executeIntent` first —
-   that's a deliberate governance boundary, not something MCP should paper
-   over.
+   **As of v0.99.3** (extended v0.99.7), `cernion_prepare_process` routes
+   the reserved `operationFamily` values to their dedicated `prepare*`
+   actions instead of the generic one (see "Reserved operation families"
+   below) — those now execute for real through `cernion_execute_process`,
+   closing this gap for the families that have one. Everything else still
+   needs a developer to add a reviewed dispatch case in `_executeIntent`
+   first — that's a deliberate governance boundary, not something MCP
+   should paper over. See "Full capability exposure (v0.99.7)" below for
+   why only 2 of ~19 unwired VDMI write operations were added, not all of
+   them.
 
 3. **Receipts have no direct execution path either.** There is no
    "run this receipt for real" REST action — only `test`/`testStored`
@@ -256,12 +259,78 @@ fallback when no matching operation exists. A prompt-engineering-level
 fix, not a code fix — worth knowing if `askCernionAgent`'s own routing
 improves later, since these descriptions would then be overly cautious.
 
-## Reserved operation families (v0.99.3)
+## Full capability exposure (v0.99.7)
+
+Scoping question from the platform owner: "are we still meaningfully behind
+what the REST API/OpenAPI spec can do, especially for VDMI (processes) and
+structured retrieval/filtering?" Two real, confirmed gaps, one incidental
+security finding:
+
+**1. `cernion_describe(kind=operation)` had no parameter/body schema.** It
+returned only `{method, path, operationId, summary, tags, aliases}` — an
+MCP client had no way to discover what to filter/pass (query params, body
+fields) before calling `execute_read`, even though the full OpenAPI
+`parameters`/`requestBody` schema (with types, required fields, examples)
+was already sitting in `openapi-export.json` for every operation, just
+never carried through `agent-manifest.listOperations()`. Fixed by having
+`loadOperations()`/`dedupeOperations()` (`services/agent-manifest.
+service.js`) also capture `description` (not just `summary` — often has the
+real usage guidance, see `gas-storage_countryStorage`'s "Use cases:..."
+prose), `parameters`, and `requestBody` straight from the parsed spec.
+`describe`'s operation branch already spread `...op` into its response, so
+no change was needed there — the new fields just flow through. `search`'s
+operation results are untouched (still the lean `{ref, kind, title,
+summary, riskClass}` shape) since a 10-row search list isn't the place for
+full schemas — that's what `describe` is for.
+
+**2. VDMI write coverage was 1 of ~20 operations.** All 24 VDMI
+*read*-shaped operations were already reachable via `cernion_search`+
+`execute_read`. But only `prepareVdmiEvidence` had a dedicated
+prepare→confirm→execute path — `nominate`, `confirm-nomination`, `detect`,
+`revert`, `findings/mitigate`, `findings/resolve`, `evidence/sign`, and
+others had none. This is **not** purely an MCP-layer gap: `copilot-process.
+service.js`'s `_executeIntent` dispatch table is deliberately hand-reviewed
+per operation (see deviation #2 above) — there is no generic "execute
+whatever the intent says" path, by design, since each write needs its own
+validation review (see the `connectionRejectionEvidence` `decision`-enum
+gap in "Reserved operation families" below for why that caution is
+warranted). One target, VDMI nomination, doesn't even have a real Phase 3
+execute path server-side yet (`prepareVdmiValidation`'s own response says
+`"Noch nicht implementiert (Phase 3)"`) — building that is a platform
+feature, not something to bolt on under an MCP release. Given that, v0.99.7
+adds the 2 highest-value, lowest-risk additions —
+`vdmiFindingMitigation`/`vdmiFindingResolution` (see "Reserved operation
+families" below) — rather than rushing all ~19 through in one pass. The
+remaining VDMI write operations, and the still-unimplemented nomination
+Phase 3, are deliberately deferred to a future release with its own
+per-action review, not silently dropped.
+
+**3. Security finding made while confirming #2's target list**:
+`vdmi.resolveFinding` — a genuine write (persists `finding.status =
+'resolved'` to PouchDB) — was misclassified `data_read`/`recommended
+ExecutionMode: direct` in `operation-capability-index.json`, meaning it was
+silently reachable through the supposedly read-only `cernion_execute_read`
+tool. Root cause: `src/operation-capability-classifier.js`'s
+`QUERY_VERB_PATTERN` treats any POST operation whose summary starts with
+"resolve" as a read query (correct for genuine cases like
+`chatgpt-sidecar.plan`'s "Resolve a request to a route (no execution)",
+wrong here — "resolve" also means "close out a stateful entity"). Auditing
+every operation the same heuristic let through found 2 more real instances:
+`interface-placeholder.resolveGap` and `job-status.resolveAlarm`. Not fixed
+in the classifier itself — it's relied on by other consumers beyond MCP, so
+narrowing the "resolve" verb there needs its own dedicated audit — instead
+overridden in `src/mcp-execute-read-policy.js` (`KNOWN_MISCLASSIFIED_
+WRITE_PATTERNS`) the same way v0.99.5 handled `znp_deleteProject`'s
+misclassification. All 3 are now explicitly denied by `execute_read`
+regardless of index classification; see the module comment there for the
+exact paths and regression tests in `tests/mcp-execute-read-policy.test.js`.
+
+## Reserved operation families (v0.99.3, extended v0.99.7)
 
 `cernion_prepare_process`'s `operationFamily` param routes to one of two
 places (`src/mcp-reserved-families.js`):
 
-- One of the 4 reserved values below → the matching dedicated `prepare*`
+- One of the 6 reserved values below → the matching dedicated `prepare*`
   action in `services/copilot-process.service.js`, whose intent **does**
   execute for real via `cernion_execute_process`.
 - Anything else → the generic `prepareProcessIntent` (deviation #2 above —
@@ -273,8 +342,10 @@ places (`src/mcp-reserved-families.js`):
 | `gridConnection` | at least one of `gridOperatorId` / `gridOperatorBdew` / `gridOperatorName` | `includeCapacityCheck` | `grid-connection.validate` — runs the Netzanschluss validation pipeline (up to 2 min) |
 | `znp` | `projectId`, `text` | — | `znp.addAssumption` — adds a ZNP planning assumption |
 | `connectionRejectionEvidence` | `gridOperatorId`, `applicantReference`, `loadAssumptionKw`, `netzverknuepfungspunktId`, `voltageLevel`, `bottleneckDescription`, `n1QualityStatus` (`COMPLIANT`\|`NON_COMPLIANT`\|`CONDITIONALLY_COMPLIANT`\|`UNKNOWN`), `decision` (`GO`\|`CONDITIONAL`\|`NO_GO`\|`PENDING`) | — | `connection-rejection-evidence.create` — creates an evidence package |
+| `vdmiFindingMitigation` (v0.99.7) | `findingId`, `owner`, `dueAt`, `plan` | — | `vdmi.mitigateFinding` — submits a mitigation plan for a VDMI finding |
+| `vdmiFindingResolution` (v0.99.7) | `findingId`, `resolutionReason` | `evidenceRef` | `vdmi.resolveFinding` — resolves/closes a VDMI finding |
 
-`reason` (top-level, not inside `payload`) is required for all 4 — the
+`reason` (top-level, not inside `payload`) is required for all 6 — the
 dedicated actions require it themselves.
 
 **A bug found and worked around, not fixed at the source**:
@@ -290,13 +361,20 @@ confusing failure after the human has already confirmed. Not fixed in
 (including tests that rely on the current loose validation) for a fix
 that's only load-bearing through the new MCP path.
 
-The 4 families' read-only context endpoints
+The original 4 families' read-only context endpoints
 (`getVdmiContext`, `listOpenResponsibilities`, `getZnpProjectStatus`,
 `getGridConnectionValidation`) needed no changes — they're plain GET
 routes, so `cernion_search`/`describe`/`execute_read` already reach them
 via the normal operation catalogue. `connectionRejectionEvidence` has no
 equivalent context endpoint in `copilot-process.service.js` (a pre-existing
 asymmetry with the other 3 families, not something this change introduces).
+`vdmiFindingMitigation`/`vdmiFindingResolution` likewise reuse an existing
+read endpoint, `vdmi.findings` (`GET /api/vdmi/findings`), for existence
+checks in their `prepare*` actions rather than needing a new one.
+
+**`vdmiFindingResolution` is the write-path fix for the v0.99.7 execute_read
+security finding below** — before this, `vdmi.resolveFinding` had no MCP
+write path *and* was reachable through the read-only tool by mistake.
 
 ## Auth and RBAC — why this needed its own gate
 

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.6
-- changelog_latest_release: 0.99.6
+- version: 0.99.7
+- changelog_latest_release: 0.99.7
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -182,7 +182,7 @@ recipes:
   transformation-financing-scenario-view "Management needs one dossier-safe view over cashflow, gas…"
 resolve: GET /api/_agent/operations?domain=governance
 
-### platform (13 capabilities · 9 recipes · 427 operations)
+### platform (13 capabilities · 9 recipes · 429 operations)
 capabilities: datasource_registry_classification_governance, dr_readiness_evidence_gate, energy_sidecar_route_registry, evidence_grounding_confidence_audit, evu_api_migration_diagnostics, file_ingest_monitor, hitl_role_based_evidence_request, live_update_stream_contract_status, receipt_grounded_presentation_contract, stadtwerk_mauer_e2e_process_demo, stadtwerk_mauer_external_interface_stubs, stadtwerk_mauer_mastr_data_overlay, stadtwerk_mauer_sandbox_runtime
 recipes:
   agentic-production-feedback-prompt "An engineering agent should receive a consistent, redacted…"
@@ -246,17 +246,17 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: 247a474e30ae26993e3a76446cd7a2f8cb2c56d2375bfdcdcd678da3bff61148
+- CHANGELOG.md: 49505c511b77d50100039d52f6210d0ef122a04d0ec26218d0df1c19843b2fa3
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: 3e303b519aea14e06040f8a24e6c4b62743710db3d1e64d1e243b1c77fdb7ce8
+- openapi-export.json: fa9819ed0996deebfa6b2bf9c417f1dc49d90ddd5a01146a47a9b0dd9442c873
 
 ## OpenAPI Surface (full contract, not embedded)
-- path_count: 1021
-- operation_count: 1133
+- path_count: 1023
+- operation_count: 1135
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: d97a4f50cabdb658d7ba4986ebeb3c1ed22744ddf068b40785975475096fec79
+- llm_txt_sha256: 17f2c2c1d3240463bffb7a5d82a6166c621ddd5103ce110cd38ff18a676b767b

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.6",
+    "version": "0.99.7",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -2470,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.6",
+  "x-version": "0.99.7",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.6",
+    "version": "0.99.7",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -8738,6 +8738,140 @@
                   "idempotencyKey": {
                     "type": "string",
                     "example": "idem-vdmi-20260611"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-openai-isConsequential": false
+      }
+    },
+    "/api/copilot-process/vdmi/findings/:findingId/prepare-mitigation": {
+      "post": {
+        "operationId": "prepareVdmiFindingMitigation",
+        "summary": "Prepare VDMI finding mitigation intent — no write",
+        "tags": [
+          "Copilot Process"
+        ],
+        "responses": {
+          "200": {
+            "description": "VDMI finding mitigation intent created"
+          },
+          "404": {
+            "description": "Finding not found"
+          }
+        },
+        "description": "Verifies the VDMI finding exists and creates a persistent ProcessExecutionIntent for submitting a mitigation plan. No finding is modified.\nReturns intentId, expiresAt, and confirmationMessage. Execute via executeProcessIntent outside Copilot.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "findingId",
+                  "owner",
+                  "dueAt",
+                  "plan",
+                  "reason"
+                ],
+                "properties": {
+                  "findingId": {
+                    "type": "string",
+                    "example": "finding-abc123"
+                  },
+                  "owner": {
+                    "type": "string",
+                    "minLength": 2,
+                    "example": "grid-lead"
+                  },
+                  "dueAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2026-12-31T00:00:00.000Z"
+                  },
+                  "plan": {
+                    "type": "string",
+                    "minLength": 3,
+                    "example": "Ablösung des Schattenpfads durch API-Integration"
+                  },
+                  "reason": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500,
+                    "example": "Mitigation nach Governance-Review"
+                  },
+                  "correlationId": {
+                    "type": "string",
+                    "example": "req-2026-001"
+                  },
+                  "idempotencyKey": {
+                    "type": "string",
+                    "example": "idem-finding-20260611"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-openai-isConsequential": false
+      }
+    },
+    "/api/copilot-process/vdmi/findings/:findingId/prepare-resolution": {
+      "post": {
+        "operationId": "prepareVdmiFindingResolution",
+        "summary": "Prepare VDMI finding resolution intent — no write",
+        "tags": [
+          "Copilot Process"
+        ],
+        "responses": {
+          "200": {
+            "description": "VDMI finding resolution intent created"
+          },
+          "404": {
+            "description": "Finding not found"
+          }
+        },
+        "description": "Verifies the VDMI finding exists and creates a persistent ProcessExecutionIntent for resolving it. No finding is modified.\nReturns intentId, expiresAt, and confirmationMessage. Execute via executeProcessIntent outside Copilot.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "findingId",
+                  "resolutionReason",
+                  "reason"
+                ],
+                "properties": {
+                  "findingId": {
+                    "type": "string",
+                    "example": "finding-abc123"
+                  },
+                  "resolutionReason": {
+                    "type": "string",
+                    "minLength": 3,
+                    "example": "Integration abgeschlossen"
+                  },
+                  "evidenceRef": {
+                    "type": "string",
+                    "example": "ticket-123"
+                  },
+                  "reason": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500,
+                    "example": "Abschluss nach Governance-Review"
+                  },
+                  "correlationId": {
+                    "type": "string",
+                    "example": "req-2026-001"
+                  },
+                  "idempotencyKey": {
+                    "type": "string",
+                    "example": "idem-finding-20260611"
                   }
                 }
               }
@@ -91084,5 +91218,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.6"
+  "x-version": "0.99.7"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.6",
-  "sourceOpenApiHash": "3e303b519aea14e06040f8a24e6c4b62743710db3d1e64d1e243b1c77fdb7ce8",
+  "packageVersion": "0.99.7",
+  "sourceOpenApiHash": "fa9819ed0996deebfa6b2bf9c417f1dc49d90ddd5a01146a47a9b0dd9442c873",
   "coverage": {
-    "rawOperationCount": 1133,
-    "operationCount": 877,
-    "agentableCount": 875,
+    "rawOperationCount": 1135,
+    "operationCount": 879,
+    "agentableCount": 877,
     "nonAgentableCount": 2,
     "byOperationKind": {
       "data_read": 385,
@@ -15,7 +15,7 @@
       "process_step": 20,
       "process_start": 42,
       "advisory_plan": 46,
-      "draft_write": 11,
+      "draft_write": 13,
       "external_effect": 4,
       "dashboard_read": 125,
       "internal": 7
@@ -13034,6 +13034,237 @@
         "negativeCues": [],
         "examples": [
           "Please prepare vdmi matrix nomination — draft only, no write"
+        ],
+        "synonyms": [
+          "agent infrastructure",
+          "system"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "prepareVdmiFindingMitigation",
+      "method": "POST",
+      "path": "/api/copilot-process/vdmi/findings/:findingId/prepare-mitigation",
+      "service": "copilot-process",
+      "action": null,
+      "summary": "Prepare VDMI finding mitigation intent — no write",
+      "tags": [
+        "Copilot Process"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "draft_write",
+      "consequenceLevel": "low",
+      "recommendedExecutionMode": "prepare",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "copilot-process.prepare_vdmi_finding_mitigation"
+      ],
+      "domains": [
+        "platform"
+      ],
+      "dataSources": [
+        "VDMI"
+      ],
+      "entityTypes": [],
+      "requiredScopes": [
+        "copilot-process:write"
+      ],
+      "tenantScoped": true,
+      "writesTo": [
+        "copilot-process"
+      ],
+      "sideEffects": [
+        "creates_draft_or_intent"
+      ],
+      "idempotency": "not_idempotent",
+      "rollbackHint": "Discard the created draft/intent - no persisted business state changes until a subsequent confirm/promote step.",
+      "parameters": {
+        "required": [
+          {
+            "name": "findingId",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "owner",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "dueAt",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "plan",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "reason",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          }
+        ],
+        "optional": [
+          {
+            "name": "correlationId",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": "geo_coordinate"
+          },
+          {
+            "name": "idempotencyKey",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          }
+        ]
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "prepare",
+          "vdmi",
+          "finding",
+          "mitigation",
+          "intent",
+          "—",
+          "no",
+          "write",
+          "copilot",
+          "process"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Please prepare vdmi finding mitigation intent — no write"
+        ],
+        "synonyms": [
+          "agent infrastructure",
+          "system"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "prepareVdmiFindingResolution",
+      "method": "POST",
+      "path": "/api/copilot-process/vdmi/findings/:findingId/prepare-resolution",
+      "service": "copilot-process",
+      "action": null,
+      "summary": "Prepare VDMI finding resolution intent — no write",
+      "tags": [
+        "Copilot Process"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "draft_write",
+      "consequenceLevel": "low",
+      "recommendedExecutionMode": "prepare",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "copilot-process.prepare_vdmi_finding_resolution"
+      ],
+      "domains": [
+        "platform"
+      ],
+      "dataSources": [
+        "VDMI"
+      ],
+      "entityTypes": [],
+      "requiredScopes": [
+        "copilot-process:write"
+      ],
+      "tenantScoped": true,
+      "writesTo": [
+        "copilot-process"
+      ],
+      "sideEffects": [
+        "creates_draft_or_intent"
+      ],
+      "idempotency": "not_idempotent",
+      "rollbackHint": "Discard the created draft/intent - no persisted business state changes until a subsequent confirm/promote step.",
+      "parameters": {
+        "required": [
+          {
+            "name": "findingId",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "resolutionReason",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "reason",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          }
+        ],
+        "optional": [
+          {
+            "name": "evidenceRef",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "correlationId",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": "geo_coordinate"
+          },
+          {
+            "name": "idempotencyKey",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          }
+        ]
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "prepare",
+          "vdmi",
+          "finding",
+          "resolution",
+          "intent",
+          "—",
+          "no",
+          "write",
+          "copilot",
+          "process"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Please prepare vdmi finding resolution intent — no write"
         ],
         "synonyms": [
           "agent infrastructure",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.6",
+  "version": "0.99.7",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {

--- a/services/agent-manifest.service.js
+++ b/services/agent-manifest.service.js
@@ -43,7 +43,10 @@ function loadOperations() {
         method: method.toUpperCase(),
         operationId: op.operationId || '',
         summary: op.summary || '',
+        description: op.description || '',
         tags: Array.isArray(op.tags) ? op.tags : [],
+        parameters: Array.isArray(op.parameters) ? op.parameters : [],
+        requestBody: op.requestBody || null,
       });
     }
   }
@@ -76,7 +79,10 @@ function dedupeOperations(operations) {
       path: canonical.path,
       operationId: canonical.operationId,
       summary: canonical.summary,
+      description: canonical.description,
       tags: canonical.tags,
+      parameters: canonical.parameters,
+      requestBody: canonical.requestBody,
       aliases,
     });
   }

--- a/services/copilot-process.service.js
+++ b/services/copilot-process.service.js
@@ -27,6 +27,8 @@ const RESERVED_PROCESS_OPERATION_FAMILIES = new Set([
   'gridConnection',
   'znp',
   'connectionRejectionEvidence',
+  'vdmiFindingMitigation',
+  'vdmiFindingResolution',
 ]);
 
 function buildAudit(ctx, correlationId) {
@@ -1118,6 +1120,240 @@ Returns intentId, expiresAt, and confirmationMessage. Execute via executeProcess
     },
 
     /**
+     * Prepare a VDMI finding mitigation intent — no write.
+     * operationId: prepareVdmiFindingMitigation
+     *
+     * v0.99.7: vdmi.mitigateFinding (POST /api/vdmi/findings/:findingId/mitigate)
+     * is a genuine write with no MCP write path before this — only VDMI
+     * evidence injection had one. Added alongside prepareVdmiFindingResolution
+     * as the highest-value pair of the ~19 unwired VDMI write operations
+     * (see docs/mcp-server.md's "Full capability exposure" section for why
+     * the other ~17 are deliberately deferred rather than wired in bulk).
+     */
+    prepareVdmiFindingMitigation: {
+      rest: 'POST /vdmi/findings/:findingId/prepare-mitigation',
+      params: {
+        findingId: { type: 'string', min: 2 },
+        owner: { type: 'string', min: 2 },
+        dueAt: { type: 'string', min: 10 },
+        plan: { type: 'string', min: 3 },
+        reason: { type: 'string', min: 1, max: 500 },
+        correlationId: { type: 'string', optional: true },
+        idempotencyKey: { type: 'string', optional: true },
+        decisionFrameId: { type: 'string', optional: true },
+      },
+      openapi: {
+        operationId: 'prepareVdmiFindingMitigation',
+        'x-openai-isConsequential': false,
+        summary: 'Prepare VDMI finding mitigation intent — no write',
+        description: `Verifies the VDMI finding exists and creates a persistent ProcessExecutionIntent for submitting a mitigation plan. No finding is modified.
+Returns intentId, expiresAt, and confirmationMessage. Execute via executeProcessIntent outside Copilot.`,
+        tags: [SERVICE_TAG],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['findingId', 'owner', 'dueAt', 'plan', 'reason'],
+                properties: {
+                  findingId: { type: 'string', example: 'finding-abc123' },
+                  owner: { type: 'string', minLength: 2, example: 'grid-lead' },
+                  dueAt: {
+                    type: 'string',
+                    format: 'date-time',
+                    example: '2026-12-31T00:00:00.000Z',
+                  },
+                  plan: {
+                    type: 'string',
+                    minLength: 3,
+                    example: 'Ablösung des Schattenpfads durch API-Integration',
+                  },
+                  reason: {
+                    type: 'string',
+                    minLength: 1,
+                    maxLength: 500,
+                    example: 'Mitigation nach Governance-Review',
+                  },
+                  correlationId: { type: 'string', example: 'req-2026-001' },
+                  idempotencyKey: { type: 'string', example: 'idem-finding-20260611' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          200: { description: 'VDMI finding mitigation intent created' },
+          404: { description: 'Finding not found' },
+        },
+      },
+      async handler(ctx) {
+        const callOpts = { meta: { ...ctx.meta, $gateway: false } };
+        const { findingId, owner, dueAt, plan, reason } = ctx.params;
+        const audit = buildAudit(ctx, ctx.params.correlationId);
+
+        const { findings } = await ctx.call('vdmi.findings', { limit: 500 }, callOpts);
+        const finding = (findings || []).find((f) => f.id === findingId);
+        if (!finding) {
+          throw new MoleculerClientError(
+            `Finding not found: ${findingId}`,
+            404,
+            'FINDING_NOT_FOUND'
+          );
+        }
+
+        const inputSummary = `Submit mitigation plan for finding '${finding.code || findingId}': owner ${owner}, due ${dueAt}`;
+        const intent = this.intentStore.create({
+          operationFamily: 'vdmiFindingMitigation',
+          proposedAction: 'mitigate_finding',
+          targetType: 'vdmiFinding',
+          targetId: findingId,
+          inputSummary,
+          payload: { findingId, owner, dueAt, plan },
+          risk: 'medium',
+          createdBy: audit.requestedBy,
+          correlationId: audit.correlationId,
+          reason,
+          decisionFrameId: ctx.params.decisionFrameId || null,
+        });
+
+        return {
+          intentId: intent.intentId,
+          operationFamily: 'vdmiFindingMitigation',
+          proposedAction: 'mitigate_finding',
+          target: { findingId, code: finding.code },
+          inputSummary: intent.inputSummary,
+          status: intent.status,
+          expiresAt: intent.expiresAt,
+          risk: 'medium',
+          requiresHumanConfirmation: true,
+          decisionFrameId: intent.decisionFrameId,
+          summary: `Mitigations-Intent erstellt für Finding '${finding.code || findingId}'. Menschliche Bestätigung erforderlich.`,
+          confirmationMessage: `Bitte bestätige den Mitigationsplan für Finding '${finding.code || findingId}' (Owner: ${owner}, Frist: ${dueAt}).`,
+          executeVia: {
+            operationId: 'executeProcessIntent',
+            note: 'Not available via Copilot. Use direct API: POST /api/copilot-process/intents/:intentId/execute',
+          },
+          auditTrail: { ...audit, idempotencyKey: ctx.params.idempotencyKey ?? null, reason },
+        };
+      },
+    },
+
+    /**
+     * Prepare a VDMI finding resolution intent — no write.
+     * operationId: prepareVdmiFindingResolution
+     *
+     * v0.99.7: vdmi.resolveFinding (POST /api/vdmi/findings/:findingId/resolve)
+     * was found misclassified as data_read/direct in
+     * operation-capability-index.json while scoping this release (see
+     * src/mcp-execute-read-policy.js's KNOWN_MISCLASSIFIED_WRITE_PATTERNS) —
+     * it is a genuine write, now denied from cernion_execute_read AND given
+     * its own proper prepare→confirm→execute path here.
+     */
+    prepareVdmiFindingResolution: {
+      rest: 'POST /vdmi/findings/:findingId/prepare-resolution',
+      params: {
+        findingId: { type: 'string', min: 2 },
+        resolutionReason: { type: 'string', min: 3 },
+        evidenceRef: { type: 'string', optional: true },
+        reason: { type: 'string', min: 1, max: 500 },
+        correlationId: { type: 'string', optional: true },
+        idempotencyKey: { type: 'string', optional: true },
+        decisionFrameId: { type: 'string', optional: true },
+      },
+      openapi: {
+        operationId: 'prepareVdmiFindingResolution',
+        'x-openai-isConsequential': false,
+        summary: 'Prepare VDMI finding resolution intent — no write',
+        description: `Verifies the VDMI finding exists and creates a persistent ProcessExecutionIntent for resolving it. No finding is modified.
+Returns intentId, expiresAt, and confirmationMessage. Execute via executeProcessIntent outside Copilot.`,
+        tags: [SERVICE_TAG],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['findingId', 'resolutionReason', 'reason'],
+                properties: {
+                  findingId: { type: 'string', example: 'finding-abc123' },
+                  resolutionReason: {
+                    type: 'string',
+                    minLength: 3,
+                    example: 'Integration abgeschlossen',
+                  },
+                  evidenceRef: { type: 'string', example: 'ticket-123' },
+                  reason: {
+                    type: 'string',
+                    minLength: 1,
+                    maxLength: 500,
+                    example: 'Abschluss nach Governance-Review',
+                  },
+                  correlationId: { type: 'string', example: 'req-2026-001' },
+                  idempotencyKey: { type: 'string', example: 'idem-finding-20260611' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          200: { description: 'VDMI finding resolution intent created' },
+          404: { description: 'Finding not found' },
+        },
+      },
+      async handler(ctx) {
+        const callOpts = { meta: { ...ctx.meta, $gateway: false } };
+        const { findingId, resolutionReason, evidenceRef, reason } = ctx.params;
+        const audit = buildAudit(ctx, ctx.params.correlationId);
+
+        const { findings } = await ctx.call('vdmi.findings', { limit: 500 }, callOpts);
+        const finding = (findings || []).find((f) => f.id === findingId);
+        if (!finding) {
+          throw new MoleculerClientError(
+            `Finding not found: ${findingId}`,
+            404,
+            'FINDING_NOT_FOUND'
+          );
+        }
+
+        const inputSummary = `Resolve finding '${finding.code || findingId}': ${resolutionReason}`;
+        const intent = this.intentStore.create({
+          operationFamily: 'vdmiFindingResolution',
+          proposedAction: 'resolve_finding',
+          targetType: 'vdmiFinding',
+          targetId: findingId,
+          inputSummary,
+          payload: { findingId, reason: resolutionReason, evidenceRef: evidenceRef || null },
+          risk: 'medium',
+          createdBy: audit.requestedBy,
+          correlationId: audit.correlationId,
+          reason,
+          decisionFrameId: ctx.params.decisionFrameId || null,
+        });
+
+        return {
+          intentId: intent.intentId,
+          operationFamily: 'vdmiFindingResolution',
+          proposedAction: 'resolve_finding',
+          target: { findingId, code: finding.code },
+          inputSummary: intent.inputSummary,
+          status: intent.status,
+          expiresAt: intent.expiresAt,
+          risk: 'medium',
+          requiresHumanConfirmation: true,
+          decisionFrameId: intent.decisionFrameId,
+          summary: `Resolution-Intent erstellt für Finding '${finding.code || findingId}'. Menschliche Bestätigung erforderlich.`,
+          confirmationMessage: `Bitte bestätige die Auflösung von Finding '${finding.code || findingId}': ${resolutionReason}.`,
+          executeVia: {
+            operationId: 'executeProcessIntent',
+            note: 'Not available via Copilot. Use direct API: POST /api/copilot-process/intents/:intentId/execute',
+          },
+          auditTrail: { ...audit, idempotencyKey: ctx.params.idempotencyKey ?? null, reason },
+        };
+      },
+    },
+
+    /**
      * Prepare a ZNP planning assumption intent — no write.
      * operationId: prepareZnpAssumption
      */
@@ -1890,6 +2126,10 @@ NOT available via Copilot — not for autonomous agent use.`,
           return ctx.call('znp.addAssumption', payload, callOpts);
         case 'connectionRejectionEvidence':
           return ctx.call('connection-rejection-evidence.create', payload, callOpts);
+        case 'vdmiFindingMitigation':
+          return ctx.call('vdmi.mitigateFinding', payload, callOpts);
+        case 'vdmiFindingResolution':
+          return ctx.call('vdmi.resolveFinding', payload, callOpts);
         default:
           throw new MoleculerClientError(
             `Unknown operationFamily: ${operationFamily}`,

--- a/services/copilot-process.service.js
+++ b/services/copilot-process.service.js
@@ -1188,54 +1188,31 @@ Returns intentId, expiresAt, and confirmationMessage. Execute via executeProcess
         },
       },
       async handler(ctx) {
-        const callOpts = { meta: { ...ctx.meta, $gateway: false } };
-        const { findingId, owner, dueAt, plan, reason } = ctx.params;
-        const audit = buildAudit(ctx, ctx.params.correlationId);
-
-        const { findings } = await ctx.call('vdmi.findings', { limit: 500 }, callOpts);
-        const finding = (findings || []).find((f) => f.id === findingId);
-        if (!finding) {
-          throw new MoleculerClientError(
-            `Finding not found: ${findingId}`,
-            404,
-            'FINDING_NOT_FOUND'
-          );
-        }
-
-        const inputSummary = `Submit mitigation plan for finding '${finding.code || findingId}': owner ${owner}, due ${dueAt}`;
-        const intent = this.intentStore.create({
-          operationFamily: 'vdmiFindingMitigation',
-          proposedAction: 'mitigate_finding',
-          targetType: 'vdmiFinding',
-          targetId: findingId,
-          inputSummary,
-          payload: { findingId, owner, dueAt, plan },
-          risk: 'medium',
-          createdBy: audit.requestedBy,
-          correlationId: audit.correlationId,
+        const {
+          findingId,
+          owner,
+          dueAt,
+          plan,
           reason,
-          decisionFrameId: ctx.params.decisionFrameId || null,
-        });
-
-        return {
-          intentId: intent.intentId,
+          correlationId,
+          idempotencyKey,
+          decisionFrameId,
+        } = ctx.params;
+        return this._prepareVdmiFindingIntent(ctx, {
+          findingId,
           operationFamily: 'vdmiFindingMitigation',
           proposedAction: 'mitigate_finding',
-          target: { findingId, code: finding.code },
-          inputSummary: intent.inputSummary,
-          status: intent.status,
-          expiresAt: intent.expiresAt,
-          risk: 'medium',
-          requiresHumanConfirmation: true,
-          decisionFrameId: intent.decisionFrameId,
-          summary: `Mitigations-Intent erstellt für Finding '${finding.code || findingId}'. Menschliche Bestätigung erforderlich.`,
-          confirmationMessage: `Bitte bestätige den Mitigationsplan für Finding '${finding.code || findingId}' (Owner: ${owner}, Frist: ${dueAt}).`,
-          executeVia: {
-            operationId: 'executeProcessIntent',
-            note: 'Not available via Copilot. Use direct API: POST /api/copilot-process/intents/:intentId/execute',
-          },
-          auditTrail: { ...audit, idempotencyKey: ctx.params.idempotencyKey ?? null, reason },
-        };
+          reason,
+          correlationId,
+          idempotencyKey,
+          decisionFrameId,
+          describe: (finding) => ({
+            payload: { findingId, owner, dueAt, plan },
+            inputSummary: `Submit mitigation plan for finding '${finding.code || findingId}': owner ${owner}, due ${dueAt}`,
+            summary: `Mitigations-Intent erstellt für Finding '${finding.code || findingId}'. Menschliche Bestätigung erforderlich.`,
+            confirmationMessage: `Bitte bestätige den Mitigationsplan für Finding '${finding.code || findingId}' (Owner: ${owner}, Frist: ${dueAt}).`,
+          }),
+        });
       },
     },
 
@@ -1302,54 +1279,30 @@ Returns intentId, expiresAt, and confirmationMessage. Execute via executeProcess
         },
       },
       async handler(ctx) {
-        const callOpts = { meta: { ...ctx.meta, $gateway: false } };
-        const { findingId, resolutionReason, evidenceRef, reason } = ctx.params;
-        const audit = buildAudit(ctx, ctx.params.correlationId);
-
-        const { findings } = await ctx.call('vdmi.findings', { limit: 500 }, callOpts);
-        const finding = (findings || []).find((f) => f.id === findingId);
-        if (!finding) {
-          throw new MoleculerClientError(
-            `Finding not found: ${findingId}`,
-            404,
-            'FINDING_NOT_FOUND'
-          );
-        }
-
-        const inputSummary = `Resolve finding '${finding.code || findingId}': ${resolutionReason}`;
-        const intent = this.intentStore.create({
-          operationFamily: 'vdmiFindingResolution',
-          proposedAction: 'resolve_finding',
-          targetType: 'vdmiFinding',
-          targetId: findingId,
-          inputSummary,
-          payload: { findingId, reason: resolutionReason, evidenceRef: evidenceRef || null },
-          risk: 'medium',
-          createdBy: audit.requestedBy,
-          correlationId: audit.correlationId,
+        const {
+          findingId,
+          resolutionReason,
+          evidenceRef,
           reason,
-          decisionFrameId: ctx.params.decisionFrameId || null,
-        });
-
-        return {
-          intentId: intent.intentId,
+          correlationId,
+          idempotencyKey,
+          decisionFrameId,
+        } = ctx.params;
+        return this._prepareVdmiFindingIntent(ctx, {
+          findingId,
           operationFamily: 'vdmiFindingResolution',
           proposedAction: 'resolve_finding',
-          target: { findingId, code: finding.code },
-          inputSummary: intent.inputSummary,
-          status: intent.status,
-          expiresAt: intent.expiresAt,
-          risk: 'medium',
-          requiresHumanConfirmation: true,
-          decisionFrameId: intent.decisionFrameId,
-          summary: `Resolution-Intent erstellt für Finding '${finding.code || findingId}'. Menschliche Bestätigung erforderlich.`,
-          confirmationMessage: `Bitte bestätige die Auflösung von Finding '${finding.code || findingId}': ${resolutionReason}.`,
-          executeVia: {
-            operationId: 'executeProcessIntent',
-            note: 'Not available via Copilot. Use direct API: POST /api/copilot-process/intents/:intentId/execute',
-          },
-          auditTrail: { ...audit, idempotencyKey: ctx.params.idempotencyKey ?? null, reason },
-        };
+          reason,
+          correlationId,
+          idempotencyKey,
+          decisionFrameId,
+          describe: (finding) => ({
+            payload: { findingId, reason: resolutionReason, evidenceRef: evidenceRef || null },
+            inputSummary: `Resolve finding '${finding.code || findingId}': ${resolutionReason}`,
+            summary: `Resolution-Intent erstellt für Finding '${finding.code || findingId}'. Menschliche Bestätigung erforderlich.`,
+            confirmationMessage: `Bitte bestätige die Auflösung von Finding '${finding.code || findingId}': ${resolutionReason}.`,
+          }),
+        });
       },
     },
 
@@ -2113,6 +2066,68 @@ NOT available via Copilot — not for autonomous agent use.`,
   },
 
   methods: {
+    // Shared by prepareVdmiFindingMitigation and prepareVdmiFindingResolution
+    // (v0.99.7) — both look up the same finding, create an intent the same
+    // way, and return the same response shape; only the domain-specific
+    // payload/summary text differs, supplied via `describe(finding)`.
+    async _prepareVdmiFindingIntent(
+      ctx,
+      {
+        findingId,
+        operationFamily,
+        proposedAction,
+        reason,
+        correlationId,
+        idempotencyKey,
+        decisionFrameId,
+        describe,
+      }
+    ) {
+      const callOpts = { meta: { ...ctx.meta, $gateway: false } };
+      const audit = buildAudit(ctx, correlationId);
+
+      const { findings } = await ctx.call('vdmi.findings', { limit: 500 }, callOpts);
+      const finding = (findings || []).find((f) => f.id === findingId);
+      if (!finding) {
+        throw new MoleculerClientError(`Finding not found: ${findingId}`, 404, 'FINDING_NOT_FOUND');
+      }
+
+      const details = describe(finding);
+      const intent = this.intentStore.create({
+        operationFamily,
+        proposedAction,
+        targetType: 'vdmiFinding',
+        targetId: findingId,
+        inputSummary: details.inputSummary,
+        payload: details.payload,
+        risk: 'medium',
+        createdBy: audit.requestedBy,
+        correlationId: audit.correlationId,
+        reason,
+        decisionFrameId: decisionFrameId || null,
+      });
+
+      return {
+        intentId: intent.intentId,
+        operationFamily,
+        proposedAction,
+        target: { findingId, code: finding.code },
+        inputSummary: intent.inputSummary,
+        status: intent.status,
+        expiresAt: intent.expiresAt,
+        risk: 'medium',
+        requiresHumanConfirmation: true,
+        decisionFrameId: intent.decisionFrameId,
+        summary: details.summary,
+        confirmationMessage: details.confirmationMessage,
+        executeVia: {
+          operationId: 'executeProcessIntent',
+          note: 'Not available via Copilot. Use direct API: POST /api/copilot-process/intents/:intentId/execute',
+        },
+        auditTrail: { ...audit, idempotencyKey: idempotencyKey ?? null, reason },
+      };
+    },
+
     async _executeIntent(ctx, intent) {
       const callOpts = { meta: { ...ctx.meta, $gateway: false } };
       const { operationFamily, payload } = intent;

--- a/src/mcp-execute-read-policy.js
+++ b/src/mcp-execute-read-policy.js
@@ -39,6 +39,19 @@
  * more than the caller's own tenant) was never actually blocked. Caught by
  * cross-checking this file against the operation index while investigating
  * the CO₂ report, not by the report itself.
+ *
+ * v0.99.7: auditing every POST operation classified `data_read` via the
+ * classifier's `QUERY_VERB_PATTERN` (any summary starting with "resolve" is
+ * treated as a read, e.g. "Resolve a request to a route") found 3 real
+ * writes let through by that same heuristic — "resolve" also means "close
+ * out a stateful entity" (finding/gap/alarm), not just "look up": `POST
+ * /vdmi/findings/:findingId/resolve` (persists finding.status='resolved'),
+ * `POST /interface-placeholder/gaps/:placeholderId/resolve`, and `POST
+ * /jobs/alarms/:alarmId/resolve` (persists alarm status via jobStore). Not
+ * fixed in the classifier itself (`src/operation-capability-classifier.js`
+ * is relied on by other consumers beyond MCP; narrowing the "resolve" verb
+ * there needs its own dedicated audit) — overridden here the same way
+ * v0.99.5 handled `znp_deleteProject`'s misclassification.
  */
 
 const fs = require('fs');
@@ -63,6 +76,16 @@ const DENYLIST_PATH_PATTERNS = [
   /^\/tenant-quotas?(\/|$)/,
 ];
 
+// Confirmed real writes that operation-capability-index.json misclassifies
+// as data_read/direct (see the "v0.99.7" module comment above) — checked by
+// exact method + path, not folded into DENYLIST_PATH_PATTERNS above since
+// the reason is a classifier false positive, not an admin/secret surface.
+const KNOWN_MISCLASSIFIED_WRITE_PATTERNS = [
+  { method: 'POST', pattern: /^\/vdmi\/findings\/[^/]+\/resolve$/ },
+  { method: 'POST', pattern: /^\/interface-placeholder\/gaps\/[^/]+\/resolve$/ },
+  { method: 'POST', pattern: /^\/jobs\/alarms\/[^/]+\/resolve$/ },
+];
+
 // Fallback for operations not found in operation-capability-index.json —
 // POST endpoints that are read-only or dry-run in effect despite the verb.
 const POST_ALLOWLIST_PATH_PATTERNS = [
@@ -82,6 +105,12 @@ function stripApiPrefix(path_) {
 
 function isDenied(relativePath) {
   return DENYLIST_PATH_PATTERNS.some((pattern) => pattern.test(relativePath));
+}
+
+function isKnownMisclassifiedWrite(method, relativePath) {
+  return KNOWN_MISCLASSIFIED_WRITE_PATTERNS.some(
+    (entry) => entry.method === method && entry.pattern.test(relativePath)
+  );
 }
 
 let _operationLookup = null;
@@ -137,6 +166,13 @@ function checkExecuteReadPolicy(method, path_) {
   }
 
   const upperMethod = String(method || '').toUpperCase();
+  if (isKnownMisclassifiedWrite(upperMethod, relativePath)) {
+    return {
+      allowed: false,
+      reason: 'NOT_READ_ONLY: classifier false positive (resolve-verb heuristic)',
+    };
+  }
+
   const fullPath = String(path_ || '').startsWith('/api') ? path_ : `/api${relativePath}`;
   const entry = loadOperationLookup().get(`${upperMethod} ${fullPath}`);
   if (entry) {

--- a/src/mcp-reserved-families.js
+++ b/src/mcp-reserved-families.js
@@ -129,6 +129,38 @@ const RESERVED_FAMILIES = {
       };
     },
   },
+  // v0.99.7: the first 2 of ~19 previously-unwired VDMI write operations
+  // (see docs/mcp-server.md's "Full capability exposure" section for why
+  // the rest are deliberately deferred, and src/mcp-execute-read-policy.js
+  // for the misclassification that made vdmiFindingResolution's underlying
+  // action look like a safe read before this).
+  vdmiFindingMitigation: {
+    action: 'copilot-process.prepareVdmiFindingMitigation',
+    buildParams(payload, topLevel) {
+      return {
+        findingId: requireField(payload, 'findingId', 'vdmiFindingMitigation'),
+        owner: requireField(payload, 'owner', 'vdmiFindingMitigation'),
+        dueAt: requireField(payload, 'dueAt', 'vdmiFindingMitigation'),
+        plan: requireField(payload, 'plan', 'vdmiFindingMitigation'),
+        reason: topLevel.reason,
+        correlationId: topLevel.correlationId,
+        decisionFrameId: topLevel.decisionFrameId,
+      };
+    },
+  },
+  vdmiFindingResolution: {
+    action: 'copilot-process.prepareVdmiFindingResolution',
+    buildParams(payload, topLevel) {
+      return {
+        findingId: requireField(payload, 'findingId', 'vdmiFindingResolution'),
+        resolutionReason: requireField(payload, 'resolutionReason', 'vdmiFindingResolution'),
+        evidenceRef: payload.evidenceRef,
+        reason: topLevel.reason,
+        correlationId: topLevel.correlationId,
+        decisionFrameId: topLevel.decisionFrameId,
+      };
+    },
+  },
 };
 
 /**

--- a/src/mcp-transport.js
+++ b/src/mcp-transport.js
@@ -147,7 +147,7 @@ const TOOL_DEFS = [
       'Never writes by itself. Returns a cernion://intent/{id} ref for cernion_execute_process.\n\n' +
       'operationFamily is the routing key. Most values go through the generic intake path (real ' +
       'execution needs a developer to wire a dispatch case first — see cernion_execute_process). ' +
-      'Four operationFamily values are reserved and route to dedicated, fully-executable actions — for ' +
+      'Six operationFamily values are reserved and route to dedicated, fully-executable actions — for ' +
       'these, reason is required and payload must contain:\n' +
       '- "vdmi": payload.matrixId, payload.evidenceType, payload.reference (payload.content optional). ' +
       'Injects VDMI evidence.\n' +
@@ -159,7 +159,13 @@ const TOOL_DEFS = [
       'payload.loadAssumptionKw, payload.netzverknuepfungspunktId, payload.voltageLevel, ' +
       'payload.bottleneckDescription, payload.n1QualityStatus ' +
       '(COMPLIANT|NON_COMPLIANT|CONDITIONALLY_COMPLIANT|UNKNOWN), payload.decision ' +
-      '(GO|CONDITIONAL|NO_GO|PENDING). Creates a connection-rejection evidence package.',
+      '(GO|CONDITIONAL|NO_GO|PENDING). Creates a connection-rejection evidence package.\n' +
+      '- "vdmiFindingMitigation": payload.findingId, payload.owner, payload.dueAt, payload.plan. ' +
+      'Submits a mitigation plan for a VDMI finding.\n' +
+      '- "vdmiFindingResolution": payload.findingId, payload.resolutionReason (payload.evidenceRef ' +
+      'optional). Resolves/closes a VDMI finding. NOTE: the underlying REST operation looks read-only ' +
+      'by name (its summary starts with "Resolve...") but is a genuine write — do not attempt this via ' +
+      'cernion_execute_read (it is explicitly refused there); use this operationFamily instead.',
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     inputSchema: {
       operationFamily: z.string().min(1).max(64),
@@ -181,11 +187,11 @@ const TOOL_DEFS = [
     description:
       'Executes (action=execute, default) or rejects (action=reject) a pending_confirmation intent by ' +
       'id/ref. Deliberately a separate tool call from cernion_prepare_process so a client cannot ' +
-      'prepare-and-execute in one shot. Intents from the 4 reserved operationFamily values (vdmi, ' +
-      'gridConnection, znp, connectionRejectionEvidence — see cernion_prepare_process) execute for ' +
-      'real. NOTE: intents from any other (generic) operationFamily have no wired auto-execution (by ' +
-      'design — see docs/mcp-server.md) and will fail execute with a clear error; reject still works ' +
-      'for those.',
+      'prepare-and-execute in one shot. Intents from the 6 reserved operationFamily values (vdmi, ' +
+      'gridConnection, znp, connectionRejectionEvidence, vdmiFindingMitigation, vdmiFindingResolution ' +
+      '— see cernion_prepare_process) execute for real. NOTE: intents from any other (generic) ' +
+      'operationFamily have no wired auto-execution (by design — see docs/mcp-server.md) and will fail ' +
+      'execute with a clear error; reject still works for those.',
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
     inputSchema: {
       ref: z.string().optional(),

--- a/tests/agent-manifest.service.test.js
+++ b/tests/agent-manifest.service.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const { ServiceBroker } = require('moleculer');
+const AgentManifestService = require('../services/agent-manifest.service');
+
+// v0.99.7: cernion_describe(kind=operation) used to return only
+// {method,path,operationId,summary,tags} — no parameter or request-body
+// schema, so an MCP client had no way to discover what to filter/pass
+// before calling cernion_execute_read (found while scoping "full capability
+// exposure" — the schema was always present in openapi-export.json, just
+// never carried through agent-manifest.listOperations). These tests run
+// against the real generated openapi-export.json, not a stub, since the
+// point is verifying the real spec's schema survives the round trip.
+describe('agent-manifest service — operation parameter/requestBody exposure (v0.99.7)', () => {
+  let broker;
+
+  beforeAll(async () => {
+    broker = new ServiceBroker({ logger: false });
+    broker.createService(AgentManifestService);
+    await broker.start();
+  });
+
+  afterAll(() => broker.stop());
+
+  test('includes requestBody schema for a body-based operation (gas-storage.countryStorage)', async () => {
+    const res = await broker.call('agent-manifest.listOperations', {});
+    const op = res.data.find((o) => o.operationId === 'gas-storage_countryStorage');
+    expect(op).toBeDefined();
+    expect(op.requestBody).toBeTruthy();
+    const schema = op.requestBody.content['application/json'].schema;
+    expect(schema.required).toContain('country');
+    expect(schema.properties).toHaveProperty('country');
+  });
+
+  test('includes query parameters for a GET operation', async () => {
+    const res = await broker.call('agent-manifest.listOperations', {});
+    const op = res.data.find(
+      (o) => o.method === 'GET' && Array.isArray(o.parameters) && o.parameters.length > 0
+    );
+    expect(op).toBeDefined();
+    expect(op.parameters[0]).toHaveProperty('name');
+    expect(op.parameters[0]).toHaveProperty('in');
+  });
+
+  test('includes the full description text, not just summary', async () => {
+    const res = await broker.call('agent-manifest.listOperations', {});
+    const op = res.data.find((o) => o.operationId === 'gas-storage_countryStorage');
+    expect(op.description).toEqual(expect.stringContaining('AGSI+'));
+    expect(op.description.length).toBeGreaterThan(op.summary.length);
+  });
+
+  test('operations without a requestBody expose null, not undefined', async () => {
+    const res = await broker.call('agent-manifest.listOperations', {});
+    const op = res.data.find((o) => o.method === 'GET');
+    expect(op).toBeDefined();
+    expect(op.requestBody).toBeNull();
+  });
+});

--- a/tests/copilot-process-phase3.service.test.js
+++ b/tests/copilot-process-phase3.service.test.js
@@ -37,6 +37,13 @@ const MOCK_ZNP_PROJECT = {
   createdAt: '2026-05-01T08:00:00Z',
 };
 
+const MOCK_FINDING = {
+  id: 'finding-p3-1',
+  code: 'VD_GOV_RECURRENCE_K',
+  severity: 'H',
+  status: 'open',
+};
+
 // ── Helper: build isolated broker with mocked dependencies ────────────────────
 
 async function buildBroker({ vdmiMatrixNotFound, znpProjectNotFound } = {}) {
@@ -44,7 +51,14 @@ async function buildBroker({ vdmiMatrixNotFound, znpProjectNotFound } = {}) {
   broker.createService(CopilotProcessService);
 
   // Track calls to write actions so we can assert they were NOT called during prepare
-  const writeCalls = { vdmiEvidence: 0, znpAddAssumption: 0, gcValidate: 0, creCreate: 0 };
+  const writeCalls = {
+    vdmiEvidence: 0,
+    znpAddAssumption: 0,
+    gcValidate: 0,
+    creCreate: 0,
+    vdmiMitigateFinding: 0,
+    vdmiResolveFinding: 0,
+  };
 
   broker.createService({
     name: 'vdmi',
@@ -61,6 +75,23 @@ async function buildBroker({ vdmiMatrixNotFound, znpProjectNotFound } = {}) {
         handler() {
           writeCalls.vdmiEvidence++;
           return { success: true, evidenceId: 'ev-001' };
+        },
+      },
+      findings: {
+        handler() {
+          return { success: true, count: 1, findings: [MOCK_FINDING] };
+        },
+      },
+      mitigateFinding: {
+        handler() {
+          writeCalls.vdmiMitigateFinding++;
+          return { success: true, finding: { ...MOCK_FINDING, status: 'mitigated' } };
+        },
+      },
+      resolveFinding: {
+        handler() {
+          writeCalls.vdmiResolveFinding++;
+          return { success: true, finding: { ...MOCK_FINDING, status: 'resolved' } };
         },
       },
     },
@@ -267,6 +298,123 @@ describe('copilot-process service — Phase 3', () => {
     });
   });
 
+  // ── prepareVdmiFindingMitigation ────────────────────────────────────────────
+  describe('prepareVdmiFindingMitigation', () => {
+    let broker;
+    beforeAll(async () => {
+      ({ broker } = await buildBroker());
+    });
+    afterAll(() => broker.stop());
+
+    const VALID_PARAMS = {
+      findingId: 'finding-p3-1',
+      owner: 'grid-lead',
+      dueAt: '2026-12-31T00:00:00.000Z',
+      plan: 'Ablösung des Schattenpfads durch API-Integration',
+      reason: 'Mitigation nach Governance-Review',
+    };
+
+    it('returns intentId and status pending_confirmation', async () => {
+      const result = await broker.call(
+        'copilot-process.prepareVdmiFindingMitigation',
+        VALID_PARAMS
+      );
+      expect(result).toHaveProperty('intentId');
+      expect(result).toHaveProperty('status', 'pending_confirmation');
+    });
+
+    it('operationFamily is vdmiFindingMitigation', async () => {
+      const result = await broker.call(
+        'copilot-process.prepareVdmiFindingMitigation',
+        VALID_PARAMS
+      );
+      expect(result.operationFamily).toBe('vdmiFindingMitigation');
+    });
+
+    it('proposedAction is mitigate_finding', async () => {
+      const result = await broker.call(
+        'copilot-process.prepareVdmiFindingMitigation',
+        VALID_PARAMS
+      );
+      expect(result.proposedAction).toBe('mitigate_finding');
+    });
+
+    it('throws 404 if finding not found', async () => {
+      await expect(
+        broker.call('copilot-process.prepareVdmiFindingMitigation', {
+          ...VALID_PARAMS,
+          findingId: 'notfound',
+        })
+      ).rejects.toMatchObject({ code: 404 });
+    });
+
+    it('requires owner, dueAt, plan, and reason', async () => {
+      await expect(
+        broker.call('copilot-process.prepareVdmiFindingMitigation', {
+          findingId: 'finding-p3-1',
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  // ── prepareVdmiFindingResolution ────────────────────────────────────────────
+  describe('prepareVdmiFindingResolution', () => {
+    let broker;
+    beforeAll(async () => {
+      ({ broker } = await buildBroker());
+    });
+    afterAll(() => broker.stop());
+
+    const VALID_PARAMS = {
+      findingId: 'finding-p3-1',
+      resolutionReason: 'Integration abgeschlossen',
+      evidenceRef: 'ticket-123',
+      reason: 'Abschluss nach Governance-Review',
+    };
+
+    it('returns intentId and status pending_confirmation', async () => {
+      const result = await broker.call(
+        'copilot-process.prepareVdmiFindingResolution',
+        VALID_PARAMS
+      );
+      expect(result).toHaveProperty('intentId');
+      expect(result).toHaveProperty('status', 'pending_confirmation');
+    });
+
+    it('operationFamily is vdmiFindingResolution', async () => {
+      const result = await broker.call(
+        'copilot-process.prepareVdmiFindingResolution',
+        VALID_PARAMS
+      );
+      expect(result.operationFamily).toBe('vdmiFindingResolution');
+    });
+
+    it('proposedAction is resolve_finding', async () => {
+      const result = await broker.call(
+        'copilot-process.prepareVdmiFindingResolution',
+        VALID_PARAMS
+      );
+      expect(result.proposedAction).toBe('resolve_finding');
+    });
+
+    it('throws 404 if finding not found', async () => {
+      await expect(
+        broker.call('copilot-process.prepareVdmiFindingResolution', {
+          ...VALID_PARAMS,
+          findingId: 'notfound',
+        })
+      ).rejects.toMatchObject({ code: 404 });
+    });
+
+    it('requires resolutionReason and reason', async () => {
+      await expect(
+        broker.call('copilot-process.prepareVdmiFindingResolution', {
+          findingId: 'finding-p3-1',
+        })
+      ).rejects.toThrow();
+    });
+  });
+
   // ── prepareConnectionRejectionEvidence ──────────────────────────────────────
   describe('prepareConnectionRejectionEvidence', () => {
     let broker;
@@ -401,6 +549,26 @@ describe('copilot-process service — Phase 3', () => {
       return result.intentId;
     }
 
+    async function prepareVdmiFindingMitigationIntent() {
+      const result = await broker.call('copilot-process.prepareVdmiFindingMitigation', {
+        findingId: 'finding-p3-1',
+        owner: 'grid-lead',
+        dueAt: '2026-12-31T00:00:00.000Z',
+        plan: 'Ablösung des Schattenpfads durch API-Integration',
+        reason: 'Test',
+      });
+      return result.intentId;
+    }
+
+    async function prepareVdmiFindingResolutionIntent() {
+      const result = await broker.call('copilot-process.prepareVdmiFindingResolution', {
+        findingId: 'finding-p3-1',
+        resolutionReason: 'Integration abgeschlossen',
+        reason: 'Test',
+      });
+      return result.intentId;
+    }
+
     it('executes a pending_confirmation vdmi intent successfully', async () => {
       const intentId = await prepareVdmiIntent();
       const result = await broker.call('copilot-process.executeProcessIntent', { intentId });
@@ -483,6 +651,22 @@ describe('copilot-process service — Phase 3', () => {
       const callsBefore = writeCalls.creCreate;
       await broker.call('copilot-process.executeProcessIntent', { intentId });
       expect(writeCalls.creCreate).toBe(callsBefore + 1);
+    });
+
+    it('dispatches vdmi.mitigateFinding for vdmiFindingMitigation operationFamily', async () => {
+      const intentId = await prepareVdmiFindingMitigationIntent();
+      const callsBefore = writeCalls.vdmiMitigateFinding;
+      const result = await broker.call('copilot-process.executeProcessIntent', { intentId });
+      expect(writeCalls.vdmiMitigateFinding).toBe(callsBefore + 1);
+      expect(result.status).toBe('executed');
+    });
+
+    it('dispatches vdmi.resolveFinding for vdmiFindingResolution operationFamily', async () => {
+      const intentId = await prepareVdmiFindingResolutionIntent();
+      const callsBefore = writeCalls.vdmiResolveFinding;
+      const result = await broker.call('copilot-process.executeProcessIntent', { intentId });
+      expect(writeCalls.vdmiResolveFinding).toBe(callsBefore + 1);
+      expect(result.status).toBe('executed');
     });
   });
 
@@ -660,6 +844,16 @@ describe('copilot-process service — Phase 3', () => {
 
     it('prepareConnectionRejectionEvidence action has x-openai-isConsequential: false', () => {
       const action = CopilotProcessService.actions.prepareConnectionRejectionEvidence;
+      expect(action.openapi['x-openai-isConsequential']).toBe(false);
+    });
+
+    it('prepareVdmiFindingMitigation action has x-openai-isConsequential: false', () => {
+      const action = CopilotProcessService.actions.prepareVdmiFindingMitigation;
+      expect(action.openapi['x-openai-isConsequential']).toBe(false);
+    });
+
+    it('prepareVdmiFindingResolution action has x-openai-isConsequential: false', () => {
+      const action = CopilotProcessService.actions.prepareVdmiFindingResolution;
       expect(action.openapi['x-openai-isConsequential']).toBe(false);
     });
 

--- a/tests/mcp-execute-read-policy.test.js
+++ b/tests/mcp-execute-read-policy.test.js
@@ -43,6 +43,32 @@ describe('mcp-execute-read-policy (operation-capability-index-backed, v0.99.5)',
     });
   });
 
+  // Regression tests for v0.99.7: operation-capability-index.json's
+  // QUERY_VERB_PATTERN heuristic treats any POST summary starting with
+  // "resolve" as a read (matching genuine cases like chatgpt-sidecar.plan's
+  // "Resolve a request to a route"), but these 3 real operations use
+  // "resolve" to mean "close out a stateful entity" and persist a write —
+  // found agentable/data_read/direct in the index despite that.
+  test.each([
+    ['/api/vdmi/findings/f1/resolve', 'POST'],
+    ['/api/interface-placeholder/gaps/ph1/resolve', 'POST'],
+    ['/api/jobs/alarms/a1/resolve', 'POST'],
+  ])(
+    'denies %s %s despite being classified data_read/direct (resolve-verb false positive)',
+    (p, m) => {
+      expect(checkExecuteReadPolicy(m, p)).toEqual({
+        allowed: false,
+        reason: 'NOT_READ_ONLY: classifier false positive (resolve-verb heuristic)',
+      });
+    }
+  );
+
+  test('does not deny an unrelated GET on a path that merely ends in /resolve-like segments', () => {
+    // Sanity check: the override is scoped to the exact 3 known paths, not
+    // a bare "/resolve" suffix match that could catch unrelated services.
+    expect(checkExecuteReadPolicy('GET', '/api/vdmi/findings')).toEqual({ allowed: true });
+  });
+
   test('denies a genuine write operation found in the index (object_store_write)', () => {
     const result = checkExecuteReadPolicy('POST', '/api/copilot-process/intents');
     expect(result.allowed).toBe(false);

--- a/tests/mcp-server.service.test.js
+++ b/tests/mcp-server.service.test.js
@@ -48,7 +48,10 @@ describe('MCP Server meta-tools', () => {
                   path: '/api/energy-market/prices',
                   operationId: 'getPrices',
                   summary: 'Prices',
+                  description: 'Full description of the prices endpoint.',
                   tags: [],
+                  parameters: [{ name: 'date', in: 'query', schema: { type: 'string' } }],
+                  requestBody: null,
                 },
                 {
                   method: 'POST',
@@ -297,6 +300,37 @@ describe('MCP Server meta-tools', () => {
             };
           },
         },
+        prepareVdmiFindingMitigation: {
+          params: {
+            findingId: { type: 'string' },
+            owner: { type: 'string' },
+            dueAt: { type: 'string' },
+            plan: { type: 'string' },
+            reason: { type: 'string' },
+          },
+          handler(ctx) {
+            return {
+              intentId: 'vdmi-finding-mitigation-intent-1',
+              operationFamily: 'vdmiFindingMitigation',
+              ...ctx.params,
+            };
+          },
+        },
+        prepareVdmiFindingResolution: {
+          params: {
+            findingId: { type: 'string' },
+            resolutionReason: { type: 'string' },
+            evidenceRef: { type: 'string', optional: true },
+            reason: { type: 'string' },
+          },
+          handler(ctx) {
+            return {
+              intentId: 'vdmi-finding-resolution-intent-1',
+              operationFamily: 'vdmiFindingResolution',
+              ...ctx.params,
+            };
+          },
+        },
       },
     });
 
@@ -432,6 +466,21 @@ describe('MCP Server meta-tools', () => {
     expect(res.data.executeReadPolicy.allowed).toBe(true);
   });
 
+  // v0.99.7: describe(kind=operation) previously returned only
+  // {method,path,operationId,summary,tags} — no parameter/body schema, so a
+  // caller had no way to discover what to filter by before calling
+  // execute_read. Now surfaces the full OpenAPI parameters/requestBody
+  // (and description, not just summary) agent-manifest.listOperations
+  // already carries.
+  test('describe an operation includes full description and parameter/requestBody schema', async () => {
+    const res = await broker.call('mcp-server.describe', { kind: 'operation', id: 'getPrices' });
+    expect(res.data.description).toBe('Full description of the prices endpoint.');
+    expect(res.data.parameters).toEqual([
+      { name: 'date', in: 'query', schema: { type: 'string' } },
+    ]);
+    expect(res.data).toHaveProperty('requestBody', null);
+  });
+
   // Real-world regression test: an MCP client asked a CO2-intensity
   // question, cernion_ask's response mentioned this blueprint by name (its
   // own L3 broker routing already knew about it), but cernion_describe
@@ -545,6 +594,61 @@ describe('MCP Server meta-tools', () => {
           proposedAction: 'inject_evidence',
           reason: 'test reason',
           payload: { matrixId: 'm-1' },
+        },
+        { meta: FULL_ACCESS_META }
+      )
+    ).rejects.toMatchObject({ type: 'MCP_MISSING_RESERVED_FAMILY_FIELD' });
+  });
+
+  // v0.99.7: the 2 newest reserved families. vdmiFindingResolution is
+  // notable because its underlying REST operation (vdmi.resolveFinding) was
+  // found misclassified as a safe read in operation-capability-index.json
+  // (see src/mcp-execute-read-policy.js) — this is now the correct/only
+  // write path for it.
+  test('prepareProcess routes operationFamily=vdmiFindingMitigation to the dedicated action', async () => {
+    const res = await broker.call(
+      'mcp-server.prepareProcess',
+      {
+        operationFamily: 'vdmiFindingMitigation',
+        proposedAction: 'mitigate_finding',
+        reason: 'test reason',
+        payload: {
+          findingId: 'finding-1',
+          owner: 'grid-lead',
+          dueAt: '2026-12-31T00:00:00.000Z',
+          plan: 'Fix it',
+        },
+      },
+      { meta: FULL_ACCESS_META }
+    );
+    expect(res.ref).toBe('cernion://intent/vdmi-finding-mitigation-intent-1');
+    expect(res.findingId).toBe('finding-1');
+  });
+
+  test('prepareProcess routes operationFamily=vdmiFindingResolution to the dedicated action', async () => {
+    const res = await broker.call(
+      'mcp-server.prepareProcess',
+      {
+        operationFamily: 'vdmiFindingResolution',
+        proposedAction: 'resolve_finding',
+        reason: 'test reason',
+        payload: { findingId: 'finding-1', resolutionReason: 'Done' },
+      },
+      { meta: FULL_ACCESS_META }
+    );
+    expect(res.ref).toBe('cernion://intent/vdmi-finding-resolution-intent-1');
+    expect(res.findingId).toBe('finding-1');
+  });
+
+  test('prepareProcess rejects operationFamily=vdmiFindingMitigation with a missing payload field', async () => {
+    await expect(
+      broker.call(
+        'mcp-server.prepareProcess',
+        {
+          operationFamily: 'vdmiFindingMitigation',
+          proposedAction: 'mitigate_finding',
+          reason: 'test reason',
+          payload: { findingId: 'finding-1' },
         },
         { meta: FULL_ACCESS_META }
       )


### PR DESCRIPTION
## Summary

Scoped from the platform owner's question: "are we still meaningfully behind what the REST API can do, especially VDMI (processes) and structured retrieval/filtering?" Answer: yes, two real gaps — plus a security finding made while confirming the VDMI target list.

### Security
- `cernion_execute_read` could silently execute 3 real writes misclassified `data_read`/`direct` in `operation-capability-index.json` by the classifier's "resolve"-verb heuristic (correct for genuine reads like `chatgpt-sidecar.plan`, wrong for state-closing writes): `vdmi.resolveFinding`, `interface-placeholder.resolveGap`, `job-status.resolveAlarm`. Not fixed in the shared classifier (other consumers rely on it) — explicitly denied in `src/mcp-execute-read-policy.js`, same pattern as v0.99.5's `znp_deleteProject` fix.

### Added
- `cernion_describe(kind=operation)` now returns full `parameters`/`requestBody`/`description` (was `{method,path,operationId,summary,tags}` only) — an MCP client previously had no way to discover what to filter/pass before calling `execute_read`, even though the schema always existed in `openapi-export.json`. `search` results are untouched (still lean).
- 2 new reserved `operationFamily` values: `vdmiFindingMitigation`, `vdmiFindingResolution` — give VDMI findings a real prepare→confirm→execute write path. `vdmiFindingResolution` is also the correct write path for the operation flagged in the Security section. The other ~17 unwired VDMI write operations (and VDMI nomination, whose Phase 3 execute path isn't implemented server-side at all yet) are deliberately deferred to a future release with per-action review, not wired in bulk — see `docs/mcp-server.md`'s "Full capability exposure" section for the reasoning.

## Test plan
- [x] `tests/mcp-execute-read-policy.test.js` — regression tests for all 3 misclassified-write denials + a sanity check against over-matching
- [x] `tests/agent-manifest.service.test.js` (new) — schema exposure, run against the real generated `openapi-export.json`
- [x] `tests/mcp-server.service.test.js`, `tests/copilot-process-phase3.service.test.js` — describe pass-through + full prepare→execute coverage for both new families
- [x] `eslint` clean on all changed files
- [x] `npm run audit:openapi` — 0 issues
- [x] `npm run check:quality-gate` — success
- [x] `npm run audit:security` — no critical findings (pre-existing, unrelated dependency advisories only)
- [x] `operation-capability-index.json` `sourceOpenApiHash` verified against fresh sha256 of `openapi-export.json`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>