### PR TITLE
fix: oep.search over curated catalog instead of dead OEP discovery API

### DIFF
--- a/services/oep.service.js
+++ b/services/oep.service.js
@@ -266,7 +266,20 @@ module.exports = {
         const cached = this._cacheGet(cacheKey);
         if (cached) return { schemas: cached, cached: true };
 
-        const data = await this._oepGet('/schema/');
+        let data;
+        try {
+          data = await this._oepGet('/schema/');
+        } catch (err) {
+          if (err.response?.status === 404) {
+            throw new MoleculerClientError(
+              'OEP schema listing is not available',
+              404,
+              'NOT_FOUND'
+            );
+          }
+          throw err;
+        }
+
         const schemas = Array.isArray(data) ? data : [];
         this._cacheSet(cacheKey, schemas);
         return { schemas, cached: false };
@@ -718,10 +731,12 @@ module.exports = {
         summary: 'Search OEP tables by name or description',
         tags: ['OEP (Open Energy Platform)'],
         description:
-          'Case-insensitive substring search across all OEP table names and descriptions. ' +
-          'Optionally scoped to a specific schema. Uses the cached table list (24 h TTL) \u2014 ' +
-          'no per-search API call is made to OEP. ' +
-          'Useful for discovering scenario datasets, e.g. "NEP", "Kohleausstieg", "photovoltaik".',
+          'Case-insensitive substring search over the curated, Cernion-relevant OEP table ' +
+          'catalog (src/oep-tables.js) \u2014 not a live full-catalog search against OEP. ' +
+          "OEP's own schema/table discovery REST endpoints were removed upstream and no " +
+          'longer respond with JSON, so free-text discovery across the entire platform is ' +
+          'not available; use oep.query directly if you already know an exact schema/table ' +
+          'pair that is not in the curated list. Optionally scoped to a specific schema.',
         parameters: [
           {
             name: 'q',
@@ -749,43 +764,25 @@ module.exports = {
         const { q, schema: schemaFilter, limit } = ctx.params;
         const term = q.toLowerCase();
 
-        // Determine which schemas to search
-        let schemasToSearch;
-        if (schemaFilter) {
-          schemasToSearch = [schemaFilter];
-        } else {
-          // Fetch schema list (cached)
-          const schemaResult = await ctx.call('oep.listSchemas');
-          schemasToSearch = schemaResult.schemas;
-        }
+        const candidates = schemaFilter
+          ? CERNION_RELEVANT_OEP_TABLES.filter((entry) => entry.schema === schemaFilter)
+          : CERNION_RELEVANT_OEP_TABLES;
 
         const matches = [];
-
-        for (const schema of schemasToSearch) {
+        for (const entry of candidates) {
           if (matches.length >= limit) break;
 
-          const tableResult = await ctx.call('oep.listTables', { schema });
-          const tables = tableResult.tables || [];
+          const nameMatch = entry.table.toLowerCase().includes(term);
+          const descMatch = (entry.description || '').toLowerCase().includes(term);
 
-          for (const entry of tables) {
-            if (matches.length >= limit) break;
-
-            // OEP returns either a string name or an object with name/description
-            const name = typeof entry === 'string' ? entry : entry.name || '';
-            const description = typeof entry === 'object' ? entry.description || '' : '';
-
-            const nameMatch = name.toLowerCase().includes(term);
-            const descMatch = description.toLowerCase().includes(term);
-
-            if (nameMatch || descMatch) {
-              matches.push({
-                schema,
-                table: name,
-                description: description || null,
-                matchedOn:
-                  nameMatch && descMatch ? 'name+description' : nameMatch ? 'name' : 'description',
-              });
-            }
+          if (nameMatch || descMatch) {
+            matches.push({
+              schema: entry.schema,
+              table: entry.table,
+              description: entry.description || null,
+              matchedOn:
+                nameMatch && descMatch ? 'name+description' : nameMatch ? 'name' : 'description',
+            });
           }
         }
 

--- a/tests/oep.service.test.js
+++ b/tests/oep.service.test.js
@@ -188,6 +188,13 @@ describe('OEP Service — action handlers', () => {
       const result = await broker.call('oep.listSchemas');
       expect(result.schemas).toEqual([]);
     });
+
+    it('throws a clean 404 instead of a raw AxiosError when OEP schema listing is unavailable', async () => {
+      const err = new Error('Not found');
+      err.response = { status: 404 };
+      axios.get.mockRejectedValueOnce(err);
+      await expect(broker.call('oep.listSchemas')).rejects.toMatchObject({ code: 404 });
+    });
   });
 
   // ------------------------------------------------------------------
@@ -331,6 +338,36 @@ describe('OEP Service — action handlers', () => {
     it('count matches tables array length', async () => {
       const result = await broker.call('oep.energyTables');
       expect(result.count).toBe(result.tables.length);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // search — searches the curated table catalog, no OEP call
+  // ------------------------------------------------------------------
+  describe('search', () => {
+    it('finds a curated table by name substring without calling OEP', async () => {
+      const result = await broker.call('oep.search', { q: 'zensus_population_per_bkg' });
+      expect(axios.get).not.toHaveBeenCalled();
+      expect(result.total).toBeGreaterThanOrEqual(1);
+      expect(result.results.some((r) => r.schema === 'society')).toBe(true);
+    });
+
+    it('finds a curated table by description substring', async () => {
+      const result = await broker.call('oep.search', { q: 'Gemeindeschlüssel' });
+      expect(result.results.some((r) => r.table.includes('zensus_population'))).toBe(true);
+    });
+
+    it('respects the schema filter', async () => {
+      const result = await broker.call('oep.search', { q: 'de', schema: 'society' });
+      for (const r of result.results) {
+        expect(r.schema).toBe('society');
+      }
+    });
+
+    it('returns an empty result set for a non-matching term', async () => {
+      const result = await broker.call('oep.search', { q: 'xyznonexistentterm' });
+      expect(result.total).toBe(0);
+      expect(result.results).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Root cause of the production error (`AxiosError: Request failed with status code 404` at `services/oep.service.js:269`, from `oep.search`): `oep.search` calls `oep.listSchemas` whenever no `schema` filter is given, and `listSchemas` hits OEP's `/schema/` endpoint with no error handling. That endpoint (and `/schema/:schema/tables/`) no longer exist on the live OEP platform — confirmed by direct testing, both consistently return OEP's themed HTML 404 page across many schema names, not JSON.
- `oep.search` now searches the curated `CERNION_RELEVANT_OEP_TABLES` list (`src/oep-tables.js`) directly instead of the dead discovery chain — same response shape (`query`, `schemaFilter`, `total`, `results[]`), no external OEP call at all.
- `oep.listSchemas` now catches 404 the same way `listTables`/`getTableMeta`/`query` already do, so a direct call fails with a clean `MoleculerClientError` instead of leaking a raw axios stack trace.
- OpenAPI description for `oep.search` updated to be honest about scope: curated catalog, not live full-platform discovery (which is not possible upstream anymore).

## Test plan
- [x] New tests: `oep.search` (name match, description match, schema filter, no-match case — asserts `axios.get` is never called) and `oep.listSchemas` 404 handling
- [x] `npx jest tests/oep.service.test.js` — 11 suites / 379 tests pass
- [x] Full regression: `npx jest tests/oep.service.test.js tests/agent.service.test.js tests/api.service.test.js` — 33 suites / 2002 tests pass
- [x] GitNexus `detect_changes`: LOW risk, no affected processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)