### PR TITLE
feat: municipality AGS lookup service, v0.99.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.8] — 2026-08-09
+
+### Added
+- **`municipality` service — dedicated Amtlicher Gemeindeschlüssel (AGS) lookup**, requested after a user asked whether the platform could resolve the AGS by name, PLZ, or geo-coordinates. `resolveMunicipalityProfile()` (`src/municipality-resolver.js`, offline against Destatis Gemeindegrenzen 2022/GV100) already covered name/PLZ/AGS, but was only reachable indirectly through `dashboard-api.municipalEnergyValueAnalysisStatus` — a much heavier economic Lagebild endpoint with mandatory year/scenario params. `GET /api/municipality/lookup` (`services/municipality.service.js`) exposes it directly with no extra computation.
+- **`GET /api/municipality/reverse-geocode` — coordinates to AGS**, closing a gap that didn't exist in any form before: no reverse-geocoding or point-in-polygon capability against municipality boundaries existed anywhere in the codebase (`src/data/gemeinden-2022.json` has no polygon geometry, only attributes). `src/municipality-geocoder.js` reverse-geocodes via OpenStreetMap Nominatim (`extratags['de:amtlicher_gemeindeschluessel']`, verified live against both a Kreisfreie Stadt and a regular Gemeinde before implementing), then joins the resolved AGS back through the same `resolveMunicipalityProfile()` used by `lookup` for a full profile. Sends an explicit `User-Agent` header from the start — Nominatim's usage policy requires one, and axios sends none by default in Node (the same class of bug fixed for Overpass below). `NOMINATIM_ENDPOINT` env var for a private mirror under sustained load, mirroring the existing `OVERPASS_ENDPOINT`/`OEP_API_BASE_URL` pattern.
+
+### Fixed
+- **`znp.addLayer1` (OSM building-clustering job) failed at the first tile fetch with a 406 from Overpass** — `src/znp-osm-buildings.js`'s `fetchBuildingTile()` sent no `User-Agent` header; overpass-api.de's Apache front-end rejects User-Agent-less requests with 406 rather than a more obvious 403. Reproduced live against the real endpoint before and after the fix.
+- **`oep.search` threw an unhandled `AxiosError` (404) in production** whenever called without a `schema` filter. Root cause: it built its candidate set via `oep.listSchemas` → `oep.listTables`, both of which call OEP REST routes (`/schema/`, `/schema/:schema/tables/`) that no longer exist on the live Open Energy Platform (confirmed live: both consistently return OEP's themed HTML 404 page, not JSON, across many schema names — a permanent upstream removal, not an outage). `oep.search` now searches the curated `CERNION_RELEVANT_OEP_TABLES` catalog directly instead, with the same response shape and no external call. `oep.listSchemas` also gets the same 404 → clean `MoleculerClientError` handling `listTables`/`getTableMeta`/`query` already had, so a direct call now fails cleanly instead of leaking a raw axios stack trace.
+
+### Data
+- **`society.destatis_zensus_population_per_bkg_vg250_6_gem` added to `CERNION_RELEVANT_OEP_TABLES`** (`src/oep-tables.js`) — Zensus 2011 population per municipality (`ags_0`, `census_sum`/`census_count`/`census_density`), enabling an OSM-independent consumption-estimation path via `oep.query`/`oep.getTableMeta`/`oep.energyTables` as an alternative to Layer 1 OSM building clustering. Verified live against the real OEP `society` schema; not discoverable via `oep.search` before the fix above existed, since that schema's real table names aren't derivable from the (broken) discovery endpoints.
+
+### Testing
+- `tests/municipality.service.test.js` (new, 16 tests) — name/PLZ/AGS lookup, coordinate reverse-geocoding including the User-Agent header, Nominatim 404/outage/no-match handling, and the case where a geocoded AGS isn't in the local GV100 snapshot.
+- `tests/oep.service.test.js` extended (5 new tests) — `oep.search` catalog-based matching (name, description, schema filter, no-match, and an explicit assertion that `axios.get` is never called) and `oep.listSchemas` 404 handling.
+- Full regression: `tests/oep.service.test.js`, `tests/agent.service.test.js`, `tests/api.service.test.js`, `tests/municipality.service.test.js` — all pass.
+
 ## [0.99.7] — 2026-08-04
 
 ### Security

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.7
-- changelog_latest_release: 0.99.7
+- version: 0.99.8
+- changelog_latest_release: 0.99.8
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -113,7 +113,7 @@ recipes:
   redispatch-settlement-audit "Check settlement readiness and financial risk exposure for…"
 resolve: GET /api/_agent/operations?domain=redispatch
 
-### grid-planning (24 capabilities · 8 recipes · 47 operations)
+### grid-planning (24 capabilities · 8 recipes · 49 operations)
 capabilities: altdaten_assessment, areal_network_integration_offer_gate, asset_valuation_transformation_gate, automatisierungsradar, blindflug_radar_anomaly_detection, budget_waterfall_governance, cost_review_committee_status, decision_readiness_matrix, finance_nkp_capex_reinvest_governance, investment_budget_cap_exception_governance, investment_committee_steering_cards, investment_data_review_queue, investment_maturity_off_balance_gate, investment_owner_deadline_budget_gate, investment_risk_translation_status, investment_two_track_control, investment_waterfall_governance, no_regret_measure_definition_gate, reinvest_signal, sap_budget_psp_gate, transformation_financing_scenario_view, vnb_100_tage_assessment, znp_portfolio_assessment, znp_production_readiness_evidence_gate
 recipes:
   cybergrid-counter-location-scout "A VNB wants to proactively identify storage locations near…"
@@ -246,17 +246,17 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: 49505c511b77d50100039d52f6210d0ef122a04d0ec26218d0df1c19843b2fa3
+- CHANGELOG.md: bffdd9566ece3b4a221bc913efa1fd459c77ee29da2bc8cbd4b3b5f0336f0543
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: fa9819ed0996deebfa6b2bf9c417f1dc49d90ddd5a01146a47a9b0dd9442c873
+- openapi-export.json: 756dfeeaf6213d72069c758a2d55b9a637d971681f58d610dc99f73b51bd5aa5
 
 ## OpenAPI Surface (full contract, not embedded)
-- path_count: 1023
-- operation_count: 1135
+- path_count: 1025
+- operation_count: 1137
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 17f2c2c1d3240463bffb7a5d82a6166c621ddd5103ce110cd38ff18a676b767b
+- llm_txt_sha256: 850e1226f49359339bc15a7940a22ea692847a17a50217c8f1e500e330a74f2a

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.7",
+    "version": "0.99.8",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -2470,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.7",
+  "x-version": "0.99.8",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.7",
+    "version": "0.99.8",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -50946,6 +50946,156 @@
         }
       }
     },
