### PR TITLE
feat: osm-geo.landuseAreas endpoint for sector-split load evidence (v0.99.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.15] — 2026-08-10
+
+### Added
+- **New `osm-geo.landuseAreas` action (`POST /osm-geo/landuse-areas`) — OSM `landuse=*` polygon areas by type, sector-split evidence for municipal load estimation.** Requested explicitly: `src/municipal-load-estimator.js`'s `sectorFractionsForProfile()` currently falls back to a population/density proxy (`evidenceStatus: 'heuristic-fallback'`) for the commercial/public/residential split, and its own `nextGateLabel` names the fix — "OSM-Gebäudenutzung, MaStR-Anlagenstandorte und kommunale Liegenschaften für lokalen Lastsplit verbinden." `src/osm-landuse-areas.js` fetches `landuse=residential|commercial|retail|industrial|institutional` way polygons (default set, filterable via `landuseTypes`) via the same Overpass data source and conventions as `osm-geo.gridTopology` (`location`/`postalCode`/`boundingBox` scope, same geocoding, same area guard), computing each polygon's area (shoelace formula) and centroid entirely locally — no external MCP dependency. **Scope limitation, documented rather than silently miscalculated:** only simple closed `way` polygons are handled in v1; multipolygon `relation`s (areas with excluded inner holes) are not fetched, understating totals for whichever areas happen to be relation-mapped.
+- **New `src/osm-geometry.js`** — the planar-projection geometry helpers (`projectXY`, `pointToSegment`, `bboxAreaSqKm`, `padBbox`, plus new `polygonAreaM2`/`polygonCentroid`) extracted from `src/osm-grid-topology.js` so `osm-landuse-areas.js` reuses the same local-metres projection instead of duplicating it, per this repo's shared-utility convention. `osm-grid-topology.js`'s own behavior and public API (`nearestPointOnWay`, `bboxAreaSqKm`, `padBbox`, etc.) are unchanged — pure internal refactor, verified via the full existing `osm-grid-topology`/`osm-geo.service` test suites passing unchanged.
+
+### Testing
+- `tests/osm-geometry.test.js` (new, 14 tests) — `polygonAreaM2` verified exactly against a known 100m × 100m square (10000 m² ±10m²), winding-direction independence, unclosed-ring handling, degenerate-input safety; `polygonCentroid`, `bboxAreaSqKm`, `padBbox`, `pointToSegment`, `nearestPointOnPolyline`.
+- `tests/osm-landuse-areas.test.js` (new, 11 tests) — way-polygon parsing into areas with computed area/centroid, default vs. filtered `landuseTypes` query construction, degenerate-geometry and non-way-element skipping, User-Agent header, error propagation, `summarizeLanduseAreas` aggregation.
+- `tests/osm-geo.service.test.js` extended (10 new tests) — `landuseAreas` action: scope resolution (bbox/location/postalCode, matching `gridTopology`'s conventions), `landuseTypes` enum validation, `GEOCODING_FAILED`/`AREA_TOO_BROAD`/Overpass-failure degraded responses, empty-result summary shape.
+- Full suite: `osm-geo.service.test.js` + `osm-grid-topology.test.js` + `osm-geometry.test.js` + `osm-landuse-areas.test.js` — 14 suites / 595 tests pass. `api.service.test.js` (touched for the new REST alias) — 11 suites / 974 tests pass unchanged.
+- Live-verified against the real Hockenheim bbox: 58 areas (industrial ~2.97 km², commercial ~0.86 km², retail ~0.16 km²), including the same named area ("Hägebüch") the requester's own preliminary feasibility check had found — closely matching their independent count of 59.
+
 ## [0.99.14] — 2026-08-09
 
 ### Added

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.14
-- changelog_latest_release: 0.99.14
+- version: 0.99.15
+- changelog_latest_release: 0.99.15
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -135,7 +135,7 @@ recipes:
   prosumer-nap-wallet-onboarding "A prosumer wants to onboard to a NAP Wallet and share…"
 resolve: GET /api/_agent/operations?domain=energy-sharing
 
-### grid-ops (35 capabilities · 10 recipes · 115 operations)
+### grid-ops (35 capabilities · 10 recipes · 116 operations)
 capabilities: agnes_bottleneck, anschlusskapazitaet_evidence_queue, bess_screening, capacity_contract_risk_asset_cockpit, capex_prioritization, connection_deadline_evidence_queue, connection_rejection_evidence, connection_rejection_fnav_14a_evidence, controllability_asset_handover, controllability_data_alignment, controllability_submission_cockpit, cross_channel_vnb_signal_queue, e2e_connection_check, evidence_freshness_guard, flex_forecast_bess_grid_operations_advisory, flex_strategic_demand_intake, flexibilitaetskosten_raster, fnav_commercial_hedging, fnav_fast_track_contract_gate, gas_transformation_dependency_map, ghost_asset_alert, grid_connection_transformation_gate, grid_operator_identity_resolution, legacy_control_technology_transition, mastr_asset_inventory, netzfahrplan_fnav_assessment, netzsignal_delta_gating, non_escalation_control_evidence, renewable_generation_forecast, residual_load_forecast_for_dso, schedule_management_governance_roadmap, smgw_connector_readiness_status, tech_commercial_offer_cockpit, vnb_delta_signal_classifier, vnb_special_topic_workstate
 recipes:
   direktvermarkter-portfolio "A user asks for installations managed by a direct marketer…"
@@ -246,17 +246,17 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: 35e72f7445c29cbca26e9d488646d347790a5d4a7d312c09da5ea62f036affa8
+- CHANGELOG.md: d6cf9616d25e3b5e028b6f31d6a1a887104e07743daad152b2ab4652fc48ba1d
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: 91e1d9b073a3e157dc69a7242990b0ef5e533b61cf2a91da20c8424a188d13ce
+- openapi-export.json: 91d0138191b1b474f72d813ccf844b8b7fdbfc3ab5988ea96541ac80ced0a950
 
 ## OpenAPI Surface (full contract, not embedded)
-- path_count: 1025
-- operation_count: 1137
+- path_count: 1026
+- operation_count: 1138
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 0fb4fc684b98bbf242e8e29278ee0e2a5795b4d69b6d2127186519b0bba897ee
+- llm_txt_sha256: 641fd3131c516a0d676282687a6ebd94e36101e742f02869017a5a4be9f4153c

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.14",
+    "version": "0.99.15",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -2470,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.14",
+  "x-version": "0.99.15",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.14",
+    "version": "0.99.15",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -54071,6 +54071,133 @@
         }
       }
     },
