### PR TITLE
feat: add OEP society schema population table for AGS-based demand estimation

### DIFF
--- a/src/oep-tables.js
+++ b/src/oep-tables.js
@@ -123,6 +123,16 @@ const CERNION_RELEVANT_OEP_TABLES = Object.freeze([
     cernionUseCase: 'Topologie-Validierung und Netzplanung',
     oeoClass: 'oeo:ElectricitySubstation',
   },
+  {
+    schema: 'society',
+    table: 'destatis_zensus_population_per_bkg_vg250_6_gem',
+    description:
+      'Zensus 2011 Bevölkerungsdaten je Gemeinde (census_sum, census_count, census_density), ' +
+      'aggregiert über BKG-VG250-Verwaltungsgrenzen und referenziert per Amtlichem ' +
+      'Gemeindeschlüssel (Feld ags_0).',
+    cernionUseCase: 'OSM-unabhängige Verbrauchsprognose über Gemeindeschlüssel (AGS) statt OSM-Gebäude-Clustering',
+    oeoClass: 'oeo:PopulationStatistic',
+  },
 ]);
 
 function getOepTableConfig(schema, table) {


### PR DESCRIPTION
## Summary
- Adds `destatis_zensus_population_per_bkg_vg250_6_gem` (OEP schema `society`) to `CERNION_RELEVANT_OEP_TABLES` in `src/oep-tables.js`.
- Provides Zensus 2011 population per municipality (`ags_0` = Amtlicher Gemeindeschlüssel, `census_sum`/`census_count`/`census_density`), verified live against the real OEP `society` schema.
- Enables an OSM-independent consumption estimation path (via `oep.query`/`oep.getTableMeta`/`oep.energyTables`) as an alternative to Layer 1 OSM building clustering — the real table names aren't discoverable through `oep.search`/`oep.listTables` (those depend on OEP discovery endpoints that no longer exist upstream), so this curated entry makes the table directly usable without needing to fix that separately.

## Test plan
- [x] Verified live against the real OEP: `meta` and `rows` both 200 for all 4 `society` schema tables via the existing `schema+table` REST path
- [x] End-to-end through the actual Moleculer service (not just curl): `oep.getTableMeta`, `oep.query`, `oep.energyTables` all return correct data for the new entry
- [x] `npx jest tests/oep.service.test.js` — 11 suites / 374 tests pass
- [x] GitNexus `detect_changes`: LOW risk, no affected processes (purely additive data entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)