### PR TITLE
fix: unify gridTopology implausibility check, covers ways-but-zero-nodes (v0.99.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.12] — 2026-08-09
+
+### Fixed
+- **v0.99.11's fix still missed a third variant of the same failure: line ways present, but *zero* tagged substation/transformer nodes at all — not wrong ones, none.** A user regression report reproduced `osm-geo.gridTopology` returning `NO_NODES` deterministically 5/5 times (3× `boundingBox`, 1× `postalCode`, consistent ~5s response time matching the full 3-attempt retry budget being exhausted every time) — unlike the earlier reports, not randomly alternating between success and failure. Root cause: `fetchAndBuildGraph()`'s "partially truncated" retry clause required `nodes.length > 0` (v0.99.9's pattern: wrong-but-present nodes), and the "totally empty" clause required `ways.length === 0` (v0.99.10's pattern: nothing at all) — a response with ways present but zero tagged nodes fell through both and was accepted as final without ever retrying.
+- **Fix:** the two clauses are now a single unified rule — if line ways were returned, *any* zero-edge result is implausible and retried, regardless of node count; if no ways were returned, only a fully empty response (no nodes either) is implausible. An isolated transformer with no nearby line in the queried bbox is a legitimate, non-implausible result and correctly does not cost an extra retry. Verified exhaustively against all 5 reachable `(ways, nodes, edges)` combinations, not just the specific case from each bug report.
+- The public Overpass instance itself was also observed to be under unusually heavy load at the time of this report (the user's `substation-finder` — the still-external `mcp.cernion.de` path — failed 3/3 times in the same session, atypical for that endpoint; a live retest here also hit a clean `504`). Both things were true at once: a real, now-fixed logic gap, and a genuinely saturated shared public instance that no amount of retrying alone fully compensates for — the existing recommendation to point `OVERPASS_ENDPOINT` at a private instance for production load stands.
+
+### Testing
+- `tests/osm-grid-topology.test.js` extended (2 new tests) — retry-and-recover for "ways present, zero tagged nodes" (the exact v0.99.11 regression pattern), and a new explicit non-regression case: no ways but a real isolated tagged node does *not* trigger a retry.
+- Full suite: `osm-geo.service.test.js` + `osm-grid-topology.test.js` — 12 suites / 533 tests pass.
+- Exhaustive manual sweep of all 5 reachable `(ways, nodes, edges)` combinations against the actual implausibility check, confirming correct retry/no-retry behavior for each — done specifically to catch further gaps before shipping, given the pattern of the previous two fixes each missing an adjacent case.
+
 ## [0.99.11] — 2026-08-09
 
 ### Fixed

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.11
-- changelog_latest_release: 0.99.11
+- version: 0.99.12
+- changelog_latest_release: 0.99.12
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -246,12 +246,12 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: 48cb7c2504ac061308c56cae4cdd79163ad967e429e183f11cde25f1677543a4
+- CHANGELOG.md: 36b5b9ae344d82c62361d25de8256cd648ce09b781d0dedf88be37a296bcaabd
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: 4d7006b9b0c43165629f8117c20a345aa8e7acacfc864aa1775d61248cde76ef
+- openapi-export.json: 3f953dccdb562fede01851497ce536df20a0b0a007562ceb557323f3ab90739e
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 1025
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 1cb10b55c8e04aa2cbcdc6d3fb5bcd2f7d56caf1ef7270a92f8805f14aaaa057
+- llm_txt_sha256: 3100a008eebd90b3be2b8588702387afbca1f20eefca03a68f8c2df11935cc9d

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.11",
+    "version": "0.99.12",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -2470,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.11",
+  "x-version": "0.99.12",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.11",
+    "version": "0.99.12",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -91375,5 +91375,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.11"
+  "x-version": "0.99.12"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.11",
-  "sourceOpenApiHash": "4d7006b9b0c43165629f8117c20a345aa8e7acacfc864aa1775d61248cde76ef",
+  "packageVersion": "0.99.12",
+  "sourceOpenApiHash": "3f953dccdb562fede01851497ce536df20a0b0a007562ceb557323f3ab90739e",
   "coverage": {
     "rawOperationCount": 1137,
     "operationCount": 881,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.11",
+  "version": "0.99.12",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {

--- a/src/osm-grid-topology.js
+++ b/src/osm-grid-topology.js
@@ -153,26 +153,36 @@ const RETRY_BACKOFF_MS = 2000;
 /**
  * Fetches grid elements and builds the graph, retrying when the result looks
  * like a truncated/degraded Overpass response rather than a genuinely empty
- * area:
- *   (a) real line ways present, at least one topology node present, but
- *       zero derivable edges (v0.99.9 regression: node portion of a
- *       compound query silently truncated while the way portion stayed
- *       complete — identical query, back to back, alternated between
- *       8 nodes/106 ways and 2 unrelated/wrong nodes/106 ways, no error,
- *       no `remark` field);
- *   (b) a completely empty response — zero ways AND zero nodes (v0.99.10
- *       regression: the same known-populated bbox, reproduced 3x, returned
- *       nothing at all with no error either — an even more severe version
- *       of the same silent-truncation failure mode, not caught by (a)'s
- *       `ways.length > 0` guard).
+ * area. Three regressions were found in production, each a more complete
+ * form of the same underlying failure (the public Overpass instance
+ * silently truncating part of a compound node+way query under load, with
+ * no error and no `remark` field, while the way portion stays complete):
+ *   (a) real line ways present, real (but wrong) topology nodes present,
+ *       zero derivable edges (v0.99.9: identical query back to back
+ *       alternated between 8 correct nodes/106 ways and 2 unrelated
+ *       nodes/106 ways);
+ *   (b) a completely empty response — zero ways AND zero nodes (v0.99.10:
+ *       the same bbox, reproduced 3x, returned nothing at all);
+ *   (c) real line ways present, but *zero* tagged topology nodes at all —
+ *       not wrong ones, none (v0.99.11: reproduced 5/5 with the v0.99.10
+ *       fix already deployed, because that fix's "partially truncated"
+ *       clause still required `nodes.length > 0` and so didn't cover this
+ *       case; the "totally empty" clause didn't apply either since
+ *       `ways.length > 0` here).
+ *
+ * The fix is a single unified rule: if ways were returned, any zero-edge
+ * result is implausible regardless of node count; if no ways were
+ * returned, only a fully empty response (no nodes either) is implausible —
+ * isolated transformers with no nearby lines in the queried bbox is a
+ * legitimate, non-implausible result and shouldn't cost an extra retry.
  *
  * This does mean a *genuinely* empty area (no power infrastructure at all
  * within the bbox) pays for one extra retry before settling — an acceptable
  * cost given this platform only ever queries real German municipality
  * areas, which essentially always have some grid infrastructure. Not a bug
- * in buildGraph() itself in either case (unchanged, still covered by its
- * deterministic unit tests) — the failure is entirely at the Overpass fetch
- * layer.
+ * in buildGraph() itself in any of the three cases (unchanged, still
+ * covered by its deterministic unit tests) — the failure is entirely at
+ * the Overpass fetch layer.
  *
  * @param {{south,west,north,east}} bbox
  * @param {string|null} voltageLevelFilter
@@ -194,10 +204,18 @@ async function fetchAndBuildGraph(bbox, voltageLevelFilter, options = {}) {
     const { nodesById, ways } = await fetchGridElements(bbox);
     result = buildGraph(nodesById, ways, voltageLevelFilter);
 
-    const partiallyTruncated =
-      ways.length > 0 && result.nodes.length > 0 && result.edges.length === 0;
-    const totallyEmpty = ways.length === 0 && nodesById.size === 0;
-    if (!partiallyTruncated && !totallyEmpty) break;
+    // Unified implausibility check: if real line ways were returned, *any*
+    // zero-edge result is suspicious regardless of how many topology nodes
+    // came back — this also covers a case found after v0.99.10 shipped:
+    // ways present but *zero* tagged substation/transformer nodes at all
+    // (not just the wrong ones), which the old two-clause check (requiring
+    // nodes.length > 0 for the "partially truncated" case) missed entirely
+    // and let through as a final NO_NODES result without ever retrying.
+    // If no ways were returned, only retry when nodes are absent too — a
+    // bbox with isolated transformers but no nearby lines is a legitimate,
+    // non-implausible result and shouldn't cost an extra retry.
+    const implausible = ways.length > 0 ? result.edges.length === 0 : nodesById.size === 0;
+    if (!implausible) break;
   }
 
   return { ...result, retried };

--- a/tests/osm-grid-topology.test.js
+++ b/tests/osm-grid-topology.test.js
@@ -318,6 +318,32 @@ describe('fetchAndBuildGraph', () => {
       },
     ],
   };
+  // Ways present, but *zero* tagged substation/transformer nodes at all --
+  // not wrong ones (that's IMPLAUSIBLE_RESPONSE above), literally none. The
+  // v0.99.11 regression: this fell through both the old "partially
+  // truncated" clause (required nodes.length > 0) and the "totally empty"
+  // clause (required ways.length === 0), so it was never retried.
+  const WAYS_BUT_NO_TAGGED_NODES_RESPONSE = {
+    elements: [
+      // Untagged skeleton node from way-recursion (`>`) -- present in
+      // nodesById but not a topology node, matching real Overpass output.
+      { type: 'node', id: 9999999999, lat: 49.305, lon: 8.505 },
+      {
+        type: 'way',
+        id: 500,
+        nodes: [1738604612, 9999999999, 1738604613],
+        tags: { power: 'line', voltage: '110000' },
+      },
+    ],
+  };
+
+  // No ways at all, but a real isolated tagged node -- a legitimate,
+  // non-implausible result (e.g. a small transformer with no nearby line
+  // within the queried bbox) that should NOT cost an extra retry.
+  const ISOLATED_NODE_NO_WAYS_RESPONSE = {
+    elements: [{ type: 'node', id: 42, lat: 49.3, lon: 8.5, tags: { power: 'transformer' } }],
+  };
+
   const bbox = { south: 49.27, west: 8.48, north: 49.36, east: 8.62 };
 
   it('returns the first result directly when it is plausible (no retry)', async () => {
@@ -367,6 +393,24 @@ describe('fetchAndBuildGraph', () => {
   it('propagates a hard fetch error without retrying', async () => {
     axios.post.mockRejectedValueOnce(new Error('OVERPASS_TIMEOUT'));
     await expect(fetchAndBuildGraph(bbox, null)).rejects.toThrow('OVERPASS_TIMEOUT');
+    expect(axios.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when ways are present but zero tagged topology nodes came back at all — the v0.99.11 regression pattern', async () => {
+    axios.post.mockResolvedValueOnce({ data: WAYS_BUT_NO_TAGGED_NODES_RESPONSE });
+    axios.post.mockResolvedValueOnce({ data: GOOD_RESPONSE });
+    const result = await fetchAndBuildGraph(bbox, null, { maxRetries: 1, backoffMs: 0 });
+    expect(result.edges).toHaveLength(1);
+    expect(result.retried).toBe(true);
+    expect(axios.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a real isolated node with no nearby lines (legitimate, non-implausible result)', async () => {
+    axios.post.mockResolvedValueOnce({ data: ISOLATED_NODE_NO_WAYS_RESPONSE });
+    const result = await fetchAndBuildGraph(bbox, null);
+    expect(result.nodes).toHaveLength(1);
+    expect(result.edges).toHaveLength(0);
+    expect(result.retried).toBe(false);
     expect(axios.post).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- v0.99.11's fix still missed a third variant of the same failure: line ways present, but *zero* tagged substation/transformer nodes at all — not wrong ones, none. A user regression report reproduced `NO_NODES` deterministically 5/5 times (not randomly alternating like earlier reports), with response time matching the full 3-attempt retry budget being exhausted every time.
- Root cause: the "partially truncated" retry clause required `nodes.length > 0` (v0.99.9's pattern), and the "totally empty" clause required `ways.length === 0` (v0.99.10's pattern) — a response with ways present but zero tagged nodes fell through both.
- Fix: unified into a single rule — if ways were returned, any zero-edge result is implausible regardless of node count; if no ways were returned, only a fully empty response is implausible (an isolated transformer with no nearby line is legitimate and correctly does not retry).
- Verified exhaustively against all 5 reachable `(ways, nodes, edges)` combinations this time, not just the specific reported case, to avoid a fourth regression.
- Noted for the record: the public Overpass instance was also independently under heavy load at report time (user's `substation-finder` failed 3/3 times too; a live retest here hit a clean 504). Both a real logic gap and genuine current saturation were true at once — the existing recommendation to use a private `OVERPASS_ENDPOINT` for production load stands.

## Test plan
- [x] `tests/osm-grid-topology.test.js` +2 tests: retry-and-recover for ways-but-zero-nodes, and an explicit non-regression case for a legitimate isolated-node-no-ways result
- [x] `npx jest tests/osm-geo.service.test.js tests/osm-grid-topology.test.js` — 12 suites / 533 tests pass
- [x] Exhaustive manual sweep of all 5 reachable `(ways, nodes, edges)` combinations against the actual implausibility check
- [x] `npm run check:operation-capability-index`, `npm run check:llm`, `npm run audit:openapi` — all clean
- [x] `npm run check:tdd-matrix-coverage`, `npm run check:quality-gate`, `npm run audit:security` — pass (security: 2 pre-existing non-critical dependency advisories, unrelated)
- [x] GitNexus `detect_changes`: LOW risk; cross-checked scope via `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)