### PR TITLE
feat: nearest-substation fallback + padded bbox fetch, first non-zero edges (v0.99.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.14] — 2026-08-09
+
+### Added
+- **`osm-geo.gridTopology`: nearest-substation fallback for unattached distribution transformers, plus a padded Overpass fetch — the combination that finally produces real edges for both pilot areas (Hockenheim and Weinheim).** Requested explicitly after the v0.99.13 spatial-proximity model still returned `edges: 0` for Weinheim: German MS (~20kV) distribution cables are almost always underground and not mapped in OSM, but every `power=transformer` must physically be fed from *some* substation — German MS networks are predominantly radial from a local Umspannwerk. A `power=transformer` node left with zero mapped-line attachment is now paired with the nearest `power=substation` node (straight-line distance, bounded by `MAX_NEAREST_SUBSTATION_DISTANCE_M`, 5 km), tagged `evidenceType: 'nearest_substation_inferred'` (vs. `'mapped_line'` for real OSM-derived edges) so callers can tell the two apart. Deliberately **not** applied to orphaned `power=substation` nodes — pairing two substations just because they're geographically close is a much weaker assumption than the transformer→local-substation one, and could fabricate connections that don't exist.
+- **`fetchGridElements()` now pads the queried bbox by `FETCH_PADDING_M` (4 km) on every side before calling Overpass.** Live-diagnosed: Weinheim's 32 real substation/transformer nodes all happened to be tagged `power=substation` (not `transformer`), so the fallback above didn't apply to them at all until the fetch was widened — a substation's real feeding HS/EHS line, or a transformer's real nearest substation, can be just outside a caller's exact bbox purely by where the box happened to be drawn, not because the infrastructure is unmapped. Sized above the largest real gap measured in this investigation (a substation up to 3.4 km from the nearest mapped line). Live-verified after both changes: Weinheim now returns 155 nodes / 7 edges (1 mapped, 6 inferred) and Hockenheim 37 nodes / 16 edges (2 mapped, 14 inferred) — up from 0 edges each.
+
+### Testing
+- `tests/osm-grid-topology.test.js` — 10 new tests: nearest-substation fallback (pairs the nearer of two substations, respects `MAX_NEAREST_SUBSTATION_DISTANCE_M`, does not re-pair an already-connected transformer, requires at least one substation to exist, respects `voltageLevelFilter`, does not apply to orphaned substations) and `padBbox` (expands on every side, pads by approximately the requested metres, zero padding is a no-op) plus a `fetchGridElements` test confirming the padded coordinates are actually sent to Overpass.
+- Full suite: `osm-geo.service.test.js` + `osm-grid-topology.test.js` — 12 suites / 559 tests pass.
+- Live-verified against both real pilot bboxes post-fix (see above) — the first successful non-zero-edge result across this entire multi-release investigation.
+
 ## [0.99.13] — 2026-08-09
 
 ### Changed

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.13
-- changelog_latest_release: 0.99.13
+- version: 0.99.14
+- changelog_latest_release: 0.99.14
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -246,12 +246,12 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: 26ae7f2af3f4696186deeb79c835d4ed327f1ebf4302df0421d3f337fd520054
+- CHANGELOG.md: 35e72f7445c29cbca26e9d488646d347790a5d4a7d312c09da5ea62f036affa8
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: 918e89b0df5922f0dc152219ac893c829d5ec375db6414dfc85eb21683b2b090
+- openapi-export.json: 91e1d9b073a3e157dc69a7242990b0ef5e533b61cf2a91da20c8424a188d13ce
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 1025
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: c3e8a5aa68f62d3a8eeb54297714ac69ee7271678c79f09deabc8f86965f8a3a
+- llm_txt_sha256: 0fb4fc684b98bbf242e8e29278ee0e2a5795b4d69b6d2127186519b0bba897ee

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.13",
+    "version": "0.99.14",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -2470,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.13",
+  "x-version": "0.99.14",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.13",
+    "version": "0.99.14",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -91375,5 +91375,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.13"
+  "x-version": "0.99.14"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.13",
-  "sourceOpenApiHash": "918e89b0df5922f0dc152219ac893c829d5ec375db6414dfc85eb21683b2b090",
+  "packageVersion": "0.99.14",
+  "sourceOpenApiHash": "91e1d9b073a3e157dc69a7242990b0ef5e533b61cf2a91da20c8424a188d13ce",
   "coverage": {
     "rawOperationCount": 1137,
     "operationCount": 881,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.13",
+  "version": "0.99.14",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {

--- a/src/osm-grid-topology.js
+++ b/src/osm-grid-topology.js
@@ -33,6 +33,37 @@
  *            voltage plausibility (isVoltageCompatible()) — a 380kV
  *            transmission line must not connect to a low-voltage
  *            distribution transformer merely because it runs nearby.
+ *
+ *            Even proximity has a real ceiling, though: measured live for
+ *            Weinheim, the closest of 32 real substation/transformer nodes
+ *            to any real line was 60m, most were 300m–3.4km away — German
+ *            MS (~20kV) distribution cables are overwhelmingly underground
+ *            and essentially never mapped in OSM, unlike HS/EHS which are
+ *            overhead and reliably mapped. For a power=transformer node
+ *            left with zero mapped-line attachment, buildGraph() falls
+ *            back to pairing it with the nearest power=substation node
+ *            (straight-line distance, bounded by
+ *            MAX_NEAREST_SUBSTATION_DISTANCE_M) — a structural assumption
+ *            (German MS networks are predominantly radial from a local
+ *            substation), not a digitised connection. These inferred edges
+ *            are tagged `evidenceType: 'nearest_substation_inferred'`
+ *            (vs. `'mapped_line'` for the rest) so callers can tell real
+ *            OSM-derived topology apart from this approximation. This
+ *            fallback deliberately only applies to power=transformer nodes,
+ *            not orphaned power=substation nodes — a substation genuinely
+ *            not near any mapped line most likely reflects a real gap in
+ *            HS/EHS line coverage for that specific substation, and pairing
+ *            two substations just because they're geographically close is a
+ *            much weaker assumption than the transformer→local-substation
+ *            radial-network one (Weinheim's real 32 unattached nodes are, in
+ *            fact, all tagged power=substation, so this fallback does not
+ *            resolve that specific case — see FETCH_PADDING_M below for the
+ *            fix that does apply there).
+ *   fetchGridElements() also widens the queried bbox by FETCH_PADDING_M on
+ *   every side before calling Overpass, so a substation right at the edge
+ *   of the caller's bbox can still find its real feeding line (or, for the
+ *   transformer fallback, its real nearest substation) even if that
+ *   infrastructure's coordinates fall just outside the requested area.
  *   This intentionally does not model towers/poles as graph nodes — matches
  *   the coarse "which substations are grid-connected to which" question the
  *   original tool's output shape (topologyMetrics, voltageBreakdown) implies,
@@ -100,6 +131,36 @@ function bboxAreaSqKm(bbox) {
   const latKm = haversineDistanceM(bbox.south, bbox.west, bbox.north, bbox.west) / 1000;
   const lonKm = haversineDistanceM(bbox.south, bbox.west, bbox.south, bbox.east) / 1000;
   return latKm * lonKm;
+}
+
+/**
+ * Amount by which fetchGridElements() widens the queried bbox before
+ * calling Overpass. A power=substation right at the edge of the requested
+ * bbox may have its real feeding HS/EHS line — or, for the nearest-
+ * substation fallback, the actual nearest power=substation — just outside
+ * it; without padding, that connection is invisible not because it's
+ * unmapped but purely because of where the caller happened to draw the
+ * box. Sized generously above the largest real gap measured live in this
+ * investigation (Weinheim: up to 3.4km from a substation to the nearest
+ * mapped line).
+ */
+const FETCH_PADDING_M = 4000;
+
+/**
+ * Expands a bbox by a fixed distance in metres on every side.
+ * @param {{south,west,north,east}} bbox
+ * @param {number} paddingM
+ * @returns {{south,west,north,east}}
+ */
+function padBbox(bbox, paddingM) {
+  const latPad = paddingM / M_PER_DEG_LAT;
+  const lonPad = paddingM / mPerDegLon((bbox.south + bbox.north) / 2);
+  return {
+    south: bbox.south - latPad,
+    north: bbox.north + latPad,
+    west: bbox.west - lonPad,
+    east: bbox.east + lonPad,
+  };
 }
 
 // ─── Voltage classification ────────────────────────────────────────────────
@@ -232,10 +293,16 @@ function nearestPointOnWay(nodeLat, nodeLon, wayCoords) {
 /**
  * Fetches substation/transformer nodes and line/cable/minor_line ways
  * (with full node-membership lists) for a bbox in a single Overpass call.
+ * The queried bbox is widened by FETCH_PADDING_M on every side first (see
+ * its docstring) so that infrastructure just outside the caller's exact
+ * bbox is still visible for line/nearest-substation matching — the
+ * returned nodes/ways are NOT filtered back down to the original bbox.
  * @param {{south,west,north,east}} bbox
  * @returns {Promise<{nodes: Map<string, object>, ways: object[]}>}
  */
 async function fetchGridElements(bbox) {
+  const padded = padBbox(bbox, FETCH_PADDING_M);
+
   // Excludes German railway traction power lines (Bahnstrom, operated by DB
   // Energie) — out of scope for VNB/distribution-grid topology. These are
   // reliably tagged frequency=16.7 (vs. 50 Hz for the public grid) in OSM;
@@ -245,8 +312,8 @@ async function fetchGridElements(bbox) {
   const query =
     `[out:json][timeout:30];` +
     `(` +
-    `node["power"~"^(substation|transformer)$"](${bbox.south},${bbox.west},${bbox.north},${bbox.east});` +
-    `way["power"~"^(line|cable|minor_line)$"]${NON_TRACTION}(${bbox.south},${bbox.west},${bbox.north},${bbox.east});` +
+    `node["power"~"^(substation|transformer)$"](${padded.south},${padded.west},${padded.north},${padded.east});` +
+    `way["power"~"^(line|cable|minor_line)$"]${NON_TRACTION}(${padded.south},${padded.west},${padded.north},${padded.east});` +
     `);` +
     `out body;>;out skel qt;`;
 
@@ -359,6 +426,15 @@ async function fetchAndBuildGraph(bbox, voltageLevelFilter, options = {}) {
 const PROXIMITY_THRESHOLD_M = 50;
 
 /**
+ * Maximum distance for the nearest-substation fallback (see buildGraph()).
+ * Bounds how far a distribution transformer can be paired with a substation
+ * it isn't really confirmed to belong to — generously covers even a large
+ * rural MS feeder radius while refusing to pair transformers and
+ * substations in different, unrelated settlements.
+ */
+const MAX_NEAREST_SUBSTATION_DISTANCE_M = 5000;
+
+/**
  * Builds the topology graph: nodes = substation/transformer elements,
  * edges = derived from spatial proximity between topology nodes and line
  * geometry, not exact OSM node-ID membership.
@@ -458,11 +534,74 @@ function buildGraph(nodesById, ways, voltageLevelFilter) {
         ref: way.tags.ref || null,
         operator: way.tags.operator || null,
         lengthKmApprox: Number(lengthKm.toFixed(3)),
+        evidenceType: 'mapped_line',
       });
       const fromNodeRef = nodesByOsmId.get(fromNode.osmId);
       const toNodeRef = nodesByOsmId.get(toNode.osmId);
       fromNodeRef.degree += 1;
       toNodeRef.degree += 1;
+    }
+  }
+
+  // ─── Fallback: nearest-substation inference for still-isolated transformers ──
+  //
+  // MS (~20kV) distribution cables in Germany are overwhelmingly underground
+  // and essentially never mapped in OSM (unlike HS/EHS, which are overhead
+  // and reliably mapped — confirmed live for Hockenheim: 106 real, correctly
+  // tagged lines). A small distribution transformer (power=transformer) that
+  // found no real mapped-line attachment above is not actually disconnected
+  // in reality — physically, every such transformer must be fed from some
+  // substation (Umspannwerk), it's just that the connecting cable isn't in
+  // the data. The nearest power=substation node is used as a structural
+  // approximation of that real-but-unmapped connection (German MS networks
+  // are predominantly radial from a local substation), bounded by
+  // MAX_NEAREST_SUBSTATION_DISTANCE_M to avoid pairing a rural transformer
+  // with a substation towns away.
+  //
+  // This is fundamentally different evidence than a mapped_line edge — an
+  // assumption grounded in grid topology conventions, not a real digitised
+  // connection — so it's tagged evidenceType: 'nearest_substation_inferred'
+  // and callers should treat the two differently (e.g. exclude inferred
+  // edges from claims about "confirmed" OSM line coverage).
+  if (!voltageLevelFilter || voltageLevelFilter === 'MS') {
+    const substationNodes = nodes.filter((n) => n.type === 'substation');
+    if (substationNodes.length > 0) {
+      for (const node of nodes) {
+        if (node.type !== 'transformer' || node.degree > 0) continue;
+
+        let nearestSubstation = null;
+        let nearestDistanceM = Infinity;
+        for (const sub of substationNodes) {
+          const distanceM = haversineDistanceM(
+            node.location.lat,
+            node.location.lon,
+            sub.location.lat,
+            sub.location.lon
+          );
+          if (distanceM < nearestDistanceM) {
+            nearestDistanceM = distanceM;
+            nearestSubstation = sub;
+          }
+        }
+        if (!nearestSubstation || nearestDistanceM > MAX_NEAREST_SUBSTATION_DISTANCE_M) continue;
+
+        const key = [node.osmId, nearestSubstation.osmId].sort().join('|');
+        if (edgesByKey.has(key)) continue;
+
+        edgesByKey.set(key, {
+          from: node.osmId,
+          to: nearestSubstation.osmId,
+          voltageLevel: 'MS',
+          voltageVolts: null,
+          osmWayId: null,
+          ref: null,
+          operator: null,
+          lengthKmApprox: Number((nearestDistanceM / 1000).toFixed(3)),
+          evidenceType: 'nearest_substation_inferred',
+        });
+        node.degree += 1;
+        nearestSubstation.degree += 1;
+      }
     }
   }
 
@@ -618,6 +757,7 @@ function shortestPath(nodes, edges, fromOsmId, toOsmId) {
 module.exports = {
   geocodeLocationToBbox,
   bboxAreaSqKm,
+  padBbox,
   classifyVoltage,
   isVoltageCompatible,
   nearestPointOnWay,
@@ -629,5 +769,7 @@ module.exports = {
   shortestPath,
   MAX_BBOX_AREA_SQ_KM,
   PROXIMITY_THRESHOLD_M,
+  MAX_NEAREST_SUBSTATION_DISTANCE_M,
+  FETCH_PADDING_M,
   VOLTAGE_BUCKETS,
 };

--- a/tests/osm-grid-topology.test.js
+++ b/tests/osm-grid-topology.test.js
@@ -9,9 +9,11 @@
 jest.mock('axios');
 
 const axios = require('axios');
+const { haversineDistanceM } = require('../src/znp-clustering-heuristics');
 const {
   geocodeLocationToBbox,
   bboxAreaSqKm,
+  padBbox,
   classifyVoltage,
   isVoltageCompatible,
   nearestPointOnWay,
@@ -23,6 +25,8 @@ const {
   shortestPath,
   MAX_BBOX_AREA_SQ_KM,
   PROXIMITY_THRESHOLD_M,
+  MAX_NEAREST_SUBSTATION_DISTANCE_M,
+  FETCH_PADDING_M,
 } = require('../src/osm-grid-topology');
 
 beforeEach(() => {
@@ -152,6 +156,36 @@ describe('bboxAreaSqKm', () => {
 });
 
 // ---------------------------------------------------------------------------
+// padBbox — widens the fetch area so infrastructure just outside the
+// caller's exact bbox (e.g. a substation's real feeding line, or the real
+// nearest substation for the transformer fallback) is still visible.
+// ---------------------------------------------------------------------------
+describe('padBbox', () => {
+  it('expands the bbox outward on every side', () => {
+    const bbox = { south: 49.3, west: 8.5, north: 49.31, east: 8.51 };
+    const padded = padBbox(bbox, 1000);
+    expect(padded.south).toBeLessThan(bbox.south);
+    expect(padded.north).toBeGreaterThan(bbox.north);
+    expect(padded.west).toBeLessThan(bbox.west);
+    expect(padded.east).toBeGreaterThan(bbox.east);
+  });
+
+  it('pads by approximately the requested distance in metres', () => {
+    const bbox = { south: 49.3, west: 8.5, north: 49.31, east: 8.51 };
+    const padded = padBbox(bbox, 4000);
+    const latPadM = haversineDistanceM(bbox.south, bbox.west, padded.south, bbox.west);
+    expect(latPadM).toBeGreaterThan(3900);
+    expect(latPadM).toBeLessThan(4100);
+  });
+
+  it('zero padding returns the same extent', () => {
+    const bbox = { south: 49.3, west: 8.5, north: 49.31, east: 8.51 };
+    const padded = padBbox(bbox, 0);
+    expect(padded).toEqual(bbox);
+  });
+});
+
+// ---------------------------------------------------------------------------
 describe('geocodeLocationToBbox', () => {
   it('parses Nominatim boundingbox (south,north,west,east order) into {south,west,north,east}', async () => {
     axios.get.mockResolvedValueOnce({
@@ -201,6 +235,19 @@ describe('fetchGridElements', () => {
     await fetchGridElements({ south: 49.27, west: 8.48, north: 49.36, east: 8.62 });
     const [, , config] = axios.post.mock.calls[0];
     expect(config.headers['User-Agent']).toBeTruthy();
+  });
+
+  it('pads the queried bbox by FETCH_PADDING_M before sending the Overpass query (boundary-truncation fix)', async () => {
+    axios.post.mockResolvedValueOnce({ data: { elements: [] } });
+    const bbox = { south: 49.27, west: 8.48, north: 49.36, east: 8.62 };
+    await fetchGridElements(bbox);
+    const [, body] = axios.post.mock.calls[0];
+    const decoded = decodeURIComponent(body);
+    // The unpadded south/west bounds should not appear verbatim -- the
+    // query must use the widened (smaller south, smaller west) bbox.
+    expect(decoded).not.toContain(`(${bbox.south},${bbox.west},`);
+    const padded = padBbox(bbox, FETCH_PADDING_M);
+    expect(decoded).toContain(`${padded.south},${padded.west},${padded.north},${padded.east}`);
   });
 
   it('excludes German railway traction power lines (16.7 Hz / DB Energie) from the query', async () => {
@@ -351,6 +398,75 @@ describe('buildGraph', () => {
     const { edges } = buildGraph(nodesById, ehsWay, null);
     expect(edges).toHaveLength(1);
     expect(edges[0].voltageLevel).toBe('EHS');
+  });
+
+  // ─── Nearest-substation fallback (the Weinheim MS-cable-is-underground fix) ──
+  describe('nearest-substation fallback for unattached transformers', () => {
+    it('pairs a transformer with no mapped-line attachment to the nearest substation', () => {
+      const nodesById = new Map([
+        ['1', { id: 1, lat: 49.3, lon: 8.5, tags: { power: 'transformer' } }], // no nearby way at all
+        ['2', { id: 2, lat: 49.301, lon: 8.501, tags: { power: 'substation' } }], // ~130m away
+        ['3', { id: 3, lat: 49.4, lon: 8.6, tags: { power: 'substation' } }], // far away
+      ]);
+      const { nodes, edges } = buildGraph(nodesById, [], null);
+      expect(nodes).toHaveLength(3);
+      expect(edges).toHaveLength(1);
+      expect(edges[0].evidenceType).toBe('nearest_substation_inferred');
+      expect(edges[0].voltageLevel).toBe('MS');
+      expect([edges[0].from, edges[0].to]).toContain('node/1');
+      expect([edges[0].from, edges[0].to]).toContain('node/2'); // the nearer of the two substations
+    });
+
+    it('does not pair a transformer with a substation beyond MAX_NEAREST_SUBSTATION_DISTANCE_M', () => {
+      const nodesById = new Map([
+        ['1', { id: 1, lat: 49.3, lon: 8.5, tags: { power: 'transformer' } }],
+        ['2', { id: 2, lat: 49.6, lon: 8.9, tags: { power: 'substation' } }], // tens of km away
+      ]);
+      const distanceM = haversineDistanceM(49.3, 8.5, 49.6, 8.9);
+      expect(distanceM).toBeGreaterThan(MAX_NEAREST_SUBSTATION_DISTANCE_M);
+      const { edges } = buildGraph(nodesById, [], null);
+      expect(edges).toHaveLength(0);
+    });
+
+    it('does not apply the fallback to a transformer that already has a real mapped-line edge (Hockenheim case unaffected)', () => {
+      const nodesById = new Map([
+        ['1', { id: 1, lat: 49.3, lon: 8.5, tags: { power: 'transformer' } }],
+        ['2', { id: 2, lat: 49.31, lon: 8.5, tags: { power: 'transformer' } }],
+        ['3', { id: 3, lat: 49.301, lon: 8.501, tags: { power: 'substation' } }], // near node 1, but node 1 is already connected
+      ]);
+      const way = [{ id: 900, nodes: [1, 2], tags: { power: 'minor_line', voltage: '20000' } }];
+      const { edges } = buildGraph(nodesById, way, null);
+      expect(edges).toHaveLength(1);
+      expect(edges[0].evidenceType).toBe('mapped_line');
+    });
+
+    it('leaves a transformer isolated when no substation exists in the fetch at all', () => {
+      const nodesById = new Map([
+        ['1', { id: 1, lat: 49.3, lon: 8.5, tags: { power: 'transformer' } }],
+      ]);
+      const { nodes, edges } = buildGraph(nodesById, [], null);
+      expect(nodes).toHaveLength(1);
+      expect(edges).toHaveLength(0);
+    });
+
+    it('respects voltageLevelFilter: excluded when filtering for a level other than MS', () => {
+      const nodesById = new Map([
+        ['1', { id: 1, lat: 49.3, lon: 8.5, tags: { power: 'transformer' } }],
+        ['2', { id: 2, lat: 49.301, lon: 8.501, tags: { power: 'substation' } }],
+      ]);
+      expect(buildGraph(nodesById, [], 'HS').edges).toHaveLength(0);
+      expect(buildGraph(nodesById, [], 'MS').edges).toHaveLength(1);
+      expect(buildGraph(nodesById, [], null).edges).toHaveLength(1);
+    });
+
+    it('does not fall back for substations (only power=transformer nodes get the inference)', () => {
+      const nodesById = new Map([
+        ['1', { id: 1, lat: 49.3, lon: 8.5, tags: { power: 'substation' } }], // isolated, no line
+        ['2', { id: 2, lat: 49.301, lon: 8.501, tags: { power: 'substation' } }],
+      ]);
+      const { edges } = buildGraph(nodesById, [], null);
+      expect(edges).toHaveLength(0);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- v0.99.13's spatial-proximity model still returned `edges: 0` for Weinheim. Added a nearest-substation fallback per explicit request: every `power=transformer` must physically be fed from some substation (German MS distribution is predominantly radial from a local Umspannwerk), even though the connecting MS cable itself is underground and unmapped. A transformer left with zero mapped-line attachment is now paired with the nearest `power=substation` (bounded, tagged `evidenceType: 'nearest_substation_inferred'` vs `'mapped_line'`). Deliberately **not** applied to orphaned substations.
- Live-diagnosed that this alone didn't fix Weinheim: all 32 real nodes there are tagged `power=substation`, not `transformer` — the fallback never engaged. Root cause was bbox truncation: `fetchGridElements()` now pads the queried bbox by `FETCH_PADDING_M` (4km) on every side, since real feeding infrastructure can be just outside the caller's exact box purely by where it was drawn.
- **Live-verified after both changes together**: Weinheim now returns 155 nodes / 7 edges (1 mapped, 6 inferred), Hockenheim 37 nodes / 16 edges (2 mapped, 14 inferred) — the first non-zero edge result across this entire multi-release investigation, including the original `mcp.cernion.de` proxy.

## Test plan
- [x] `tests/osm-grid-topology.test.js` +10 tests: nearest-substation fallback (nearer-of-two, max-distance bound, already-connected transformer unaffected, requires a substation to exist, `voltageLevelFilter` interaction, does not apply to orphaned substations), `padBbox` (expansion, approximate metre accuracy, zero-padding no-op), and `fetchGridElements` padded-coordinates verification
- [x] `npx jest tests/osm-geo.service.test.js tests/osm-grid-topology.test.js` — 12 suites / 559 tests pass
- [x] `npm run check:operation-capability-index`, `npm run check:llm`, `npm run audit:openapi` — all clean
- [x] `npm run check:tdd-matrix-coverage`, `npm run check:quality-gate`, `npm run audit:security` — pass (security: 2 pre-existing non-critical dependency advisories, unrelated)
- [x] GitNexus `detect_changes`: LOW risk; cross-checked scope via `git status`
- [x] Live-verified against both real pilot bboxes (Hockenheim, Weinheim) post-fix — first non-zero-edge result in this investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)