### PR TITLE
fix: send User-Agent header on Overpass requests to avoid 406

### DIFF
--- a/src/znp-osm-buildings.js
+++ b/src/znp-osm-buildings.js
@@ -64,7 +64,12 @@ async function fetchBuildingTile(tile) {
 
   const response = await axios.post(OVERPASS_ENDPOINT, `data=${encodeURIComponent(query)}`, {
     timeout: 35000,
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      // overpass-api.de's Apache front-end returns 406 for requests with no
+      // User-Agent header at all (axios sends none by default in Node).
+      'User-Agent': 'cernion-energy-tools/znp-layer1 (+https://cernion.energy)',
+    },
   });
 
   return (response.data.elements || []).map(parseOverpassWay).filter(Boolean);


### PR DESCRIPTION
## Summary
- `fetchBuildingTile()` in `src/znp-osm-buildings.js` called `overpass-api.de` without a `User-Agent` header. Axios sends none by default in Node, and Overpass's Apache front-end rejects User-Agent-less requests with `406 Not Acceptable`.
- This broke every `znp.addLayer1` job at the first OSM tile fetch (job status stuck at `error`, phase `osm_fetch`, ~18%, `Request failed with status code 406`).
- Reproduced directly against the live endpoint: request without `User-Agent` → 406; same request with `User-Agent: curl/8.5.0` → 200 with building data. Fix adds an explicit `User-Agent` header.

## Test plan
- [x] Reproduced the 406 against the real `overpass-api.de` endpoint and confirmed the header fixes it
- [x] `npx jest tests/znp-osm-buildings.test.js tests/znp.service.test.js` — 22 suites / 1380 tests pass
- [x] GitNexus impact analysis: LOW risk, single caller (`fetchBuildingsForBbox` → `znp.addLayer1` handler)
- [x] GitNexus `detect_changes`: only `fetchBuildingTile` touched, no other affected symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)