+    "/api/municipality/lookup": {
+      "get": {
+        "operationId": "municipality_lookup",
+        "summary": "Look up a German municipality by name, PLZ, or AGS",
+        "tags": [
+          "Municipality"
+        ],
+        "responses": {
+          "200": {
+            "description": "Municipality profile (found:false if unresolved)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "found": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "ags": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "state": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "population": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "areaSqKm": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "sourceStatus": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Resolves a municipality profile (AGS, name, Bundesland, population, PLZ) from a municipality name, a 5-digit PLZ, or an Amtlicher Gemeindeschlüssel (AGS). Offline lookup against Destatis Gemeindegrenzen 2022 (GV100, 10,990 municipalities) — no external API call. found:true with population:null means the name/PLZ resolved but there was no Destatis GV100 match (name+state known only).",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "Hockenheim"
+            },
+            "description": "Municipality name or 5-digit PLZ."
+          },
+          {
+            "name": "ags",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "08226032"
+            },
+            "description": "Amtlicher Gemeindeschlüssel, takes priority over municipality."
+          }
+        ]
+      }
+    },
+    "/api/municipality/reverse-geocode": {
+      "get": {
+        "operationId": "municipality_reverseGeocode",
+        "summary": "Resolve a German municipality (AGS) from WGS84 coordinates",
+        "tags": [
+          "Municipality"
+        ],
+        "responses": {
+          "200": {
+            "description": "Municipality profile resolved from coordinates (found:false if unresolved)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "found": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "ags": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "state": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "population": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "areaSqKm": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "sourceStatus": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Reverse-geocodes a lat/lon pair via OpenStreetMap Nominatim to a German Amtlicher Gemeindeschlüssel (AGS), then joins it against the same Destatis GV100 profile as GET /municipality/lookup. found:false means the coordinates do not fall inside a German municipality boundary known to Nominatim (e.g. outside Germany, or open water). Live external call — not cached; the public Nominatim instance is rate-limited to ~1 request/second, set NOMINATIM_ENDPOINT for a private mirror under sustained load.",
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "example": 49.3183
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "example": 8.5495
+            }
+          }
+        ]
+      }
+    },
     "/api/nbp-monitor/:bdewCode": {
       "get": {
         "operationId": "nbp-monitor_snapshot",
@@ -52908,7 +53058,7 @@
             }
           }
         },
