### PR TITLE
feat: grid-operations.marketActorDirectory bulk market actor endpoint (v0.99.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.16] — 2026-08-10
+
+### Added
+- **New `grid-operations.marketActorDirectory` action (`GET /grid-operations/market-actor-directory`) — bulk, paginated German market actor directory.** Requested explicitly as a discovery-seed replacement for consumers who would otherwise need the ~3GB MaStR full export or MaStR web-UI scraping. Investigated the existing lookup family first (`marketPartners`, `vnbdigitalSearch`, `vnbdigitalLookup`, `vnbLookup`, `vnbLookupCodes`) — all proxy to external `mcp.cernion.de` MCP tools with no local data backing, and `marketPartners`'s `offset` parameter was found live to be silently ignored by the underlying `cernion_market_partners` tool (identical results at `offset:0` and `offset:50000`) — genuine bulk enumeration was not possible through any existing capability. The Cernion MCP-side team subsequently shipped a dedicated `cernion_market_actor_directory` tool with real pagination; this action is a thin, verified proxy to it, matching the requester's exact proposed shape (`entityId`, `companyName`, `bdewCodes[]`, `marketRoles[]`, `address.{city,postalCode,state}`, `website`, `mastrId`, `lastUpdated`, plus `pagination.{limit,offset,total}`).
+- Live-verified before shipping: `offset=0` vs `offset=5` return fully disjoint result sets (0 overlap) with an honest `pagination.total` (2123 across all 3 roles); `marketRoles` filtering (`VNB`/`LIEFERANT`/`MSB`) works server-side; `website` coverage ~89% in a 100-entry sample (close to the ~93–96% reported by the MCP-side team). `address.state` and `mastrId` are documented as known, currently near-always-null data gaps in the underlying source (not a bug in this proxy) per the MCP-side team's own findings.
+- `limit` capped at 500 (the underlying tool's own server-side cap, confirmed live — requesting 1000 silently returns 500).
+
+### Testing
+- `tests/grid-operations.service.test.js` extended (7 new tests) — param pass-through incl. defaults, unwrapping the tool's double-nested response shape (verified live before writing the fixture) into a clean single-level result, `marketRoles`/`limit` validation, MCP-failure → clean 502, and pagination-fallback synthesis when the tool omits it.
+- Full suite: `tests/grid-operations.service.test.js` — 11 suites / 634 tests pass.
+- Live-verified end-to-end through a real Moleculer broker (not just mocked tests) with `marketRoles: ['VNB','LIEFERANT','MSB']` — correct shape, correct data, correct pagination.
+
 ## [0.99.15] — 2026-08-10
 
 ### Added

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.15
-- changelog_latest_release: 0.99.15
+- version: 0.99.16
+- changelog_latest_release: 0.99.16
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -135,7 +135,7 @@ recipes:
   prosumer-nap-wallet-onboarding "A prosumer wants to onboard to a NAP Wallet and share…"
 resolve: GET /api/_agent/operations?domain=energy-sharing
 
-### grid-ops (35 capabilities · 10 recipes · 116 operations)
+### grid-ops (35 capabilities · 10 recipes · 117 operations)
 capabilities: agnes_bottleneck, anschlusskapazitaet_evidence_queue, bess_screening, capacity_contract_risk_asset_cockpit, capex_prioritization, connection_deadline_evidence_queue, connection_rejection_evidence, connection_rejection_fnav_14a_evidence, controllability_asset_handover, controllability_data_alignment, controllability_submission_cockpit, cross_channel_vnb_signal_queue, e2e_connection_check, evidence_freshness_guard, flex_forecast_bess_grid_operations_advisory, flex_strategic_demand_intake, flexibilitaetskosten_raster, fnav_commercial_hedging, fnav_fast_track_contract_gate, gas_transformation_dependency_map, ghost_asset_alert, grid_connection_transformation_gate, grid_operator_identity_resolution, legacy_control_technology_transition, mastr_asset_inventory, netzfahrplan_fnav_assessment, netzsignal_delta_gating, non_escalation_control_evidence, renewable_generation_forecast, residual_load_forecast_for_dso, schedule_management_governance_roadmap, smgw_connector_readiness_status, tech_commercial_offer_cockpit, vnb_delta_signal_classifier, vnb_special_topic_workstate
 recipes:
   direktvermarkter-portfolio "A user asks for installations managed by a direct marketer…"
@@ -246,17 +246,17 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: d6cf9616d25e3b5e028b6f31d6a1a887104e07743daad152b2ab4652fc48ba1d
+- CHANGELOG.md: ef1d66055cb57ca49d57bca364ebd12cfa7488362004aa0c9245abae09f20609
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: 91d0138191b1b474f72d813ccf844b8b7fdbfc3ab5988ea96541ac80ced0a950
+- openapi-export.json: 423046080cbe2b7b5abbc144141d87d48ea3c5ef7966e194a0433ced88f5eb52
 
 ## OpenAPI Surface (full contract, not embedded)
-- path_count: 1026
-- operation_count: 1138
+- path_count: 1027
+- operation_count: 1139
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 641fd3131c516a0d676282687a6ebd94e36101e742f02869017a5a4be9f4153c
+- llm_txt_sha256: 8fa48c3c751813b8d615befdcf13e246f8337c773ce218f418e2708c73b12e23

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.15",
+    "version": "0.99.16",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -2470,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.15",
+  "x-version": "0.99.16",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.15",
+    "version": "0.99.16",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -45044,6 +45044,108 @@
         ],
         "x-oeo-class": [
           "https://openenergyplatform.org/ontology/oeo/OEO_00010082"
+        ]
+      }
+    },
+    "/api/grid-operations/market-actor-directory": {
+      "get": {
+        "operationId": "grid-operations_marketActorDirectory",
+        "summary": "Bulk, paginated directory of German energy market actors (VNB/LIEFERANT/MSB)",
+        "tags": [
+          "Grid Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated market actor list",
+            "content": {
+              "application/json": {
+                "example": {
+                  "success": true,
+                  "data": {
+                    "results": [
+                      {
+                        "entityId": "662063",
+                        "companyName": "Stadtwerke Gronau GmbH",
+                        "bdewCodes": [
+                          "9900244000009"
+                        ],
+                        "marketRoles": [
+                          "VNB"
+                        ],
+                        "address": {
+                          "city": "Gronau",
+                          "postalCode": "48599",
+                          "state": null
+                        },
+                        "website": "http://www.stadtwerke-gronau.de",
+                        "mastrId": null,
+                        "lastUpdated": "2026-07-31T22:35:00.638935+00:00"
+                      }
+                    ],
+                    "pagination": {
+                      "limit": 100,
+                      "offset": 0,
+                      "total": 2123
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Enumerates German energy market actors (grid operators, suppliers, metering point operators) with real offset-based pagination — a bulk discovery seed, distinct from marketPartners/vnbLookup which are built for single/few-result identity resolution.\n\n**Use case:** organisation discovery seed list (e.g. iterating public websites for customer-service/FAQ pages) without needing the full MaStR export (~3GB) or scraping the MaStR web UI.\n\n**Response fields per entry:** `entityId`, `companyName`, `bdewCodes[]`, `marketRoles[]`, `address.{city,postalCode,state}`, `website`, `mastrId`, `lastUpdated`.\n\n**Known data gaps (source data, not this endpoint):** `address.state` is null for almost all entries; `mastrId` is only meaningful for VNB and depends on environment data.",
+        "parameters": [
+          {
+            "name": "marketRoles",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "VNB",
+                  "LIEFERANT",
+                  "MSB"
+                ]
+              },
+              "example": [
+                "VNB"
+              ]
+            },
+            "description": "Restrict to these market roles; omit for all roles."
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "Baden-Württemberg"
+            },
+            "description": "Bundesland filter — currently rarely populated in the source data."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0
+            }
+          }
         ]
       }
     },
@@ -91502,5 +91604,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.15"
+  "x-version": "0.99.16"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,15 +1,15 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.15",
-  "sourceOpenApiHash": "91d0138191b1b474f72d813ccf844b8b7fdbfc3ab5988ea96541ac80ced0a950",
+  "packageVersion": "0.99.16",
+  "sourceOpenApiHash": "423046080cbe2b7b5abbc144141d87d48ea3c5ef7966e194a0433ced88f5eb52",
   "coverage": {
-    "rawOperationCount": 1138,
-    "operationCount": 882,
-    "agentableCount": 880,
+    "rawOperationCount": 1139,
+    "operationCount": 883,
+    "agentableCount": 881,
     "nonAgentableCount": 2,
     "byOperationKind": {
-      "data_read": 388,
+      "data_read": 389,
       "admin": 8,
       "object_store_write": 229,
       "process_step": 20,
@@ -54613,6 +54613,108 @@
         ],
         "examples": [
           "Please grid operation data (load, frequency, flows, redispatch)"
+        ],
+        "synonyms": [
+          "Netzbetrieb",
+          "grid operator",
+          "VNB",
+          "distribution grid"
+        ],
+        "curated": false
+      },
+      "aliases": []
+    },
+    {
+      "operationId": "grid-operations_marketActorDirectory",
+      "method": "GET",
+      "path": "/api/grid-operations/market-actor-directory",
+      "service": "grid-operations",
+      "action": "grid-operations.marketActorDirectory",
+      "summary": "Bulk, paginated directory of German energy market actors (VNB/LIEFERANT/MSB)",
+      "tags": [
+        "Grid Operations"
+      ],
+      "uiPage": null,
+      "oeoClass": null,
+      "operationKind": "data_read",
+      "consequenceLevel": "none",
+      "recommendedExecutionMode": "direct",
+      "agentable": true,
+      "nonAgentableReason": null,
+      "capabilityCandidates": [
+        "grid-operations.market_actor_directory"
+      ],
+      "domains": [
+        "grid-ops"
+      ],
+      "dataSources": [
+        "MaStR",
+        "Grid Operator Registry"
+      ],
+      "entityTypes": [],
+      "requiredScopes": [
+        "grid-operations:read"
+      ],
+      "tenantScoped": true,
+      "writesTo": [],
+      "sideEffects": [],
+      "idempotency": "idempotent",
+      "rollbackHint": null,
+      "parameters": {
+        "required": [],
+        "optional": [
+          {
+            "name": "marketRoles",
+            "in": "query",
+            "type": "array",
+            "description": "Restrict to these market roles; omit for all roles.",
+            "extractionHint": null
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "type": "string",
+            "description": "Bundesland filter — currently rarely populated in the source data.",
+            "extractionHint": null
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "integer",
+            "description": null,
+            "extractionHint": "result_limit"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "type": "integer",
+            "description": null,
+            "extractionHint": "pagination_offset"
+          }
+        ]
+      },
+      "rankingSignals": {
+        "positiveKeywords": [
+          "grid",
+          "operations",
+          "market",
+          "actor",
+          "directory",
+          "bulk,",
+          "paginated",
+          "german",
+          "energy",
+          "actors",
+          "(vnb",
+          "lieferant",
+          "msb)"
+        ],
+        "negativeCues": [
+          "spot price",
+          "energy sharing community"
+        ],
+        "examples": [
+          "Show me bulk, paginated directory of german energy market actors (vnb/lieferant/msb)"
         ],
         "synonyms": [
           "Netzbetrieb",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.15",
+  "version": "0.99.16",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {

--- a/services/grid-operations.service.js
+++ b/services/grid-operations.service.js
@@ -2050,6 +2050,143 @@ heat pumps, storage systems) in a given postcode area or for a specific VNB.
       },
     },
 
+    /**
+     * Bulk, paginated German market actor directory — requested explicitly
+     * as a discovery seed (avoids consumers needing the ~3GB MaStR full
+     * export or scraping the MaStR web UI just to enumerate market actors).
+     * Unlike marketPartners (single/few-result relevance search, and whose
+     * offset parameter cernion_market_partners silently ignores — verified
+     * live, not a documented limitation), this proxies the dedicated
+     * cernion_market_actor_directory MCP tool, which supports real
+     * offset-based pagination (verified live: offset=0 vs offset=5 return
+     * fully disjoint result sets, with an honest `pagination.total`).
+     *
+     * Known data gaps in the underlying source (not a bug in this proxy):
+     * - `address.state` is null almost always — not present in the
+     *   underlying bdew_codes/plz_vnb_mappings/MaStR marktakteure data for
+     *   these entities, and the municipality reference dataset it falls
+     *   back to only covers 10 municipalities.
+     * - `mastrId` is only meaningful for marketRoles containing VNB
+     *   (suppliers/MSBs have no MaStR SNB/GNB concept) and depends on the
+     *   PlzVnbMapping collection being populated in the calling environment.
+     */
+    marketActorDirectory: {
+      rest: 'GET /market-actor-directory',
+      params: {
+        marketRoles: {
+          type: 'array',
+          optional: true,
+          items: { type: 'enum', values: ['VNB', 'LIEFERANT', 'MSB'] },
+        },
+        state: { type: 'string', optional: true },
+        limit: { type: 'number', optional: true, default: 100, min: 1, max: 500, convert: true },
+        offset: { type: 'number', optional: true, default: 0, min: 0, convert: true },
+      },
+      openapi: {
+        summary: 'Bulk, paginated directory of German energy market actors (VNB/LIEFERANT/MSB)',
+        tags: ['Grid Operations'],
+        description: `Enumerates German energy market actors (grid operators, suppliers, metering point operators) with real offset-based pagination — a bulk discovery seed, distinct from marketPartners/vnbLookup which are built for single/few-result identity resolution.
+
+**Use case:** organisation discovery seed list (e.g. iterating public websites for customer-service/FAQ pages) without needing the full MaStR export (~3GB) or scraping the MaStR web UI.
+
+**Response fields per entry:** \`entityId\`, \`companyName\`, \`bdewCodes[]\`, \`marketRoles[]\`, \`address.{city,postalCode,state}\`, \`website\`, \`mastrId\`, \`lastUpdated\`.
+
+**Known data gaps (source data, not this endpoint):** \`address.state\` is null for almost all entries; \`mastrId\` is only meaningful for VNB and depends on environment data.`,
+        parameters: [
+          {
+            name: 'marketRoles',
+            in: 'query',
+            required: false,
+            schema: {
+              type: 'array',
+              items: { type: 'string', enum: ['VNB', 'LIEFERANT', 'MSB'] },
+              example: ['VNB'],
+            },
+            description: 'Restrict to these market roles; omit for all roles.',
+          },
+          {
+            name: 'state',
+            in: 'query',
+            required: false,
+            schema: { type: 'string', example: 'Baden-Württemberg' },
+            description: 'Bundesland filter — currently rarely populated in the source data.',
+          },
+          {
+            name: 'limit',
+            in: 'query',
+            required: false,
+            schema: { type: 'integer', default: 100, minimum: 1, maximum: 500 },
+          },
+          {
+            name: 'offset',
+            in: 'query',
+            required: false,
+            schema: { type: 'integer', default: 0, minimum: 0 },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Paginated market actor list',
+            content: {
+              'application/json': {
+                example: {
+                  success: true,
+                  data: {
+                    results: [
+                      {
+                        entityId: '662063',
+                        companyName: 'Stadtwerke Gronau GmbH',
+                        bdewCodes: ['9900244000009'],
+                        marketRoles: ['VNB'],
+                        address: { city: 'Gronau', postalCode: '48599', state: null },
+                        website: 'http://www.stadtwerke-gronau.de',
+                        mastrId: null,
+                        lastUpdated: '2026-07-31T22:35:00.638935+00:00',
+                      },
+                    ],
+                    pagination: { limit: 100, offset: 0, total: 2123 },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      async handler(ctx) {
+        const { marketRoles, state, limit, offset } = ctx.params;
+        const mcpParams = { limit, offset };
+        if (marketRoles) mcpParams.marketRoles = marketRoles;
+        if (state) mcpParams.state = state;
+
+        const result = await CernionMCPClient.callWithNewSession(
+          'cernion_market_actor_directory',
+          mcpParams,
+          ctx.meta.cernionToken
+        );
+
+        if (result?.success === false) {
+          throw new MoleculerClientError(
+            result.error?.message || 'cernion_market_actor_directory call failed',
+            502,
+            result.error?.code || 'MCP_CALL_FAILED'
+          );
+        }
+
+        // CernionMCPClient's generic response handling nests this specific
+        // tool's own {success, data:{results, pagination}} payload one level
+        // deeper than usual (verified live) -- unwrap to a clean single-level
+        // response rather than exposing that plumbing detail to callers.
+        const payload = result?.data?.data || result?.data || {};
+        return {
+          success: true,
+          data: {
+            results: payload.results || [],
+            pagination: payload.pagination || { limit, offset, total: payload.results?.length || 0 },
+          },
+        };
+      },
+    },
+
     // -----------------------------------------------------------------------
     // Phase 5 — Netzfahrplan / fNAV generation (v0.51.5)
     // -----------------------------------------------------------------------

--- a/tests/grid-operations.service.test.js
+++ b/tests/grid-operations.service.test.js
@@ -1049,4 +1049,105 @@ describe('Grid Operations Service', () => {
       if (svc) await broker.destroyService(svc);
     });
   });
+
+  // ─── marketActorDirectory (bulk, paginated discovery seed) ───────────────
+
+  describe('marketActorDirectory action', () => {
+    // Matches the real double-nested shape observed live from
+    // cernion_market_actor_directory via CernionMCPClient (verified before
+    // building this proxy — the client wraps the tool's own {success,
+    // data:{results,pagination}} payload one level deeper than usual).
+    const DOUBLE_NESTED_MOCK = {
+      success: true,
+      data: {
+        success: true,
+        data: {
+          results: [
+            {
+              entityId: '662063',
+              companyName: 'Stadtwerke Gronau GmbH',
+              bdewCodes: ['9900244000009'],
+              marketRoles: ['VNB'],
+              address: { city: 'Gronau', postalCode: '48599', state: null },
+              website: 'http://www.stadtwerke-gronau.de',
+              mastrId: null,
+              lastUpdated: '2026-07-31T22:35:00.638935+00:00',
+            },
+          ],
+          pagination: { limit: 100, offset: 0, total: 2123 },
+        },
+      },
+    };
+
+    beforeEach(() => callWithNewSession.mockReset());
+
+    it('calls cernion_market_actor_directory with marketRoles/state/limit/offset', async () => {
+      callWithNewSession.mockResolvedValueOnce(DOUBLE_NESTED_MOCK);
+      await broker.call('grid-operations.marketActorDirectory', {
+        marketRoles: ['VNB'],
+        state: 'Baden-Württemberg',
+        limit: 50,
+        offset: 10,
+      });
+      expect(callWithNewSession).toHaveBeenCalledWith(
+        'cernion_market_actor_directory',
+        { marketRoles: ['VNB'], state: 'Baden-Württemberg', limit: 50, offset: 10 },
+        undefined
+      );
+    });
+
+    it('applies default limit/offset when omitted', async () => {
+      callWithNewSession.mockResolvedValueOnce(DOUBLE_NESTED_MOCK);
+      await broker.call('grid-operations.marketActorDirectory', {});
+      expect(callWithNewSession).toHaveBeenCalledWith(
+        'cernion_market_actor_directory',
+        { limit: 100, offset: 0 },
+        undefined
+      );
+    });
+
+    it('unwraps the double-nested MCP response into a clean single-level result', async () => {
+      callWithNewSession.mockResolvedValueOnce(DOUBLE_NESTED_MOCK);
+      const result = await broker.call('grid-operations.marketActorDirectory', {});
+      expect(result.success).toBe(true);
+      expect(result.data.results).toHaveLength(1);
+      expect(result.data.results[0].companyName).toBe('Stadtwerke Gronau GmbH');
+      expect(result.data.results[0].website).toBe('http://www.stadtwerke-gronau.de');
+      expect(result.data.pagination).toEqual({ limit: 100, offset: 0, total: 2123 });
+    });
+
+    it('rejects an unsupported marketRoles value (enum validation)', async () => {
+      await expect(
+        broker.call('grid-operations.marketActorDirectory', { marketRoles: ['UEBERTRAGUNGSNETZ'] })
+      ).rejects.toThrow();
+    });
+
+    it('rejects limit above the 500 server cap', async () => {
+      await expect(
+        broker.call('grid-operations.marketActorDirectory', { limit: 501 })
+      ).rejects.toThrow();
+    });
+
+    it('propagates an MCP-level failure as a clean 502 error', async () => {
+      callWithNewSession.mockResolvedValueOnce({
+        success: false,
+        error: { code: 'TOOL_CALL_ERROR', message: 'directory unavailable' },
+      });
+      await expect(broker.call('grid-operations.marketActorDirectory', {})).rejects.toMatchObject({
+        code: 502,
+      });
+    });
+
+    it('falls back to a synthesised pagination object when the tool omits one', async () => {
+      callWithNewSession.mockResolvedValueOnce({
+        success: true,
+        data: { success: true, data: { results: [{ entityId: '1', companyName: 'X' }] } },
+      });
+      const result = await broker.call('grid-operations.marketActorDirectory', {
+        limit: 20,
+        offset: 0,
+      });
+      expect(result.data.pagination).toEqual({ limit: 20, offset: 0, total: 1 });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Requested explicitly as a discovery-seed replacement for consumers who would otherwise need the ~3GB MaStR full export or MaStR web-UI scraping.
- Investigated the existing lookup family first (`marketPartners`, `vnbdigitalSearch`, `vnbdigitalLookup`, `vnbLookup`, `vnbLookupCodes`) — all proxy to external `mcp.cernion.de` tools with no local data backing, and `marketPartners`'s `offset` parameter was found live to be silently ignored by `cernion_market_partners` (identical results at `offset:0` and `offset:50000`). Genuine bulk enumeration was not possible through any existing capability at that point.
- The Cernion MCP-side team subsequently shipped a dedicated `cernion_market_actor_directory` tool with real pagination. This action is a thin, verified proxy to it, matching the requester's exact proposed shape.
- **Live-verified before shipping**: `offset=0` vs `offset=5` return fully disjoint result sets (0 overlap) with an honest `pagination.total` (2123 across all 3 roles); `marketRoles` filtering works server-side; `website` coverage ~89% in a 100-entry sample. `address.state`/`mastrId` documented as known data gaps per the MCP-side team's own findings, not a bug in this proxy. `limit` capped at 500 (the tool's own server-side cap, confirmed live).

## Test plan
- [x] `tests/grid-operations.service.test.js` +7 tests: param pass-through incl. defaults, unwrapping the tool's double-nested response shape, `marketRoles`/`limit` validation, MCP-failure → clean 502, pagination-fallback synthesis
- [x] `npx jest tests/grid-operations.service.test.js` — 11 suites / 634 tests pass
- [x] `npm run check:operation-capability-index`, `npm run check:llm`, `npm run audit:openapi` — all clean
- [x] `npm run check:tdd-matrix-coverage`, `npm run check:quality-gate`, `npm run audit:security` — pass (security: 2 pre-existing non-critical dependency advisories, unrelated)
- [x] GitNexus `detect_changes`: LOW risk; cross-checked scope via `git status`
- [x] **Live-verified** end-to-end through a real Moleculer broker — correct shape, correct data, correct pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)