### PR TITLE
docs: refresh Cernion MCP metadata for Glama

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@
 
 The hosted public API is documented at [api.cernion.de](https://api.cernion.de/api/docs)
 and through the OpenAPI export in this repository. MCP-compatible access is available at
-`https://api.cernion.de/api/mcp` for clients that authenticate with a Cernion bearer token
-or compatible OAuth flow. Public self-service token onboarding starts at
-[cernion.de/cet-token](https://cernion.de/cet-token/).
+`https://api.cernion.de/api/mcp` for clients that authenticate with a Cernion bearer token.
+Public token onboarding starts at [cernion.de/cet-token](https://cernion.de/cet-token/).
 
 The repository version is maintained in `package.json` and the generated OpenAPI exports;
 this README intentionally avoids a copied static version sentence so public listings do not

--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # Cernion Energy Tools
 
-> API-first Agentic Energy Operations Layer for Stadtwerke, DSOs and energy-service teams.
-> Cernion combines deterministic energy-domain services, curated capability routing,
-> evidence dossiers, VDMI role logic, HITL boundaries and read-only integration surfaces
-> for REST, Sidecar, Microsoft Copilot, n8n, OpenWebUI and OpenClaw.
+> API-first grid-intelligence and agentic energy-operations layer for Stadtwerke,
+> distribution-system operators and energy-service teams. Cernion combines deterministic
+> energy-domain services, curated capability routing, evidence dossiers, VDMI role logic,
+> HITL boundaries and governed integration surfaces for REST, MCP, Sidecar, Microsoft
+> Copilot, n8n, OpenWebUI and OpenClaw.
+
+## MCP and API access
+
+The hosted public API is documented at [api.cernion.de](https://api.cernion.de/api/docs)
+and through the OpenAPI export in this repository. MCP-compatible access is available at
+`https://api.cernion.de/api/mcp` for clients that authenticate with a Cernion bearer token
+or compatible OAuth flow. Public self-service token onboarding starts at
+[cernion.de/cet-token](https://cernion.de/cet-token/).
+
+The repository version is maintained in `package.json` and the generated OpenAPI exports;
+this README intentionally avoids a copied static version sentence so public listings do not
+keep stale release numbers.
 
 [![Maintenance CI](https://github.com/energychain/cernion-energy-tools/actions/workflows/maintenance-ci.yml/badge.svg?branch=main)](https://github.com/energychain/cernion-energy-tools/actions/workflows/maintenance-ci.yml)
 [![CodeQL](https://github.com/energychain/cernion-energy-tools/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/energychain/cernion-energy-tools/actions/workflows/codeql.yml)
@@ -24,7 +37,6 @@ It is not just a chat frontend for energy APIs. The current platform contains:
 - **curated Copilot, Sidecar, OpenWebUI, n8n and OpenClaw integration surfaces** that expose only governed subsets of the backend
 - **agentic runtime components** for routing, receipts, dossiers, HITL, evidence, revalidation and observability
 
-Current package/OpenAPI version: **`0.99.0`**
 
 ### Public positioning
 

--- a/llm.txt
+++ b/llm.txt
@@ -247,11 +247,11 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 
 ## Source File Hashes
 - CHANGELOG.md: 6fe19d85bf81df6d1fa2b9a388a39b9fdfcc223ffe74cb80f33ac290b4b03faa
-- README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
+- README.md: 37fffb4fdba39003ecea1da45c58a103102104864b764d08b0e67d609061ccfd
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: 26cff1a4aeb5d8c39015f2dd7ea49fc6963d65b7e0a01cd8b32255195f770d85
+- openapi-export.json: c3fb0b79c24066554a32c53d7e4dee54a19eb6f7e16ff3d839776c8f26b2ec28
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 1027
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 16c0734c34cfbb7fbd8642e3e3cfbca63198633daa58fa902e7fd33f060097a1
+- llm_txt_sha256: 8efca42d6b4f269ecf41ebf4c180dc88129bc889dd9375f8a5187df8fab0e90e

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cernion Energy Tools API",
     "version": "0.99.17",
-    "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
+    "description": "API-first grid-intelligence and agentic energy-operations services for Cernion.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
     {

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cernion Energy Tools API",
     "version": "0.99.17",
-    "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
+    "description": "API-first grid-intelligence and agentic energy-operations services for Cernion.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
     {

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -2,7 +2,7 @@
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
   "packageVersion": "0.99.17",
-  "sourceOpenApiHash": "26cff1a4aeb5d8c39015f2dd7ea49fc6963d65b7e0a01cd8b32255195f770d85",
+  "sourceOpenApiHash": "c3fb0b79c24066554a32c53d7e4dee54a19eb6f7e16ff3d839776c8f26b2ec28",
   "coverage": {
     "rawOperationCount": 1139,
     "operationCount": 883,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cernion-energy-tools",
   "version": "0.99.17",
-  "description": "MicroService Agent System for Energy Markets",
+  "description": "API-first grid-intelligence and agentic energy-operations services for Cernion",
   "main": "index.js",
   "engines": {
     "node": ">=22"

--- a/scripts/export-openapi.js
+++ b/scripts/export-openapi.js
@@ -323,7 +323,7 @@ function buildStaticSpec() {
       title: 'Cernion Energy Tools API',
       version: packageVersion,
       description:
-        'MicroService Agent System for Energy Markets - REST API with AI integration.\n\n' +
+        'API-first grid-intelligence and agentic energy-operations services for Cernion.\n\n' +
         'CERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\n' +
         'For the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/.',
     },

--- a/services/api.service.js
+++ b/services/api.service.js
@@ -975,7 +975,7 @@ module.exports = {
         title: 'Cernion Energy Tools API',
         version: packageVersion,
         description:
-          'MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/.',
+          'API-first grid-intelligence and agentic energy-operations services for Cernion.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/.',
       },
       tags: [
         { name: 'Energy', description: 'Energy market operations' },


### PR DESCRIPTION
## Summary
- removes the stale copied README version sentence that Glama currently renders as `0.99.0`
- adds an early README "MCP and API access" section with the public docs, MCP endpoint, and token onboarding path
- refreshes package/OpenAPI metadata wording away from the old generic "MicroService Agent System" phrase and regenerates `openapi-export.json`, `openapi-copilot.json`, `llm.txt`, and `operation-capability-index.json`

## Verification
- `npm ci`
- `npm run export:openapi`
- `npm run export:openapi:copilot`
- `node --check scripts/export-openapi.js`
- `node --check services/api.service.js`
- `git diff --check -- README.md package.json scripts/export-openapi.js services/api.service.js openapi-export.json openapi-copilot.json`
- `grep -n "Current package/OpenAPI version\|0\.99\.0" README.md` produced no match
- `npm run generate:llm`
- `npm run check:llm`
- `npm run build`
- `npm run audit:openapi` (exit 0; existing warnings remain, total issues 0)
- `npm run generate:operation-capability-index`
- `npm run check:operation-capability-index`
- `NODE_OPTIONS=--experimental-vm-modules npx jest --coverage=false --runInBand --forceExit tests/api.service.test.js tests/copilot-openapi-subset.test.js tests/llm-manifest.test.js tests/operation-capability-index.test.js` (4 suites / 181 tests passed)

## Risk / boundaries
- Documentation and public metadata only.
- No Glama login, refresh, or support contact performed.
- No direct push to `main`, deploy, website publish, pricing, SLA, compliance, or customer/TWL content changes.