-        "description": "Case-insensitive substring search across all OEP table names and descriptions. Optionally scoped to a specific schema. Uses the cached table list (24 h TTL) — no per-search API call is made to OEP. Useful for discovering scenario datasets, e.g. \"NEP\", \"Kohleausstieg\", \"photovoltaik\".",
+        "description": "Case-insensitive substring search over the curated, Cernion-relevant OEP table catalog (src/oep-tables.js) — not a live full-catalog search against OEP. OEP's own schema/table discovery REST endpoints were removed upstream and no longer respond with JSON, so free-text discovery across the entire platform is not available; use oep.query directly if you already know an exact schema/table pair that is not in the curated list. Optionally scoped to a specific schema.",
         "parameters": [
           {
             "name": "q",
@@ -91218,5 +91368,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.7"
+  "x-version": "0.99.8"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,15 +1,15 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.7",
-  "sourceOpenApiHash": "fa9819ed0996deebfa6b2bf9c417f1dc49d90ddd5a01146a47a9b0dd9442c873",
+  "packageVersion": "0.99.8",
+  "sourceOpenApiHash": "756dfeeaf6213d72069c758a2d55b9a637d971681f58d610dc99f73b51bd5aa5",
   "coverage": {
-    "rawOperationCount": 1135,
-    "operationCount": 879,
-    "agentableCount": 877,
+    "rawOperationCount": 1137,
+    "operationCount": 881,
+    "agentableCount": 879,
     "nonAgentableCount": 2,
     "byOperationKind": {
-      "data_read": 385,
+      "data_read": 387,
       "admin": 8,
       "object_store_write": 229,
       "process_step": 20,
@@ -62609,6 +62609,161 @@
       "aliases": [
         "POST /api/mscons-import/parse"
       ]
+    },
+    {
+      "operationId": "municipality_lookup",
+      "method": "GET",
+      "path": "/api/municipality/lookup",
+      "service": "municipality",
+      "action": "municipality.lookup",
+      "summary": "Look up a German municipality by name, PLZ, or AGS",
+      "tags": [
+        "Municipality"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "data_read",
+      "consequenceLevel": "none",
+      "recommendedExecutionMode": "direct",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "municipality.lookup"
+      ],
+      "domains": [
+        "grid-planning"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "municipality:read"
+      ],
+      "tenantScoped": true,
+      "writesTo": [],
+      "sideEffects": [],
+      "idempotency": "idempotent",
+      "rollbackHint": null,
+      "parameters": {
+        "required": [],
+        "optional": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "type": "string",
+            "description": "Municipality name or 5-digit PLZ.",
+            "extractionHint": null
+          },
+          {
+            "name": "ags",
+            "in": "query",
+            "type": "string",
+            "description": "Amtlicher Gemeindeschlüssel, takes priority over municipality.",
+            "extractionHint": null
+          }
+        ]
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "municipality",
+          "lookup",
+          "look",
+          "up",
+          "german",
+          "by",
+          "name,",
+          "plz,",
+          "or",
+          "ags"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Show me look up a german municipality by name, plz, or ags"
+        ],
+        "synonyms": [
+          "Netzplanung",
+          "Zielnetzplanung",
+          "investment planning"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "municipality_reverseGeocode",
+      "method": "GET",
+      "path": "/api/municipality/reverse-geocode",
+      "service": "municipality",
+      "action": "municipality.reverseGeocode",
+      "summary": "Resolve a German municipality (AGS) from WGS84 coordinates",
+      "tags": [
+        "Municipality"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "data_read",
+      "consequenceLevel": "none",
+      "recommendedExecutionMode": "direct",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "municipality.reverse_geocode"
+      ],
+      "domains": [
+        "grid-planning"
+      ],
+      "dataSources": [],
+      "entityTypes": [],
+      "requiredScopes": [
+        "municipality:read"
+      ],
+      "tenantScoped": true,
+      "writesTo": [],
+      "sideEffects": [],
+      "idempotency": "idempotent",
+      "rollbackHint": null,
+      "parameters": {
+        "required": [
+          {
+            "name": "lat",
+            "in": "query",
+            "type": "number",
+            "description": null,
+            "extractionHint": "geo_coordinate"
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "type": "number",
+            "description": null,
+            "extractionHint": "geo_coordinate"
+          }
+        ],
+        "optional": []
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "municipality",
+          "reverse",
+          "geocode",
+          "resolve",
+          "german",
+          "(ags)",
+          "from",
+          "wgs84",
+          "coordinates"
+        ],
+        "negativeCues": [],
+        "examples": [
+          "Show me resolve a german municipality (ags) from wgs84 coordinates"
+        ],
+        "synonyms": [
+          "Netzplanung",
+          "Zielnetzplanung",
+          "investment planning"
+        ],
+        "curated": false
+      },
+      "aliases": []
     },
     {
       "operationId": "nbp-monitor_snapshot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.7",
+  "version": "0.99.8",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {

--- a/services/api.service.js
+++ b/services/api.service.js
@@ -1733,6 +1733,9 @@ module.exports = {
             'operations-runbook.stadtwerkMauerE2eSmoke',
           'GET /operations-runbook/vdmi-blueprint-packs/verify':
             'operations-runbook.verifyVdmiBlueprintPackSeed',
+          // Municipality (AGS) lookup (v0.99.8)
+          'GET /municipality/lookup': 'municipality.lookup',
+          'GET /municipality/reverse-geocode': 'municipality.reverseGeocode',
           // OEP (Open Energy Platform) read-only connector (v0.12)
           'GET /oep/schemas': 'oep.listSchemas',
           'GET /oep/schemas/:schema/tables': 'oep.listTables',

--- a/services/municipality.service.js
+++ b/services/municipality.service.js
@@ -1,0 +1,208 @@
+'use strict';
+
+/**
+ * Municipality Service — read-only Amtlicher Gemeindeschlüssel (AGS) lookup
+ *
+ * Thin, dedicated lookup surface over src/municipality-resolver.js's
+ * resolveMunicipalityProfile() (name/PLZ/AGS -> profile, offline against
+ * Destatis GV100 2022) and src/municipality-geocoder.js's reverse geocoder
+ * (lat/lon -> AGS via Nominatim). Neither existing capability had its own
+ * standalone action before this — resolveMunicipalityProfile was only
+ * reachable indirectly through dashboard-api's much heavier
+ * municipalEnergyValueAnalysisStatus (economic Lagebild, year/scenario
+ * params), and coordinate-based lookup did not exist anywhere.
+ */
+
+const { MoleculerClientError } = require('moleculer').Errors;
+const { resolveMunicipalityProfile } = require('../src/municipality-resolver');
+const { reverseGeocodeToAgs } = require('../src/municipality-geocoder');
+
+module.exports = {
+  name: 'municipality',
+
+  actions: {
+    // ------------------------------------------------------------------
+    // lookup — resolve a municipality profile by name, PLZ, or AGS
+    // ------------------------------------------------------------------
+    lookup: {
+      rest: 'GET /lookup',
+      params: {
+        municipality: { type: 'string', optional: true, min: 1 },
+        ags: { type: 'string', optional: true, min: 1 },
+      },
+      openapi: {
+        summary: 'Look up a German municipality by name, PLZ, or AGS',
+        tags: ['Municipality'],
+        description:
+          'Resolves a municipality profile (AGS, name, Bundesland, population, PLZ) from ' +
+          'a municipality name, a 5-digit PLZ, or an Amtlicher Gemeindeschlüssel (AGS). ' +
+          'Offline lookup against Destatis Gemeindegrenzen 2022 (GV100, 10,990 municipalities) ' +
+          '— no external API call. found:true with population:null means the name/PLZ ' +
+          'resolved but there was no Destatis GV100 match (name+state known only).',
+        parameters: [
+          {
+            name: 'municipality',
+            in: 'query',
+            required: false,
+            schema: { type: 'string', example: 'Hockenheim' },
+            description: 'Municipality name or 5-digit PLZ.',
+          },
+          {
+            name: 'ags',
+            in: 'query',
+            required: false,
+            schema: { type: 'string', example: '08226032' },
+            description: 'Amtlicher Gemeindeschlüssel, takes priority over municipality.',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Municipality profile (found:false if unresolved)',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    found: { type: 'boolean' },
+                    name: { type: 'string', nullable: true },
+                    ags: { type: 'string', nullable: true },
+                    state: { type: 'string', nullable: true },
+                    postalCode: { type: 'string', nullable: true },
+                    population: { type: 'integer', nullable: true },
+                    areaSqKm: { type: 'number', nullable: true },
+                    sourceStatus: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      async handler(ctx) {
+        const { municipality, ags } = ctx.params;
+        if (!municipality && !ags) {
+          throw new MoleculerClientError(
+            'At least one of municipality or ags is required',
+            422,
+            'VALIDATION_ERROR'
+          );
+        }
+
+        const profile = resolveMunicipalityProfile({ municipality, ags });
+        return {
+          found: profile.found,
+          name: profile.name,
+          ags: profile.ags,
+          state: profile.state,
+          postalCode: profile.postalCode,
+          population: profile.population,
+          areaSqKm: profile.areaSqKm,
+          sourceStatus: profile.sourceStatus,
+        };
+      },
+    },
+
+    // ------------------------------------------------------------------
+    // reverseGeocode — resolve a municipality profile from coordinates
+    // ------------------------------------------------------------------
+    reverseGeocode: {
+      rest: 'GET /reverse-geocode',
+      params: {
+        lat: { type: 'number', convert: true, min: -90, max: 90 },
+        lon: { type: 'number', convert: true, min: -180, max: 180 },
+      },
+      openapi: {
+        summary: 'Resolve a German municipality (AGS) from WGS84 coordinates',
+        tags: ['Municipality'],
+        description:
+          'Reverse-geocodes a lat/lon pair via OpenStreetMap Nominatim to a German ' +
+          'Amtlicher Gemeindeschlüssel (AGS), then joins it against the same Destatis GV100 ' +
+          'profile as GET /municipality/lookup. found:false means the coordinates do not ' +
+          'fall inside a German municipality boundary known to Nominatim (e.g. outside ' +
+          'Germany, or open water). Live external call — not cached; the public Nominatim ' +
+          'instance is rate-limited to ~1 request/second, set NOMINATIM_ENDPOINT for a ' +
+          'private mirror under sustained load.',
+        parameters: [
+          {
+            name: 'lat',
+            in: 'query',
+            required: true,
+            schema: { type: 'number', example: 49.3183 },
+          },
+          {
+            name: 'lon',
+            in: 'query',
+            required: true,
+            schema: { type: 'number', example: 8.5495 },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Municipality profile resolved from coordinates (found:false if unresolved)',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    found: { type: 'boolean' },
+                    name: { type: 'string', nullable: true },
+                    ags: { type: 'string', nullable: true },
+                    state: { type: 'string', nullable: true },
+                    postalCode: { type: 'string', nullable: true },
+                    population: { type: 'integer', nullable: true },
+                    areaSqKm: { type: 'number', nullable: true },
+                    sourceStatus: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      async handler(ctx) {
+        const { lat, lon } = ctx.params;
+
+        const geo = await reverseGeocodeToAgs(lat, lon);
+        if (!geo.found) {
+          return {
+            found: false,
+            name: geo.name,
+            ags: null,
+            state: geo.state,
+            postalCode: geo.postalCode,
+            population: null,
+            areaSqKm: null,
+            sourceStatus: 'geocoding-no-ags-match',
+          };
+        }
+
+        const profile = resolveMunicipalityProfile({ ags: geo.ags });
+        if (profile.found) {
+          return {
+            found: true,
+            name: profile.name,
+            ags: profile.ags,
+            state: profile.state,
+            postalCode: profile.postalCode || geo.postalCode,
+            population: profile.population,
+            areaSqKm: profile.areaSqKm,
+            sourceStatus: profile.sourceStatus,
+          };
+        }
+
+        // Nominatim resolved an AGS that isn't in our GV100 2022 snapshot
+        // (e.g. a post-2022 territorial reform) — surface what we have.
+        return {
+          found: true,
+          name: geo.name,
+          ags: geo.ags,
+          state: geo.state,
+          postalCode: geo.postalCode,
+          population: null,
+          areaSqKm: null,
+          sourceStatus: 'geocoding-only-no-gv100-match',
+        };
+      },
+    },
+  },
+};

--- a/src/llm-manifest-taxonomy.js
+++ b/src/llm-manifest-taxonomy.js
@@ -231,6 +231,7 @@ const OPENAPI_TAG_DOMAIN_MAP = {
   'MCP Server': 'platform',
   'MaStR Monitor': 'grid-ops',
   'MaStR Data Quality': 'grid-ops',
+  Municipality: 'grid-planning',
   VNBMonitor: 'grid-ops',
   NBPMonitor: 'grid-ops',
   'netzkoppelvertrag-workflow': 'governance',

--- a/src/municipality-geocoder.js
+++ b/src/municipality-geocoder.js
@@ -1,0 +1,102 @@
+'use strict';
+
+/**
+ * Municipality Reverse Geocoder
+ *
+ * Resolves WGS84 coordinates to a German Amtlicher Gemeindeschlüssel (AGS) via
+ * OpenStreetMap Nominatim reverse geocoding. OSM boundary relations for German
+ * municipalities carry the AGS as `extratags['de:amtlicher_gemeindeschluessel']`
+ * (verified live against real coordinates for both a Kreisfreie Stadt and a
+ * regular Gemeinde before building this).
+ *
+ * Environment variables:
+ *   NOMINATIM_ENDPOINT  Override API base URL (default: public Nominatim instance)
+ *
+ * Usage note: the public Nominatim instance's usage policy caps requests at
+ * ~1/sec and requires an identifying User-Agent (unset by axios by default —
+ * see src/znp-osm-buildings.js's Overpass fix for what happens without one).
+ * For high-volume production workloads, point NOMINATIM_ENDPOINT at a private
+ * mirror.
+ */
+
+const axios = require('axios');
+
+const NOMINATIM_ENDPOINT =
+  process.env.NOMINATIM_ENDPOINT || 'https://nominatim.openstreetmap.org/reverse';
+
+const REQUEST_TIMEOUT_MS = 15000;
+
+/**
+ * Reverse-geocode a lat/lon pair to a German municipality via Nominatim.
+ *
+ * @param {number} lat
+ * @param {number} lon
+ * @returns {Promise<{
+ *   found: boolean,
+ *   ags: string|null,
+ *   name: string|null,
+ *   adminLevel: number|null,
+ *   state: string|null,
+ *   postalCode: string|null,
+ *   displayName: string|null,
+ * }>}
+ */
+async function reverseGeocodeToAgs(lat, lon) {
+  let response;
+  try {
+    response = await axios.get(NOMINATIM_ENDPOINT, {
+      params: {
+        format: 'json',
+        lat,
+        lon,
+        zoom: 10, // city/town/village level — matches German Gemeinde admin levels 6-8
+        addressdetails: 1,
+        extratags: 1,
+      },
+      timeout: REQUEST_TIMEOUT_MS,
+      headers: {
+        // nominatim.org's usage policy requires an identifying User-Agent;
+        // requests without one are rejected.
+        'User-Agent': 'cernion-energy-tools/municipality-geocoder (+https://cernion.energy)',
+      },
+    });
+  } catch (err) {
+    if (err.response?.status === 404) {
+      return emptyResult();
+    }
+    throw err;
+  }
+
+  const data = response.data;
+  if (!data || typeof data !== 'object' || data.error) {
+    return emptyResult();
+  }
+
+  const extratags = data.extratags || {};
+  const address = data.address || {};
+  const ags = extratags['de:amtlicher_gemeindeschluessel'] || null;
+
+  return {
+    found: Boolean(ags),
+    ags,
+    name: data.name || address.city || address.town || address.village || null,
+    adminLevel: extratags.admin_level ? Number(extratags.admin_level) : null,
+    state: address.state || null,
+    postalCode: address.postcode || null,
+    displayName: data.display_name || null,
+  };
+}
+
+function emptyResult() {
+  return {
+    found: false,
+    ags: null,
+    name: null,
+    adminLevel: null,
+    state: null,
+    postalCode: null,
+    displayName: null,
+  };
+}
+
+module.exports = { reverseGeocodeToAgs };

--- a/tests/municipality.service.test.js
+++ b/tests/municipality.service.test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+/**
+ * Tests for services/municipality.service.js
+ */
+
+jest.mock('axios');
+
+const axios = require('axios');
+const { ServiceBroker } = require('moleculer');
+const MunicipalityService = require('../services/municipality.service');
+
+const HOCKENHEIM_NOMINATIM_FIXTURE = {
+  name: 'Hockenheim',
+  display_name: 'Hockenheim, VVG der Stadt Hockenheim, Rhein-Neckar-Kreis, Baden-Württemberg, 68766, Deutschland',
+  address: {
+    town: 'Hockenheim',
+    county: 'Rhein-Neckar-Kreis',
+    state: 'Baden-Württemberg',
+    postcode: '68766',
+    country: 'Deutschland',
+    country_code: 'de',
+  },
+  extratags: {
+    admin_level: '8',
+    'de:amtlicher_gemeindeschluessel': '08226032',
+  },
+};
+
+const OCEAN_NOMINATIM_FIXTURE = { error: 'Unable to geocode' };
+
+// ---------------------------------------------------------------------------
+describe('Municipality Service — structure', () => {
+  it('has correct service name', () => {
+    expect(MunicipalityService.name).toBe('municipality');
+  });
+
+  it('exposes lookup and reverseGeocode actions', () => {
+    expect(MunicipalityService.actions).toHaveProperty('lookup');
+    expect(MunicipalityService.actions).toHaveProperty('reverseGeocode');
+  });
+
+  it('both actions are GET (read-only)', () => {
+    expect(MunicipalityService.actions.lookup.rest).toMatch(/GET/);
+    expect(MunicipalityService.actions.reverseGeocode.rest).toMatch(/GET/);
+  });
+
+  it('both actions have OpenAPI tags pointing to Municipality', () => {
+    for (const [, action] of Object.entries(MunicipalityService.actions)) {
+      expect(action.openapi.tags).toContain('Municipality');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('Municipality Service — action handlers', () => {
+  let broker;
+
+  beforeAll(async () => {
+    broker = new ServiceBroker({ logger: false, transporter: null });
+    broker.createService(MunicipalityService);
+    await broker.start();
+  });
+
+  afterAll(async () => {
+    await broker.stop();
+  });
+
+  beforeEach(() => {
+    axios.get.mockReset();
+  });
+
+  // ------------------------------------------------------------------
+  // lookup
+  // ------------------------------------------------------------------
+  describe('lookup', () => {
+    it('resolves a known municipality by name', async () => {
+      const result = await broker.call('municipality.lookup', { municipality: 'Hockenheim' });
+      expect(result.found).toBe(true);
+      expect(result.ags).toBe('08226032');
+      expect(result.state).toBe('Baden-Württemberg');
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+
+    it('resolves a known municipality by PLZ', async () => {
+      const result = await broker.call('municipality.lookup', { municipality: '68766' });
+      expect(result.found).toBe(true);
+      expect(result.name).toBe('Hockenheim');
+    });
+
+    it('resolves a known municipality by AGS', async () => {
+      const result = await broker.call('municipality.lookup', { ags: '08226032' });
+      expect(result.found).toBe(true);
+      expect(result.name).toBe('Hockenheim');
+    });
+
+    it('returns found:false for an unresolvable name', async () => {
+      const result = await broker.call('municipality.lookup', {
+        municipality: 'NichtExistierendeGemeindeXYZ',
+      });
+      expect(result.found).toBe(false);
+    });
+
+    it('rejects when neither municipality nor ags is given', async () => {
+      await expect(broker.call('municipality.lookup', {})).rejects.toMatchObject({ code: 422 });
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // reverseGeocode
+  // ------------------------------------------------------------------
+  describe('reverseGeocode', () => {
+    it('resolves AGS + full GV100 profile from coordinates', async () => {
+      axios.get.mockResolvedValueOnce({ data: HOCKENHEIM_NOMINATIM_FIXTURE });
+      const result = await broker.call('municipality.reverseGeocode', {
+        lat: 49.3183,
+        lon: 8.5495,
+      });
+      expect(result.found).toBe(true);
+      expect(result.ags).toBe('08226032');
+      expect(result.name).toBe('Hockenheim');
+      expect(result.population).toBeGreaterThan(0);
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('nominatim'),
+        expect.objectContaining({ params: expect.objectContaining({ lat: 49.3183, lon: 8.5495 }) })
+      );
+    });
+
+    it('sends a non-empty User-Agent header (Overpass 406 lesson)', async () => {
+      axios.get.mockResolvedValueOnce({ data: HOCKENHEIM_NOMINATIM_FIXTURE });
+      await broker.call('municipality.reverseGeocode', { lat: 49.3183, lon: 8.5495 });
+      const [, config] = axios.get.mock.calls[0];
+      expect(config.headers['User-Agent']).toBeTruthy();
+    });
+
+    it('returns found:false when Nominatim has no match (e.g. open water)', async () => {
+      axios.get.mockResolvedValueOnce({ data: OCEAN_NOMINATIM_FIXTURE });
+      const result = await broker.call('municipality.reverseGeocode', { lat: 0, lon: 0 });
+      expect(result.found).toBe(false);
+      expect(result.sourceStatus).toBe('geocoding-no-ags-match');
+    });
+
+    it('returns found:false when Nominatim 404s', async () => {
+      const err = new Error('Not found');
+      err.response = { status: 404 };
+      axios.get.mockRejectedValueOnce(err);
+      const result = await broker.call('municipality.reverseGeocode', { lat: 0, lon: 0 });
+      expect(result.found).toBe(false);
+    });
+
+    it('propagates non-404 errors (e.g. Nominatim outage)', async () => {
+      const err = new Error('Service unavailable');
+      err.response = { status: 503 };
+      axios.get.mockRejectedValueOnce(err);
+      await expect(
+        broker.call('municipality.reverseGeocode', { lat: 49.3183, lon: 8.5495 })
+      ).rejects.toThrow();
+    });
+
+    it('validates lat/lon ranges', async () => {
+      await expect(
+        broker.call('municipality.reverseGeocode', { lat: 200, lon: 8.5495 })
+      ).rejects.toMatchObject({ type: 'VALIDATION_ERROR' });
+    });
+
+    it('surfaces geocoding-only-no-gv100-match when AGS is not in the local GV100 snapshot', async () => {
+      axios.get.mockResolvedValueOnce({
+        data: {
+          ...HOCKENHEIM_NOMINATIM_FIXTURE,
+          extratags: { admin_level: '8', 'de:amtlicher_gemeindeschluessel': '99999999' },
+        },
+      });
+      const result = await broker.call('municipality.reverseGeocode', {
+        lat: 49.3183,
+        lon: 8.5495,
+      });
+      expect(result.found).toBe(true);
+      expect(result.ags).toBe('99999999');
+      expect(result.sourceStatus).toBe('geocoding-only-no-gv100-match');
+      expect(result.population).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **New `municipality` service** — closes both gaps from the earlier discussion:
  - `GET /api/municipality/lookup` (`municipality`/`ags` query param) — thin wrapper over the existing `resolveMunicipalityProfile()` (`src/municipality-resolver.js`, offline against Destatis GV100 2022). Previously only reachable indirectly via `dashboard-api.municipalEnergyValueAnalysisStatus`, a much heavier economic Lagebild endpoint.
  - `GET /api/municipality/reverse-geocode` (`lat`/`lon`) — new capability, did not exist in any form before. Reverse-geocodes via OpenStreetMap Nominatim (`extratags['de:amtlicher_gemeindeschluessel']`, verified live against both a Kreisfreie Stadt and a regular Gemeinde), then joins the AGS back through the same GV100 profile. Explicit `User-Agent` header from the start (Nominatim requires one — same class of bug just fixed for Overpass in #539).
- **v0.99.8 release packaging**: version bump, `CHANGELOG.md` entry covering this plus the three fixes already merged since 0.99.7 (#539 Overpass User-Agent/406, #540 OEP society population table, #541 `oep.search` curated-catalog fix), and regenerated build artifacts (`openapi-export.json`, `openapi-copilot.json`, `operation-capability-index.json`, `llm.txt`).
- `'Municipality'` OpenAPI tag mapped to `grid-planning` in `src/llm-manifest-taxonomy.js` — required, `generate-llm-txt.js` refuses to run with unmapped operations.

## Test plan
- [x] New: `tests/municipality.service.test.js` (16 tests) — name/PLZ/AGS lookup, coordinate reverse-geocoding incl. User-Agent header, Nominatim 404/outage/no-match handling, AGS-not-in-local-snapshot case
- [x] Live-verified against the real Nominatim API before writing tests (Hockenheim, Mannheim, open-water no-match)
- [x] End-to-end through a real Moleculer broker (all 4 lookup paths + error case)
- [x] `npm run check:operation-capability-index`, `npm run check:llm`, `npm run audit:openapi` — all clean, auto-classified as `data_read`/`agentable:true`/`consequenceLevel:none` with `lat`/`lon` auto-detected as `geo_coordinate`
- [x] `npm run check:tdd-matrix-coverage`, `npm run check:quality-gate`, `npm run audit:security` — pass (security: 2 pre-existing non-critical dependency advisories, unrelated)
- [x] Full repo test suite (`tests/`, excluding unrelated stray worktree copies and the two `tests/rest-usecases/*.reference.test.js` that require a live server on port 3000): 301+ suites, 7000+ tests passing
- [x] GitNexus `detect_changes`: LOW risk, no affected processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)