### PR TITLE
fix: retry gridTopology on a totally empty Overpass response too (v0.99.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.11] — 2026-08-09
+
+### Fixed
+- **v0.99.10's implausible-result retry had a gap: it only triggered when Overpass returned real line ways but zero derivable edges, not when the whole response came back completely empty.** A user regression report reproduced `osm-geo.gridTopology` returning 0 nodes/0 edges (`coverageLabel: "NO_NODES"`) 3x in a row for the same known-populated Hockenheim bbox — including with `voltageLevel` filters and `postalCode` scope — while `osm-geo.substationFinder` reliably found 75 real substations for the identical bbox in the same test session, proving the underlying data was available and this was not a data gap. Root cause: `fetchAndBuildGraph()`'s implausibility check (`ways.length > 0 && nodes.length > 0 && edges.length === 0`) required `ways.length > 0`, so a totally empty Overpass response (0 ways *and* 0 nodes — an even more severe version of the same silent-truncation failure mode fixed in v0.99.10) never entered the retry path at all.
+- **Fix:** the retry condition now also covers a completely empty response (`ways.length === 0 && nodesById.size === 0`), and `maxRetries` default raised from 1 to 2 given how persistently degraded the public Overpass instance has been observed to be across this investigation (up to 3 attempts total). A genuinely empty area (no power infrastructure at all in the bbox) now pays for one extra retry before settling — an acceptable cost, since this platform only ever queries real German municipality areas.
+
+### Testing
+- `tests/osm-grid-topology.test.js` — the "does not retry a genuinely empty area" test (encoding the old, now-wrong behavior) replaced with two tests: retry-and-recover on a totally-empty-then-good sequence (the exact v0.99.10 regression pattern), and honest give-up after exhausting retries on a persistently empty area.
+- Full suite: `osm-geo.service.test.js` + `osm-grid-topology.test.js` — 12 suites / 531 tests pass.
+- Live verification against the real Overpass instance was not possible for this fix — the public instance was still returning clean `504`s from this investigation's own preceding load at the time of shipping (itself confirmation that the error path added in v0.99.10 continues to surface real failures honestly rather than silently). Correctness rests on the deterministic unit tests above.
+
 ## [0.99.10] — 2026-08-09
 
 ### Fixed

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.10
-- changelog_latest_release: 0.99.10
+- version: 0.99.11
+- changelog_latest_release: 0.99.11
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -246,12 +246,12 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: e692c92bac3e953882f97f21622c0ec3aea2b408421368f7f3de4a30a0f87b82
+- CHANGELOG.md: 48cb7c2504ac061308c56cae4cdd79163ad967e429e183f11cde25f1677543a4
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: df84668b01a083582d191e7e734ea96a528815bd179adcff5210c70d3656f13d
+- openapi-export.json: 4d7006b9b0c43165629f8117c20a345aa8e7acacfc864aa1775d61248cde76ef
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 1025
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 20dcab7fb964bf6fd15d18450b18136d52f4eab2ff617a1fbad8a799525690db
+- llm_txt_sha256: 1cb10b55c8e04aa2cbcdc6d3fb5bcd2f7d56caf1ef7270a92f8805f14aaaa057

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.10",
+    "version": "0.99.11",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -2470,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.10",
+  "x-version": "0.99.11",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.10",
+    "version": "0.99.11",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -91375,5 +91375,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.10"
+  "x-version": "0.99.11"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.10",
-  "sourceOpenApiHash": "df84668b01a083582d191e7e734ea96a528815bd179adcff5210c70d3656f13d",
+  "packageVersion": "0.99.11",
+  "sourceOpenApiHash": "4d7006b9b0c43165629f8117c20a345aa8e7acacfc864aa1775d61248cde76ef",
   "coverage": {
     "rawOperationCount": 1137,
     "operationCount": 881,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.10",
+  "version": "0.99.11",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {

--- a/src/osm-grid-topology.js
+++ b/src/osm-grid-topology.js
@@ -151,22 +151,28 @@ async function fetchGridElements(bbox) {
 const RETRY_BACKOFF_MS = 2000;
 
 /**
- * Fetches grid elements and builds the graph, retrying the fetch once if the
- * result is topologically implausible: real line ways present, at least one
- * topology node present, but zero derivable edges.
+ * Fetches grid elements and builds the graph, retrying when the result looks
+ * like a truncated/degraded Overpass response rather than a genuinely empty
+ * area:
+ *   (a) real line ways present, at least one topology node present, but
+ *       zero derivable edges (v0.99.9 regression: node portion of a
+ *       compound query silently truncated while the way portion stayed
+ *       complete — identical query, back to back, alternated between
+ *       8 nodes/106 ways and 2 unrelated/wrong nodes/106 ways, no error,
+ *       no `remark` field);
+ *   (b) a completely empty response — zero ways AND zero nodes (v0.99.10
+ *       regression: the same known-populated bbox, reproduced 3x, returned
+ *       nothing at all with no error either — an even more severe version
+ *       of the same silent-truncation failure mode, not caught by (a)'s
+ *       `ways.length > 0` guard).
  *
- * This exists because the public Overpass instance was observed live to
- * silently truncate the node portion of a compound node+way query under
- * load while the way portion stayed complete (identical query, back to
- * back: 8 nodes/106 ways, then only 2 unrelated nodes/106 ways, with no
- * error or `remark` field either time) — a v0.99.9 regression report
- * reproduced the exact same 2 spurious node IDs independently, which is
- * consistent with a fixed internal processing/truncation order on an
- * overloaded shared instance rather than a bug in buildGraph() (already
- * covered by deterministic unit tests). A short-backoff retry resolves this
- * in practice; if it recurs, the caller gets an honest zero-edges result
- * (see osm-geo.service.js's dataQuality messaging) rather than a fabricated
- * explanation.
+ * This does mean a *genuinely* empty area (no power infrastructure at all
+ * within the bbox) pays for one extra retry before settling — an acceptable
+ * cost given this platform only ever queries real German municipality
+ * areas, which essentially always have some grid infrastructure. Not a bug
+ * in buildGraph() itself in either case (unchanged, still covered by its
+ * deterministic unit tests) — the failure is entirely at the Overpass fetch
+ * layer.
  *
  * @param {{south,west,north,east}} bbox
  * @param {string|null} voltageLevelFilter
@@ -174,7 +180,7 @@ const RETRY_BACKOFF_MS = 2000;
  * @returns {Promise<{nodes: object[], edges: object[], retried: boolean}>}
  */
 async function fetchAndBuildGraph(bbox, voltageLevelFilter, options = {}) {
-  const maxRetries = options.maxRetries ?? 1;
+  const maxRetries = options.maxRetries ?? 2;
   const backoffMs = options.backoffMs ?? RETRY_BACKOFF_MS;
   let result = { nodes: [], edges: [] };
   let retried = false;
@@ -188,8 +194,10 @@ async function fetchAndBuildGraph(bbox, voltageLevelFilter, options = {}) {
     const { nodesById, ways } = await fetchGridElements(bbox);
     result = buildGraph(nodesById, ways, voltageLevelFilter);
 
-    const implausible = ways.length > 0 && result.nodes.length > 0 && result.edges.length === 0;
-    if (!implausible) break;
+    const partiallyTruncated =
+      ways.length > 0 && result.nodes.length > 0 && result.edges.length === 0;
+    const totallyEmpty = ways.length === 0 && nodesById.size === 0;
+    if (!partiallyTruncated && !totallyEmpty) break;
   }
 
   return { ...result, retried };

--- a/tests/osm-grid-topology.test.js
+++ b/tests/osm-grid-topology.test.js
@@ -346,12 +346,22 @@ describe('fetchAndBuildGraph', () => {
     expect(axios.post).toHaveBeenCalledTimes(2);
   });
 
-  it('does not retry a genuinely empty area (no ways at all)', async () => {
+  it('retries a totally empty response (0 ways, 0 nodes) — the v0.99.10 regression pattern', async () => {
     axios.post.mockResolvedValueOnce({ data: { elements: [] } });
-    const result = await fetchAndBuildGraph(bbox, null);
+    axios.post.mockResolvedValueOnce({ data: GOOD_RESPONSE });
+    const result = await fetchAndBuildGraph(bbox, null, { maxRetries: 1, backoffMs: 0 });
+    expect(result.edges).toHaveLength(1);
+    expect(result.retried).toBe(true);
+    expect(axios.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up on a genuinely empty area after exhausting retries', async () => {
+    axios.post.mockResolvedValue({ data: { elements: [] } });
+    const result = await fetchAndBuildGraph(bbox, null, { maxRetries: 1, backoffMs: 0 });
+    expect(result.nodes).toHaveLength(0);
     expect(result.edges).toHaveLength(0);
-    expect(result.retried).toBe(false);
-    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect(result.retried).toBe(true);
+    expect(axios.post).toHaveBeenCalledTimes(2);
   });
 
   it('propagates a hard fetch error without retrying', async () => {


### PR DESCRIPTION
## Summary
- v0.99.10's implausible-result retry only triggered when Overpass returned real line ways but zero derivable edges (required `ways.length > 0`). A user regression report reproduced `gridTopology` returning 0 nodes/0 edges (`NO_NODES`) 3x in a row for a known-populated bbox — including with `voltageLevel` filters and `postalCode` scope — while `substationFinder` reliably found 75 real substations for the identical bbox in the same session, proving the data existed and this wasn't a data gap.
- Root cause: a totally empty Overpass response (0 ways AND 0 nodes — an even more severe silent-truncation failure than v0.99.10's partial-truncation pattern) never entered the retry path at all, because the guard required `ways.length > 0`.
- Fix: `fetchAndBuildGraph()`'s retry condition now also covers a completely empty response, and `maxRetries` default raised from 1 to 2 given how persistently degraded the public Overpass instance has been observed across this investigation.

## Test plan
- [x] `tests/osm-grid-topology.test.js` — the now-wrong "does not retry a genuinely empty area" test replaced with retry-and-recover and honest-give-up cases for the totally-empty pattern
- [x] `npx jest tests/osm-geo.service.test.js tests/osm-grid-topology.test.js` — 12 suites / 531 tests pass
- [x] `npm run check:operation-capability-index`, `npm run check:llm`, `npm run audit:openapi` — all clean
- [x] `npm run check:tdd-matrix-coverage`, `npm run check:quality-gate`, `npm run audit:security` — pass (security: 2 pre-existing non-critical dependency advisories, unrelated)
- [x] GitNexus `detect_changes`: LOW risk; cross-checked scope via `git status` (matches expected file set exactly)
- [ ] Live verification against the real Overpass instance was not possible for this fix — it was still returning clean `504`s from this investigation's own preceding load at ship time

🤖 Generated with [Claude Code](https://claude.com/claude-code)