+    "/api/osm-geo/landuse-areas": {
+      "post": {
+        "operationId": "osm-geo_landuseAreas",
+        "summary": "OSM landuse areas (residential/commercial/retail/industrial/institutional)",
+        "tags": [
+          "OSM Geo (OpenStreetMap)"
+        ],
+        "responses": {
+          "200": {
+            "description": "Landuse areas and per-type summary",
+            "content": {
+              "application/json": {
+                "example": {
+                  "success": true,
+                  "data": {
+                    "areas": [
+                      {
+                        "osmId": "way/28300155",
+                        "landuseType": "industrial",
+                        "name": "Hägebüch",
+                        "areaM2Approx": 123456,
+                        "centroid": {
+                          "lat": 49.33,
+                          "lon": 8.55
+                        }
+                      }
+                    ],
+                    "summary": {
+                      "totalAreaM2ByType": {
+                        "industrial": 850000,
+                        "commercial": 210000,
+                        "retail": 95000
+                      },
+                      "areaCount": 59
+                    },
+                    "dataQuality": {
+                      "source": "© OpenStreetMap contributors (ODbL 1.0)",
+                      "disclaimer": "OSM-Daten sind freiwillig gepflegt und können unvollständig oder veraltet sein."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Fetches OSM `landuse=*` way polygons within an area and computes their area (shoelace formula on a local planar projection) and centroid locally — no external MCP dependency, same Overpass data source as osm-geo.gridTopology. Intended as sector-split evidence for municipal load/consumption estimation (area share by landuse type instead of equal distribution across a municipality). **Scope limitation:** only simple closed way polygons are handled — multipolygon relations (areas with excluded inner holes) are not fetched in v1, which understates totals for whichever areas happen to be relation-mapped rather than miscalculating them. **Scope input:** at least one of `location`, `postalCode`, or `boundingBox`.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "string",
+                    "example": "Hockenheim"
+                  },
+                  "postalCode": {
+                    "type": "string",
+                    "example": "68766"
+                  },
+                  "boundingBox": {
+                    "type": "object",
+                    "example": {
+                      "south": 49.273,
+                      "west": 8.483,
+                      "north": 49.363,
+                      "east": 8.621
+                    },
+                    "properties": {
+                      "north": {
+                        "type": "number"
+                      },
+                      "south": {
+                        "type": "number"
+                      },
+                      "east": {
+                        "type": "number"
+                      },
+                      "west": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "landuseTypes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "residential",
+                        "commercial",
+                        "retail",
+                        "industrial",
+                        "institutional"
+                      ]
+                    },
+                    "example": [
+                      "industrial",
+                      "commercial",
+                      "retail"
+                    ],
+                    "description": "Restrict to these landuse types (default: all 5 supported)."
+                  }
+                }
+              },
+              "examples": {
+                "hockenheimIndustrial": {
+                  "summary": "Industrial/commercial/retail areas for Hockenheim",
+                  "value": {
+                    "boundingBox": {
+                      "south": 49.273,
+                      "west": 8.483,
+                      "north": 49.363,
+                      "east": 8.621
+                    },
+                    "landuseTypes": [
+                      "industrial",
+                      "commercial",
+                      "retail"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/personal-agent/chat": {
       "post": {
         "operationId": "personal-agent_chat",
@@ -91375,5 +91502,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.14"
+  "x-version": "0.99.15"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,15 +1,15 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.14",
-  "sourceOpenApiHash": "91e1d9b073a3e157dc69a7242990b0ef5e533b61cf2a91da20c8424a188d13ce",
+  "packageVersion": "0.99.15",
+  "sourceOpenApiHash": "91d0138191b1b474f72d813ccf844b8b7fdbfc3ab5988ea96541ac80ced0a950",
   "coverage": {
-    "rawOperationCount": 1137,
-    "operationCount": 881,
-    "agentableCount": 879,
+    "rawOperationCount": 1138,
+    "operationCount": 882,
+    "agentableCount": 880,
     "nonAgentableCount": 2,
     "byOperationKind": {
-      "data_read": 387,
+      "data_read": 388,
       "admin": 8,
       "object_store_write": 229,
       "process_step": 20,
@@ -66787,6 +66787,106 @@
         ],
         "examples": [
           "Please energy infrastructure near a location (sorted by distance)"
+        ],
+        "synonyms": [
+          "Netzbetrieb",
+          "grid operator",
+          "VNB",
+          "distribution grid"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "osm-geo_landuseAreas",
+      "method": "POST",
+      "path": "/api/osm-geo/landuse-areas",
+      "service": "osm-geo",
+      "action": "osm-geo.landuseAreas",
+      "summary": "OSM landuse areas (residential/commercial/retail/industrial/institutional)",
+      "tags": [
+        "OSM Geo (OpenStreetMap)"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "data_read",
+      "consequenceLevel": "none",
+      "recommendedExecutionMode": "direct",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "osm-geo.landuse_areas"
+      ],
+      "domains": [
+        "grid-ops"
+      ],
+      "dataSources": [
+        "OpenStreetMap"
+      ],
+      "entityTypes": [],
+      "requiredScopes": [
+        "osm-geo:read"
+      ],
+      "tenantScoped": true,
+      "writesTo": [],
+      "sideEffects": [],
+      "idempotency": "idempotent",
+      "rollbackHint": null,
+      "parameters": {
+        "required": [],
+        "optional": [
+          {
+            "name": "location",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "postalCode",
+            "in": "body",
+            "type": "string",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "boundingBox",
+            "in": "body",
+            "type": "object",
+            "description": null,
+            "extractionHint": null
+          },
+          {
+            "name": "landuseTypes",
+            "in": "body",
+            "type": "array",
+            "description": "Restrict to these landuse types (default: all 5 supported).",
+            "extractionHint": null
+          }
+        ]
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "osm",
+          "geo",
+          "landuse",
+          "areas",
+          "(residential",
+          "commercial",
+          "retail",
+          "industrial",
+          "institutional)",
+          "(open",
+          "street",
+          "map)"
+        ],
+        "negativeCues": [
+          "spot price",
+          "energy sharing community"
+        ],
+        "examples": [
+          "Please osm landuse areas (residential/commercial/retail/industrial/institutional)"
         ],
         "synonyms": [
           "Netzbetrieb",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.14",
+  "version": "0.99.15",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {

--- a/services/api.service.js
+++ b/services/api.service.js
@@ -1747,6 +1747,7 @@ module.exports = {
           'POST /osm-geo/infrastructure-nearby': 'osm-geo.infrastructureNearby',
           'POST /osm-geo/substation-finder': 'osm-geo.substationFinder',
           'POST /osm-geo/grid-topology': 'osm-geo.gridTopology',
+          'POST /osm-geo/landuse-areas': 'osm-geo.landuseAreas',
           // Knowledge RAG (v0.39)
           'POST /knowledge-rag/query': 'knowledge-rag.query',
           'POST /knowledge-rag/semantic': 'knowledge-rag.semantic',

--- a/services/osm-geo.service.js
+++ b/services/osm-geo.service.js
@@ -14,6 +14,7 @@
 
 const CernionMCPClient = require('../src/mcp-client');
 const osmGridTopology = require('../src/osm-grid-topology');
+const osmLanduseAreas = require('../src/osm-landuse-areas');
 
 const DEFAULT_MCP_TIMEOUT_MS = 60000;
 
@@ -996,6 +997,171 @@ Returns both a detail list and **aggregated statistics**:
         }
 
         return { success: true, data };
+      },
+    },
+
+    /**
+     * Tool: landuse_areas
+     *
+     * OSM landuse=* polygon areas grouped by type — sector-split evidence
+     * for municipal load estimation (src/municipal-load-estimator.js's
+     * sectorFractionsForProfile() currently falls back to a population/
+     * density proxy; its own nextGateLabel names this as the fix).
+     *
+     * POST /api/osm-geo/landuse-areas
+     */
+    landuseAreas: {
+      rest: 'POST /landuse-areas',
+      params: {
+        location: { type: 'string', optional: true },
+        postalCode: { type: 'string', optional: true },
+        boundingBox: { type: 'object', optional: true },
+        landuseTypes: {
+          type: 'array',
+          optional: true,
+          items: { type: 'enum', values: osmLanduseAreas.DEFAULT_LANDUSE_TYPES },
+        },
+      },
+      openapi: {
+        summary: 'OSM landuse areas (residential/commercial/retail/industrial/institutional)',
+        tags: ['OSM Geo (OpenStreetMap)'],
+        description:
+          'Fetches OSM `landuse=*` way polygons within an area and computes their area ' +
+          '(shoelace formula on a local planar projection) and centroid locally — no ' +
+          'external MCP dependency, same Overpass data source as osm-geo.gridTopology. ' +
+          'Intended as sector-split evidence for municipal load/consumption estimation ' +
+          '(area share by landuse type instead of equal distribution across a municipality). ' +
+          '**Scope limitation:** only simple closed way polygons are handled — multipolygon ' +
+          'relations (areas with excluded inner holes) are not fetched in v1, which ' +
+          'understates totals for whichever areas happen to be relation-mapped rather than ' +
+          'miscalculating them. **Scope input:** at least one of `location`, `postalCode`, ' +
+          'or `boundingBox`.',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  location: { type: 'string', example: 'Hockenheim' },
+                  postalCode: { type: 'string', example: '68766' },
+                  boundingBox: {
+                    type: 'object',
+                    example: { south: 49.273, west: 8.483, north: 49.363, east: 8.621 },
+                    properties: {
+                      north: { type: 'number' },
+                      south: { type: 'number' },
+                      east: { type: 'number' },
+                      west: { type: 'number' },
+                    },
+                  },
+                  landuseTypes: {
+                    type: 'array',
+                    items: { type: 'string', enum: osmLanduseAreas.DEFAULT_LANDUSE_TYPES },
+                    example: ['industrial', 'commercial', 'retail'],
+                    description: 'Restrict to these landuse types (default: all 5 supported).',
+                  },
+                },
+              },
+              examples: {
+                hockenheimIndustrial: {
+                  summary: 'Industrial/commercial/retail areas for Hockenheim',
+                  value: {
+                    boundingBox: { south: 49.273, west: 8.483, north: 49.363, east: 8.621 },
+                    landuseTypes: ['industrial', 'commercial', 'retail'],
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: 'Landuse areas and per-type summary',
+            content: {
+              'application/json': {
+                example: {
+                  success: true,
+                  data: {
+                    areas: [
+                      {
+                        osmId: 'way/28300155',
+                        landuseType: 'industrial',
+                        name: 'Hägebüch',
+                        areaM2Approx: 123456,
+                        centroid: { lat: 49.33, lon: 8.55 },
+                      },
+                    ],
+                    summary: {
+                      totalAreaM2ByType: { industrial: 850000, commercial: 210000, retail: 95000 },
+                      areaCount: 59,
+                    },
+                    dataQuality: {
+                      source: '© OpenStreetMap contributors (ODbL 1.0)',
+                      disclaimer:
+                        'OSM-Daten sind freiwillig gepflegt und können unvollständig oder veraltet sein.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      async handler(ctx) {
+        const { location, postalCode, boundingBox, landuseTypes } = ctx.params;
+        if (!location && !postalCode && !boundingBox) {
+          throw new Error('At least one scope parameter must be provided: location, postalCode, or boundingBox.');
+        }
+
+        let bbox;
+        let area;
+        let scopeSource;
+        if (boundingBox) {
+          bbox = boundingBox;
+          area = 'bbox';
+          scopeSource = 'explicit_bbox';
+        } else {
+          const locationName = postalCode && location ? `${postalCode} ${location}` : postalCode || location;
+          try {
+            bbox = await osmGridTopology.geocodeLocationToBbox(locationName);
+          } catch (err) {
+            return _degraded(_classifyDegradedReason(err.message), err.message);
+          }
+          if (!bbox) {
+            return _degraded('GEOCODING_FAILED', `Could not resolve "${locationName}" to a bounding box.`);
+          }
+          area = locationName;
+          scopeSource = postalCode ? 'postal_code' : 'location_name';
+        }
+
+        if (osmLanduseAreas.bboxAreaSqKm(bbox) > osmLanduseAreas.MAX_BBOX_AREA_SQ_KM) {
+          return _degraded(
+            'AREA_TOO_BROAD',
+            `Bounding box exceeds ${osmLanduseAreas.MAX_BBOX_AREA_SQ_KM} km² — narrow the query scope.`
+          );
+        }
+
+        let areas;
+        try {
+          areas = await osmLanduseAreas.fetchLanduseAreas(bbox, landuseTypes);
+        } catch (err) {
+          return _degraded(_classifyDegradedReason(err.message), err.message);
+        }
+
+        return {
+          success: true,
+          data: {
+            area,
+            scopeSource,
+            areas,
+            summary: osmLanduseAreas.summarizeLanduseAreas(areas),
+            dataQuality: {
+              source: '© OpenStreetMap contributors (ODbL 1.0)',
+              disclaimer:
+                'OSM-Daten sind freiwillig gepflegt und können unvollständig oder veraltet sein.',
+            },
+          },
+        };
       },
     },
   },

--- a/src/osm-geometry.js
+++ b/src/osm-geometry.js
@@ -1,0 +1,153 @@
+'use strict';
+
+/**
+ * Shared planar-projection geometry helpers for OSM-derived spatial
+ * analysis. Extracted from src/osm-grid-topology.js when src/osm-landuse-
+ * areas.js needed the same local-metres projection for polygon area
+ * calculation, rather than duplicating it (per this repo's shared-utility
+ * convention — see CLAUDE.md).
+ *
+ * All functions use an equirectangular (locally-flat) approximation around
+ * a reference latitude — accurate to well under 1% error at the few-
+ * kilometre scale of a single municipality query, which is more than
+ * sufficient for the tens-of-metres proximity thresholds and polygon areas
+ * these modules work with. Not suitable for country-scale geometry.
+ */
+
+const { haversineDistanceM } = require('./znp-clustering-heuristics');
+
+/** Metres per degree of latitude (approx, standard WGS84 mid-latitude value). */
+const M_PER_DEG_LAT = 110540;
+
+/** Metres per degree of longitude at a given reference latitude. */
+function mPerDegLon(refLatDeg) {
+  return 111320 * Math.cos((refLatDeg * Math.PI) / 180);
+}
+
+/**
+ * Projects a lat/lon point to local planar metres around a reference
+ * latitude.
+ * @param {number} lat @param {number} lon @param {number} refLat
+ * @returns {{x: number, y: number}}
+ */
+function projectXY(lat, lon, refLat) {
+  return { x: lon * mPerDegLon(refLat), y: lat * M_PER_DEG_LAT };
+}
+
+/**
+ * Minimum distance from point P to segment AB (all in planar metres), plus
+ * how far along AB (in metres from A) the closest point falls.
+ * @returns {{distanceM: number, alongM: number}}
+ */
+function pointToSegment(px, py, ax, ay, bx, by) {
+  const abx = bx - ax;
+  const aby = by - ay;
+  const segLenSq = abx * abx + aby * aby;
+  let t = segLenSq > 0 ? ((px - ax) * abx + (py - ay) * aby) / segLenSq : 0;
+  t = Math.max(0, Math.min(1, t));
+  const cx = ax + t * abx;
+  const cy = ay + t * aby;
+  const dx = px - cx;
+  const dy = py - cy;
+  return { distanceM: Math.sqrt(dx * dx + dy * dy), alongM: t * Math.sqrt(segLenSq) };
+}
+
+/**
+ * Finds the closest point on a resolved polyline to a given location,
+ * returning the perpendicular distance and the cumulative distance along
+ * the polyline from its start to that point.
+ * @param {number} lat @param {number} lon
+ * @param {Array<{lat:number, lon:number}>} coords  Resolved polyline, >= 2 points.
+ * @returns {{distanceM: number, alongM: number}}
+ */
+function nearestPointOnPolyline(lat, lon, coords) {
+  const refLat = coords[0].lat;
+  const p = projectXY(lat, lon, refLat);
+
+  let best = null;
+  let cumulativeM = 0;
+  for (let i = 0; i < coords.length - 1; i++) {
+    const a = projectXY(coords[i].lat, coords[i].lon, refLat);
+    const b = projectXY(coords[i + 1].lat, coords[i + 1].lon, refLat);
+    const { distanceM, alongM } = pointToSegment(p.x, p.y, a.x, a.y, b.x, b.y);
+    const totalAlongM = cumulativeM + alongM;
+    if (!best || distanceM < best.distanceM) best = { distanceM, alongM: totalAlongM };
+    cumulativeM += Math.hypot(b.x - a.x, b.y - a.y);
+  }
+  return best;
+}
+
+/**
+ * Area of a closed polygon ring in square metres, via the shoelace formula
+ * on the locally-projected coordinates. The ring does not need to be
+ * explicitly closed (first point repeated as last) — this handles both.
+ * @param {Array<{lat:number, lon:number}>} coords
+ * @returns {number} area in m^2 (always >= 0)
+ */
+function polygonAreaM2(coords) {
+  if (!coords || coords.length < 3) return 0;
+  const refLat = coords[0].lat;
+  const points = coords.map((c) => projectXY(c.lat, c.lon, refLat));
+
+  let sum = 0;
+  for (let i = 0; i < points.length; i++) {
+    const a = points[i];
+    const b = points[(i + 1) % points.length];
+    sum += a.x * b.y - b.x * a.y;
+  }
+  return Math.abs(sum) / 2;
+}
+
+/**
+ * Centroid of a polygon ring (simple coordinate average — adequate for a
+ * representative point label, not an area-weighted geometric centroid).
+ * @param {Array<{lat:number, lon:number}>} coords
+ * @returns {{lat: number, lon: number}|null}
+ */
+function polygonCentroid(coords) {
+  if (!coords || coords.length === 0) return null;
+  const sum = coords.reduce(
+    (acc, c) => ({ lat: acc.lat + c.lat, lon: acc.lon + c.lon }),
+    { lat: 0, lon: 0 }
+  );
+  return { lat: sum.lat / coords.length, lon: sum.lon / coords.length };
+}
+
+/**
+ * @param {{south,west,north,east}} bbox
+ * @returns {number} approximate area in km^2
+ */
+function bboxAreaSqKm(bbox) {
+  const latKm = haversineDistanceM(bbox.south, bbox.west, bbox.north, bbox.west) / 1000;
+  const lonKm = haversineDistanceM(bbox.south, bbox.west, bbox.south, bbox.east) / 1000;
+  return latKm * lonKm;
+}
+
+/**
+ * Expands a bbox by a fixed distance in metres on every side.
+ * @param {{south,west,north,east}} bbox
+ * @param {number} paddingM
+ * @returns {{south,west,north,east}}
+ */
+function padBbox(bbox, paddingM) {
+  const latPad = paddingM / M_PER_DEG_LAT;
+  const lonPad = paddingM / mPerDegLon((bbox.south + bbox.north) / 2);
+  return {
+    south: bbox.south - latPad,
+    north: bbox.north + latPad,
+    west: bbox.west - lonPad,
+    east: bbox.east + lonPad,
+  };
+}
+
+module.exports = {
+  M_PER_DEG_LAT,
+  mPerDegLon,
+  projectXY,
+  pointToSegment,
+  nearestPointOnPolyline,
+  polygonAreaM2,
+  polygonCentroid,
+  bboxAreaSqKm,
+  padBbox,
+};

--- a/src/osm-grid-topology.js
+++ b/src/osm-grid-topology.js
@@ -79,6 +79,7 @@
 
 const axios = require('axios');
 const { haversineDistanceM } = require('./znp-clustering-heuristics');
+const { nearestPointOnPolyline, bboxAreaSqKm, padBbox } = require('./osm-geometry');
 
 const OVERPASS_ENDPOINT =
   process.env.OVERPASS_ENDPOINT || 'https://overpass-api.de/api/interpreter';
@@ -124,16 +125,6 @@ async function geocodeLocationToBbox(locationName) {
 }
 
 /**
- * @param {{south,west,north,east}} bbox
- * @returns {number} approximate area in km^2
- */
-function bboxAreaSqKm(bbox) {
-  const latKm = haversineDistanceM(bbox.south, bbox.west, bbox.north, bbox.west) / 1000;
-  const lonKm = haversineDistanceM(bbox.south, bbox.west, bbox.south, bbox.east) / 1000;
-  return latKm * lonKm;
-}
-
-/**
  * Amount by which fetchGridElements() widens the queried bbox before
  * calling Overpass. A power=substation right at the edge of the requested
  * bbox may have its real feeding HS/EHS line — or, for the nearest-
@@ -145,23 +136,6 @@ function bboxAreaSqKm(bbox) {
  * mapped line).
  */
 const FETCH_PADDING_M = 4000;
-
-/**
- * Expands a bbox by a fixed distance in metres on every side.
- * @param {{south,west,north,east}} bbox
- * @param {number} paddingM
- * @returns {{south,west,north,east}}
- */
-function padBbox(bbox, paddingM) {
-  const latPad = paddingM / M_PER_DEG_LAT;
-  const lonPad = paddingM / mPerDegLon((bbox.south + bbox.north) / 2);
-  return {
-    south: bbox.south - latPad,
-    north: bbox.north + latPad,
-    west: bbox.west - lonPad,
-    east: bbox.east + lonPad,
-  };
-}
 
 // ─── Voltage classification ────────────────────────────────────────────────
 
@@ -223,69 +197,19 @@ function isVoltageCompatible(nodeVoltageLevel, nodeType, wayVoltageLevel) {
 }
 
 // ─── Spatial geometry helpers ───────────────────────────────────────────────
-
-/** Metres per degree of latitude (approx, standard WGS84 mid-latitude value). */
-const M_PER_DEG_LAT = 110540;
-
-/** Metres per degree of longitude at a given reference latitude. */
-function mPerDegLon(refLatDeg) {
-  return 111320 * Math.cos((refLatDeg * Math.PI) / 180);
-}
+// The actual projection/distance math lives in src/osm-geometry.js, shared
+// with src/osm-landuse-areas.js (polygon area calculation needs the same
+// local-metres projection). nearestPointOnWay is kept as a name/param-order
+// compatible wrapper around nearestPointOnPolyline since it's part of this
+// module's existing public API (services/osm-geo.service.js, tests).
 
 /**
- * Projects a lat/lon point to local planar metres around a reference
- * latitude (equirectangular approximation — accurate to well under 1% error
- * at the few-kilometre scale of a single municipality query, more than
- * sufficient for a tens-of-metres proximity threshold).
- * @param {number} lat @param {number} lon @param {number} refLat
- * @returns {{x: number, y: number}}
- */
-function projectXY(lat, lon, refLat) {
-  return { x: lon * mPerDegLon(refLat), y: lat * M_PER_DEG_LAT };
-}
-
-/**
- * Minimum distance from point P to segment AB (all in planar metres), plus
- * how far along AB (in metres from A) the closest point falls.
- * @returns {{distanceM: number, alongM: number}}
- */
-function pointToSegment(px, py, ax, ay, bx, by) {
-  const abx = bx - ax;
-  const aby = by - ay;
-  const segLenSq = abx * abx + aby * aby;
-  let t = segLenSq > 0 ? ((px - ax) * abx + (py - ay) * aby) / segLenSq : 0;
-  t = Math.max(0, Math.min(1, t));
-  const cx = ax + t * abx;
-  const cy = ay + t * aby;
-  const dx = px - cx;
-  const dy = py - cy;
-  return { distanceM: Math.sqrt(dx * dx + dy * dy), alongM: t * Math.sqrt(segLenSq) };
-}
-
-/**
- * Finds the closest point on a resolved way polyline to a given node
- * location, returning the perpendicular distance and the cumulative
- * distance along the polyline from its start to that point (used to order
- * multiple attached nodes correctly along the same way).
  * @param {number} nodeLat @param {number} nodeLon
  * @param {Array<{lat:number, lon:number}>} wayCoords  Resolved way geometry, >= 2 points.
  * @returns {{distanceM: number, alongM: number}}
  */
 function nearestPointOnWay(nodeLat, nodeLon, wayCoords) {
-  const refLat = wayCoords[0].lat;
-  const p = projectXY(nodeLat, nodeLon, refLat);
-
-  let best = null;
-  let cumulativeM = 0;
-  for (let i = 0; i < wayCoords.length - 1; i++) {
-    const a = projectXY(wayCoords[i].lat, wayCoords[i].lon, refLat);
-    const b = projectXY(wayCoords[i + 1].lat, wayCoords[i + 1].lon, refLat);
-    const { distanceM, alongM } = pointToSegment(p.x, p.y, a.x, a.y, b.x, b.y);
-    const totalAlongM = cumulativeM + alongM;
-    if (!best || distanceM < best.distanceM) best = { distanceM, alongM: totalAlongM };
-    cumulativeM += Math.hypot(b.x - a.x, b.y - a.y);
-  }
-  return best;
+  return nearestPointOnPolyline(nodeLat, nodeLon, wayCoords);
 }
 
 // ─── Overpass fetch ─────────────────────────────────────────────────────────

--- a/src/osm-landuse-areas.js
+++ b/src/osm-landuse-areas.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/**
+ * OSM Landuse Areas — sector-split evidence for municipal load estimation.
+ *
+ * Background: src/municipal-load-estimator.js's sectorFractionsForProfile()
+ * currently derives the commercial/public/residential load split purely
+ * from population and density (evidenceStatus: 'heuristic-fallback'), and
+ * its own nextGateLabel names the fix: "OSM-Gebäudenutzung, MaStR-
+ * Anlagenstandorte und kommunale Liegenschaften für lokalen Lastsplit
+ * verbinden." This module is that OSM building-usage evidence source —
+ * OSM landuse=* polygon areas grouped by type, for a caller (e.g.
+ * CernionGIS) to weight a municipality-wide value by area share instead of
+ * equal distribution.
+ *
+ * Same Overpass data source and User-Agent/query conventions as
+ * src/osm-grid-topology.js and src/znp-osm-buildings.js; shares the
+ * planar-projection geometry helpers in src/osm-geometry.js (polygon area
+ * via the shoelace formula on a local equirectangular projection —
+ * verified against a known 100m x 100m square before use).
+ *
+ * Scope limitation: only simple closed `way` polygons are handled. OSM
+ * also allows landuse areas mapped as multipolygon `relation`s (a way with
+ * excluded inner rings/holes, or multiple disjoint outer rings) — these are
+ * real but rarer for the residential/commercial/retail/industrial/
+ * institutional categories relevant here, and are not fetched or counted
+ * in v1. Their absence understates totalAreaM2ByType for whichever areas
+ * happen to be relation-mapped, not a silent miscalculation.
+ */
+
+const axios = require('axios');
+const { polygonAreaM2, polygonCentroid, bboxAreaSqKm } = require('./osm-geometry');
+
+const OVERPASS_ENDPOINT =
+  process.env.OVERPASS_ENDPOINT || 'https://overpass-api.de/api/interpreter';
+const REQUEST_TIMEOUT_MS = 30000;
+const USER_AGENT = 'cernion-energy-tools/osm-landuse-areas (+https://cernion.energy)';
+
+/** Bbox area guard — protects the public Overpass instance from oversized queries. */
+const MAX_BBOX_AREA_SQ_KM = 2500; // ~50km x 50km
+
+/**
+ * Default landuse categories fetched when the caller doesn't restrict via
+ * landuseTypes — the OSM tags relevant to the residential/commercial/
+ * public sector split used by municipal-load-estimator.js.
+ */
+const DEFAULT_LANDUSE_TYPES = [
+  'residential',
+  'commercial',
+  'retail',
+  'industrial',
+  'institutional',
+];
+
+/**
+ * Fetches OSM landuse=* way polygons within a bbox and computes their area
+ * and centroid locally (no separate node-resolution pass needed — Overpass
+ * `out geom` inlines full-resolution coordinates per way).
+ * @param {{south,west,north,east}} bbox
+ * @param {string[]} [landuseTypes]  Restrict to these landuse values; defaults to DEFAULT_LANDUSE_TYPES.
+ * @returns {Promise<object[]>} areas
+ */
+async function fetchLanduseAreas(bbox, landuseTypes) {
+  const types =
+    Array.isArray(landuseTypes) && landuseTypes.length ? landuseTypes : DEFAULT_LANDUSE_TYPES;
+  const typePattern = types.map((t) => t.replace(/[^a-z_]/gi, '')).join('|');
+
+  const query =
+    `[out:json][timeout:30];` +
+    `way["landuse"~"^(${typePattern})$"](${bbox.south},${bbox.west},${bbox.north},${bbox.east});` +
+    `out geom;`;
+
+  const response = await axios.post(OVERPASS_ENDPOINT, `data=${encodeURIComponent(query)}`, {
+    timeout: REQUEST_TIMEOUT_MS + 5000,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': USER_AGENT,
+    },
+  });
+
+  const elements = response.data?.elements || [];
+  const areas = [];
+  for (const el of elements) {
+    if (el.type !== 'way' || !Array.isArray(el.geometry) || el.geometry.length < 3) continue;
+    const coords = el.geometry
+      .filter((g) => g && g.lat != null && g.lon != null)
+      .map((g) => ({ lat: g.lat, lon: g.lon }));
+    if (coords.length < 3) continue;
+
+    areas.push({
+      osmId: `way/${el.id}`,
+      landuseType: el.tags?.landuse || null,
+      name: el.tags?.name || null,
+      areaM2Approx: Math.round(polygonAreaM2(coords)),
+      centroid: polygonCentroid(coords),
+    });
+  }
+  return areas;
+}
+
+/**
+ * Aggregates a landuse area list into per-type totals.
+ * @param {object[]} areas
+ * @returns {{totalAreaM2ByType: Record<string, number>, areaCount: number}}
+ */
+function summarizeLanduseAreas(areas) {
+  const totalAreaM2ByType = {};
+  for (const area of areas) {
+    const key = area.landuseType || 'unknown';
+    totalAreaM2ByType[key] = (totalAreaM2ByType[key] || 0) + area.areaM2Approx;
+  }
+  return { totalAreaM2ByType, areaCount: areas.length };
+}
+
+module.exports = {
+  DEFAULT_LANDUSE_TYPES,
+  MAX_BBOX_AREA_SQ_KM,
+  fetchLanduseAreas,
+  summarizeLanduseAreas,
+  bboxAreaSqKm,
+};

--- a/tests/osm-geo.service.test.js
+++ b/tests/osm-geo.service.test.js
@@ -46,6 +46,33 @@ const GRID_TOPOLOGY_OVERPASS_FIXTURE = {
   ],
 };
 
+const LANDUSE_OVERPASS_FIXTURE = {
+  elements: [
+    {
+      type: 'way',
+      id: 28300155,
+      tags: { landuse: 'industrial', name: 'Hägebüch' },
+      geometry: [
+        { lat: 49.33, lon: 8.55 },
+        { lat: 49.33, lon: 8.551 },
+        { lat: 49.331, lon: 8.551 },
+        { lat: 49.331, lon: 8.55 },
+      ],
+    },
+    {
+      type: 'way',
+      id: 28300156,
+      tags: { landuse: 'retail' },
+      geometry: [
+        { lat: 49.34, lon: 8.56 },
+        { lat: 49.34, lon: 8.5605 },
+        { lat: 49.3405, lon: 8.5605 },
+        { lat: 49.3405, lon: 8.56 },
+      ],
+    },
+  ],
+};
+
 describe('OSM Geo Service', () => {
   let broker;
 
@@ -494,6 +521,107 @@ describe('OSM Geo Service', () => {
       expect(result.data.topologyMetrics.edges).toBe(0);
       expect(result.data.dataQuality.osmEdgeCoverageEstimate).toBeNull();
       expect(result.data.dataQuality.warning).not.toMatch(/0% in OSM erfasst/);
+    });
+  });
+
+  // ─── landuseAreas ────────────────────────────────────────────────────────────
+
+  describe('landuseAreas action', () => {
+    it('should be defined', () => {
+      expect(broker.getLocalService('osm-geo').schema.actions.landuseAreas).toBeDefined();
+    });
+
+    it('should have correct REST endpoint', () => {
+      const action = broker.getLocalService('osm-geo').schema.actions.landuseAreas;
+      expect(action.rest).toBe('POST /landuse-areas');
+    });
+
+    it('should reject when no scope parameter is provided', async () => {
+      await expect(broker.call('osm-geo.landuseAreas', {})).rejects.toThrow();
+    });
+
+    it('returns areas and a per-type summary for an explicit boundingBox', async () => {
+      axios.post.mockResolvedValueOnce({ data: LANDUSE_OVERPASS_FIXTURE });
+      const result = await broker.call('osm-geo.landuseAreas', {
+        boundingBox: { north: 49.363, south: 49.273, east: 8.621, west: 8.483 },
+        landuseTypes: ['industrial', 'retail'],
+      });
+      expect(result.success).toBe(true);
+      expect(result.data.scopeSource).toBe('explicit_bbox');
+      expect(result.data.areas).toHaveLength(2);
+      expect(result.data.areas[0].osmId).toBe('way/28300155');
+      expect(result.data.areas[0].name).toBe('Hägebüch');
+      expect(result.data.summary.areaCount).toBe(2);
+      expect(result.data.summary.totalAreaM2ByType).toHaveProperty('industrial');
+      expect(result.data.summary.totalAreaM2ByType).toHaveProperty('retail');
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+
+    it('geocodes a location name via Nominatim before querying Overpass', async () => {
+      axios.get.mockResolvedValueOnce({ data: NOMINATIM_SEARCH_FIXTURE });
+      axios.post.mockResolvedValueOnce({ data: LANDUSE_OVERPASS_FIXTURE });
+      const result = await broker.call('osm-geo.landuseAreas', { location: 'Hockenheim' });
+      expect(result.success).toBe(true);
+      expect(result.data.scopeSource).toBe('location_name');
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('nominatim'),
+        expect.objectContaining({ params: expect.objectContaining({ q: 'Hockenheim' }) })
+      );
+    });
+
+    it('combines postalCode + location the same way as gridTopology/substationFinder', async () => {
+      axios.get.mockResolvedValueOnce({ data: NOMINATIM_SEARCH_FIXTURE });
+      axios.post.mockResolvedValueOnce({ data: { elements: [] } });
+      await broker.call('osm-geo.landuseAreas', { location: 'Meckesheim', postalCode: '74909' });
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('nominatim'),
+        expect.objectContaining({ params: expect.objectContaining({ q: '74909 Meckesheim' }) })
+      );
+    });
+
+    it('rejects an unsupported landuseTypes value (enum validation)', async () => {
+      await expect(
+        broker.call('osm-geo.landuseAreas', {
+          boundingBox: { north: 49.363, south: 49.273, east: 8.621, west: 8.483 },
+          landuseTypes: ['forest'],
+        })
+      ).rejects.toThrow();
+    });
+
+    it('returns GEOCODING_FAILED when Nominatim finds no match', async () => {
+      axios.get.mockResolvedValueOnce({ data: [] });
+      const result = await broker.call('osm-geo.landuseAreas', {
+        location: 'NichtExistierenderOrtXYZ',
+      });
+      expect(result.success).toBe(false);
+      expect(result.degradedReason).toBe('GEOCODING_FAILED');
+    });
+
+    it('rejects bounding boxes larger than the area guard', async () => {
+      const result = await broker.call('osm-geo.landuseAreas', {
+        boundingBox: { north: 55, south: 47, east: 15, west: 5 },
+      });
+      expect(result.success).toBe(false);
+      expect(result.degradedReason).toBe('AREA_TOO_BROAD');
+    });
+
+    it('returns a degraded response when Overpass fails', async () => {
+      axios.post.mockRejectedValueOnce(new Error('OVERPASS_TIMEOUT: query stalled'));
+      const result = await broker.call('osm-geo.landuseAreas', {
+        boundingBox: { north: 49.363, south: 49.273, east: 8.621, west: 8.483 },
+      });
+      expect(result.success).toBe(false);
+      expect(result.degradedReason).toBe('OVERPASS_TIMEOUT');
+    });
+
+    it('returns an empty areas list with a zero-count summary when nothing is found', async () => {
+      axios.post.mockResolvedValueOnce({ data: { elements: [] } });
+      const result = await broker.call('osm-geo.landuseAreas', {
+        boundingBox: { north: 49.363, south: 49.273, east: 8.621, west: 8.483 },
+      });
+      expect(result.success).toBe(true);
+      expect(result.data.areas).toEqual([]);
+      expect(result.data.summary).toEqual({ totalAreaM2ByType: {}, areaCount: 0 });
     });
   });
 

--- a/tests/osm-geometry.test.js
+++ b/tests/osm-geometry.test.js
@@ -1,0 +1,153 @@
+'use strict';
+
+/**
+ * Tests for src/osm-geometry.js — shared planar-projection geometry helpers
+ * used by src/osm-grid-topology.js and src/osm-landuse-areas.js.
+ */
+
+const {
+  projectXY,
+  pointToSegment,
+  nearestPointOnPolyline,
+  polygonAreaM2,
+  polygonCentroid,
+  bboxAreaSqKm,
+  padBbox,
+  M_PER_DEG_LAT,
+  mPerDegLon,
+} = require('../src/osm-geometry');
+
+describe('projectXY / mPerDegLon', () => {
+  it('increases x with longitude and y with latitude', () => {
+    const a = projectXY(49.3, 8.5, 49.3);
+    const b = projectXY(49.3, 8.51, 49.3);
+    const c = projectXY(49.31, 8.5, 49.3);
+    expect(b.x).toBeGreaterThan(a.x);
+    expect(c.y).toBeGreaterThan(a.y);
+  });
+
+  it('mPerDegLon shrinks toward the poles (cosine falloff)', () => {
+    expect(mPerDegLon(0)).toBeCloseTo(111320, 0);
+    expect(mPerDegLon(60)).toBeCloseTo(111320 * 0.5, 0);
+  });
+});
+
+describe('pointToSegment', () => {
+  it('returns 0 distance for a point on the segment', () => {
+    const { distanceM } = pointToSegment(5, 0, 0, 0, 10, 0);
+    expect(distanceM).toBeCloseTo(0, 5);
+  });
+
+  it('clamps the projection to the segment endpoints', () => {
+    const { alongM } = pointToSegment(-5, 3, 0, 0, 10, 0);
+    expect(alongM).toBe(0); // clamped to A, not extrapolated to -5
+  });
+});
+
+describe('nearestPointOnPolyline', () => {
+  it('finds 0 distance for a point exactly on a vertex', () => {
+    const coords = [
+      { lat: 49.3, lon: 8.5 },
+      { lat: 49.31, lon: 8.5 },
+    ];
+    const result = nearestPointOnPolyline(49.3, 8.5, coords);
+    expect(result.distanceM).toBeLessThan(1);
+  });
+});
+
+describe('polygonAreaM2', () => {
+  it('computes the exact area of a known 100m x 100m square', () => {
+    const lat0 = 49.3;
+    const lon0 = 8.5;
+    const dLat = 100 / M_PER_DEG_LAT;
+    const dLon = 100 / mPerDegLon(lat0);
+    const square = [
+      { lat: lat0, lon: lon0 },
+      { lat: lat0, lon: lon0 + dLon },
+      { lat: lat0 + dLat, lon: lon0 + dLon },
+      { lat: lat0 + dLat, lon: lon0 },
+    ];
+    expect(polygonAreaM2(square)).toBeCloseTo(10000, -1); // within ~10m^2
+  });
+
+  it('is unaffected by winding direction (clockwise vs counter-clockwise)', () => {
+    const lat0 = 49.3;
+    const lon0 = 8.5;
+    const dLat = 50 / M_PER_DEG_LAT;
+    const dLon = 50 / mPerDegLon(lat0);
+    const cw = [
+      { lat: lat0, lon: lon0 },
+      { lat: lat0 + dLat, lon: lon0 },
+      { lat: lat0 + dLat, lon: lon0 + dLon },
+      { lat: lat0, lon: lon0 + dLon },
+    ];
+    const ccw = [...cw].reverse();
+    expect(polygonAreaM2(cw)).toBeCloseTo(polygonAreaM2(ccw), 1);
+  });
+
+  it('returns 0 for fewer than 3 points or empty input', () => {
+    expect(polygonAreaM2([])).toBe(0);
+    expect(polygonAreaM2([{ lat: 0, lon: 0 }])).toBe(0);
+    expect(polygonAreaM2([{ lat: 0, lon: 0 }, { lat: 1, lon: 1 }])).toBe(0);
+  });
+
+  it('handles a ring that is not explicitly closed (first point not repeated as last)', () => {
+    const lat0 = 49.3;
+    const lon0 = 8.5;
+    const dLat = 100 / M_PER_DEG_LAT;
+    const dLon = 100 / mPerDegLon(lat0);
+    const openRing = [
+      { lat: lat0, lon: lon0 },
+      { lat: lat0, lon: lon0 + dLon },
+      { lat: lat0 + dLat, lon: lon0 + dLon },
+      { lat: lat0 + dLat, lon: lon0 },
+    ];
+    const closedRing = [...openRing, openRing[0]];
+    expect(polygonAreaM2(openRing)).toBeCloseTo(polygonAreaM2(closedRing), 1);
+  });
+});
+
+describe('polygonCentroid', () => {
+  it('returns the coordinate average of the ring', () => {
+    const square = [
+      { lat: 49.3, lon: 8.5 },
+      { lat: 49.3, lon: 8.502 },
+      { lat: 49.302, lon: 8.502 },
+      { lat: 49.302, lon: 8.5 },
+    ];
+    const centroid = polygonCentroid(square);
+    expect(centroid.lat).toBeCloseTo(49.301, 3);
+    expect(centroid.lon).toBeCloseTo(8.501, 3);
+  });
+
+  it('returns null for an empty ring', () => {
+    expect(polygonCentroid([])).toBeNull();
+  });
+});
+
+describe('bboxAreaSqKm', () => {
+  it('computes a plausible area for a ~10km x 10km bbox', () => {
+    const area = bboxAreaSqKm({ south: 49.273, west: 8.483, north: 49.363, east: 8.621 });
+    expect(area).toBeGreaterThan(50);
+    expect(area).toBeLessThan(150);
+  });
+});
+
+describe('padBbox', () => {
+  it('expands the bbox outward on every side by approximately the requested metres', () => {
+    const bbox = { south: 49.3, west: 8.5, north: 49.31, east: 8.51 };
+    const padded = padBbox(bbox, 2000);
+    expect(padded.south).toBeLessThan(bbox.south);
+    expect(padded.north).toBeGreaterThan(bbox.north);
+    expect(padded.west).toBeLessThan(bbox.west);
+    expect(padded.east).toBeGreaterThan(bbox.east);
+    const latPadM = (bbox.south - padded.south) * M_PER_DEG_LAT;
+    expect(latPadM).toBeGreaterThan(1900);
+    expect(latPadM).toBeLessThan(2100);
+  });
+
+  it('zero padding is a no-op', () => {
+    const bbox = { south: 49.3, west: 8.5, north: 49.31, east: 8.51 };
+    expect(padBbox(bbox, 0)).toEqual(bbox);
+  });
+});

--- a/tests/osm-landuse-areas.test.js
+++ b/tests/osm-landuse-areas.test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+/**
+ * Tests for src/osm-landuse-areas.js — OSM landuse=* polygon area extraction,
+ * sector-split evidence for src/municipal-load-estimator.js (see its
+ * nextGateLabel: "OSM-Gebäudenutzung ... für lokalen Lastsplit verbinden.").
+ */
+
+jest.mock('axios');
+
+const axios = require('axios');
+const {
+  DEFAULT_LANDUSE_TYPES,
+  MAX_BBOX_AREA_SQ_KM,
+  fetchLanduseAreas,
+  summarizeLanduseAreas,
+  bboxAreaSqKm,
+} = require('../src/osm-landuse-areas');
+
+beforeEach(() => {
+  axios.post.mockReset();
+});
+
+const HOCKENHEIM_BBOX = { south: 49.273, west: 8.483, north: 49.363, east: 8.621 };
+
+// A small square way, real Overpass `out geom` shape: geometry inlines
+// {lat, lon} per node directly on the way, no separate node resolution.
+function squareWay(id, landuseType, name, lat0, lon0, sizeDeg) {
+  return {
+    type: 'way',
+    id,
+    tags: { landuse: landuseType, ...(name ? { name } : {}) },
+    geometry: [
+      { lat: lat0, lon: lon0 },
+      { lat: lat0, lon: lon0 + sizeDeg },
+      { lat: lat0 + sizeDeg, lon: lon0 + sizeDeg },
+      { lat: lat0 + sizeDeg, lon: lon0 },
+    ],
+  };
+}
+
+describe('fetchLanduseAreas', () => {
+  it('parses way polygons into areas with computed areaM2Approx and centroid', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: {
+        elements: [squareWay(1, 'industrial', 'Hägebüch', 49.33, 8.55, 0.001)],
+      },
+    });
+    const areas = await fetchLanduseAreas(HOCKENHEIM_BBOX);
+    expect(areas).toHaveLength(1);
+    expect(areas[0].osmId).toBe('way/1');
+    expect(areas[0].landuseType).toBe('industrial');
+    expect(areas[0].name).toBe('Hägebüch');
+    expect(areas[0].areaM2Approx).toBeGreaterThan(0);
+    expect(areas[0].centroid).toHaveProperty('lat');
+    expect(areas[0].centroid).toHaveProperty('lon');
+  });
+
+  it('defaults to the 5 supported landuse types when landuseTypes is omitted', async () => {
+    axios.post.mockResolvedValueOnce({ data: { elements: [] } });
+    await fetchLanduseAreas(HOCKENHEIM_BBOX);
+    const [, body] = axios.post.mock.calls[0];
+    const decoded = decodeURIComponent(body);
+    for (const type of DEFAULT_LANDUSE_TYPES) {
+      expect(decoded).toContain(type);
+    }
+  });
+
+  it('restricts the query to the given landuseTypes filter', async () => {
+    axios.post.mockResolvedValueOnce({ data: { elements: [] } });
+    await fetchLanduseAreas(HOCKENHEIM_BBOX, ['industrial', 'retail']);
+    const [, body] = axios.post.mock.calls[0];
+    const decoded = decodeURIComponent(body);
+    expect(decoded).toContain('industrial|retail');
+    expect(decoded).not.toContain('residential');
+  });
+
+  it('returns null name for unnamed areas', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: { elements: [squareWay(2, 'commercial', null, 49.3, 8.5, 0.0005)] },
+    });
+    const areas = await fetchLanduseAreas(HOCKENHEIM_BBOX);
+    expect(areas[0].name).toBeNull();
+  });
+
+  it('skips ways with fewer than 3 resolvable geometry points (degenerate)', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: {
+        elements: [
+          {
+            type: 'way',
+            id: 3,
+            tags: { landuse: 'industrial' },
+            geometry: [
+              { lat: 49.3, lon: 8.5 },
+              { lat: 49.301, lon: 8.501 },
+            ],
+          },
+        ],
+      },
+    });
+    const areas = await fetchLanduseAreas(HOCKENHEIM_BBOX);
+    expect(areas).toHaveLength(0);
+  });
+
+  it('ignores non-way elements defensively', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: {
+        elements: [
+          { type: 'node', id: 99, lat: 49.3, lon: 8.5, tags: { landuse: 'industrial' } },
+          squareWay(4, 'retail', null, 49.32, 8.52, 0.0008),
+        ],
+      },
+    });
+    const areas = await fetchLanduseAreas(HOCKENHEIM_BBOX);
+    expect(areas).toHaveLength(1);
+    expect(areas[0].osmId).toBe('way/4');
+  });
+
+  it('sends an identifying User-Agent (Overpass 406 lesson from the addLayer1 fix)', async () => {
+    axios.post.mockResolvedValueOnce({ data: { elements: [] } });
+    await fetchLanduseAreas(HOCKENHEIM_BBOX);
+    const [, , config] = axios.post.mock.calls[0];
+    expect(config.headers['User-Agent']).toBeTruthy();
+  });
+
+  it('propagates a hard fetch error to the caller', async () => {
+    axios.post.mockRejectedValueOnce(new Error('OVERPASS_TIMEOUT'));
+    await expect(fetchLanduseAreas(HOCKENHEIM_BBOX)).rejects.toThrow('OVERPASS_TIMEOUT');
+  });
+});
+
+describe('summarizeLanduseAreas', () => {
+  it('aggregates total area per landuse type', () => {
+    const areas = [
+      { landuseType: 'industrial', areaM2Approx: 1000 },
+      { landuseType: 'industrial', areaM2Approx: 500 },
+      { landuseType: 'retail', areaM2Approx: 200 },
+    ];
+    const summary = summarizeLanduseAreas(areas);
+    expect(summary.totalAreaM2ByType).toEqual({ industrial: 1500, retail: 200 });
+    expect(summary.areaCount).toBe(3);
+  });
+
+  it('returns an empty summary for an empty area list', () => {
+    const summary = summarizeLanduseAreas([]);
+    expect(summary.totalAreaM2ByType).toEqual({});
+    expect(summary.areaCount).toBe(0);
+  });
+});
+
+describe('module constants', () => {
+  it('re-exports bboxAreaSqKm and MAX_BBOX_AREA_SQ_KM for the service handler guard', () => {
+    expect(typeof bboxAreaSqKm).toBe('function');
+    expect(MAX_BBOX_AREA_SQ_KM).toBeGreaterThan(0);
+    expect(DEFAULT_LANDUSE_TYPES).toEqual(
+      expect.arrayContaining(['residential', 'commercial', 'retail', 'industrial', 'institutional'])
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Requested explicitly for CernionGIS's municipal-value projection methodology: `municipal-load-estimator.js`'s `sectorFractionsForProfile()` currently falls back to a population/density proxy for the commercial/public/residential split (`evidenceStatus: 'heuristic-fallback'`), and its own `nextGateLabel` names the fix — "OSM-Gebäudenutzung, MaStR-Anlagenstandorte und kommunale Liegenschaften für lokalen Lastsplit verbinden."
- New `POST /osm-geo/landuse-areas` action (`src/osm-landuse-areas.js`) fetches `landuse=residential|commercial|retail|industrial|institutional` way polygons via the same Overpass source/conventions as `osm-geo.gridTopology` (`location`/`postalCode`/`boundingBox` scope, same geocoding, same area guard), computing area (shoelace formula) and centroid entirely locally — no external MCP dependency.
- **v1 scope limitation, documented rather than silently miscalculated:** only simple closed way polygons, not multipolygon relations.
- Extracted `src/osm-geometry.js` from `src/osm-grid-topology.js` (planar-projection helpers, plus new `polygonAreaM2`/`polygonCentroid`) so the new module reuses the same local-metres projection instead of duplicating it. Pure internal refactor for `osm-grid-topology.js` — public API/behavior unchanged, verified by its full existing test suite passing without modification.

## Test plan
- [x] `tests/osm-geometry.test.js` (new, 14 tests) — incl. exact area verification against a known 100m × 100m square
- [x] `tests/osm-landuse-areas.test.js` (new, 11 tests)
- [x] `tests/osm-geo.service.test.js` +10 tests for the new action (scope resolution, enum validation, degraded responses)
- [x] `npx jest` across all 4 affected suites — 14 suites / 595 tests pass
- [x] `npx jest tests/api.service.test.js` (touched for the REST alias) — 11 suites / 974 tests pass unchanged
- [x] `npm run check:operation-capability-index`, `npm run check:llm`, `npm run audit:openapi` — all clean
- [x] `npm run check:tdd-matrix-coverage`, `npm run check:quality-gate`, `npm run audit:security` — pass (security: 2 pre-existing non-critical dependency advisories, unrelated)
- [x] GitNexus `detect_changes`: LOW risk; cross-checked scope via `git status`
- [x] **Live-verified** against the real Hockenheim bbox: 58 areas (industrial ~2.97 km², commercial ~0.86 km², retail ~0.16 km²), including the same named area ("Hägebüch") the requester's own preliminary feasibility check had found — closely matching their independent count of 59

🤖 Generated with [Claude Code](https://claude.com/claude-code)