### PR TITLE
fix: MCP session-error (-32001) auto-retry with fresh session (v0.99.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.18] — 2026-08-13
+
+### Fixed
+- **MCP calls that failed with JSON-RPC `-32001 "Session not found"` were never retried, even though the retry mechanism needed to fix them already existed.** Reported live: `osm-geo/substation-finder` intermittently returned `success:false` with a `-32001 "Session not found"` error at HTTP 200 (not a clean HTTP error — only visible via the body), for bounding boxes that returned real data seconds later via a different endpoint — i.e. not geodata-dependent, purely a transient server-side session/connection-pool condition. A separately-documented sustained multi-minute `assets/all` outage (every call timing out) shares the same underlying client code path (`src/async-job-poller.js` also calls `CernionMCPClient.callWithNewSession`).
+- Root cause: `callTool()`'s own catch block (`src/mcp-client.js`) converts a thrown transport error into a returned `{success:false, error:{...}}` object rather than re-throwing, so `callWithNewSession`'s retry-decision check (`_isQuotaError`, matching only "quota"/"rate limit"/"too many requests") never saw a `-32001`/"Session not found" message as retryable — it was returned immediately on the first attempt. The retry loop itself already builds a brand-new `CernionMCPClient` (and therefore a brand-new session) on every attempt, exactly the "expliziter Session-Neuaufbau" fix a drafted external bug report to Cernion was going to ask about — no external change needed for this part.
+- Added `CernionMCPClient._isSessionError()` (matches "session not found" / "-32001") and a combined `_isRetryableError()` gate used at all three retry-decision sites (the inner `connect()` retry-break, the per-attempt result check, and the catch-block check) in `callWithNewSession`. Exhausting all retries on a session-only error now returns `error.code: 'SESSION_ERROR_EXHAUSTED'` (previously indistinguishable from `QUOTA_EXHAUSTED`, or, before this fix, whatever ad-hoc code the SDK's transport error happened to carry — `404` in the reported case).
+- `services/osm-geo.service.js`'s shared `_classifyDegradedReason()` (used by all `osm-geo.*` actions) gained a `SESSION_ERROR` category (checked before the pre-existing `NOT_FOUND` match, since "Session not found" would otherwise be misclassified as `GEOCODING_FAILED`) so a caller's exhausted-retry session failure is distinguishable from a real "no data in this area" response and from the generic `SERVICE_ABORT` bucket it fell into before.
+
+### Testing
+- `tests/mcp-client.test.js` — 3 new tests: retries and succeeds on a `-32001` result returned from `callTool()` (the actual reported code path — a returned object, not a thrown exception), returns `SESSION_ERROR_EXHAUSTED` (not `QUOTA_EXHAUSTED`) after all retries fail, and retries when the session error instead surfaces as a thrown `connect()` exception (symmetry with the existing quota-error tests).
+- `tests/osm-geo.service.test.js` — 1 new test: an exhausted session error is classified as `SESSION_ERROR`, not `SERVICE_ABORT`.
+- Full suite: `mcp-client.test.js` + `osm-geo.service.test.js` + `async-job-poller.test.js` + `assets.service.test.js` + `grid-operations.service.test.js` (every direct/known consumer of the changed retry path) — 5 suites / 208 tests pass.
+- `callWithNewSession` is a heavily fanned-in shared facade (~25 services) — GitNexus impact analysis flagged this change HIGH risk. Verified the change is purely an additive widening of the retry-classification predicate (no change to existing quota-error or success-path behavior); confirmed via grep that no code or test elsewhere depends on the old, incidental `error.code: 404` shape for MCP session failures.
+
 ## [0.99.17] — 2026-08-10
 
 ### Fixed

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.17
-- changelog_latest_release: 0.99.17
+- version: 0.99.18
+- changelog_latest_release: 0.99.18
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -246,12 +246,12 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: 6fe19d85bf81df6d1fa2b9a388a39b9fdfcc223ffe74cb80f33ac290b4b03faa
+- CHANGELOG.md: 678f62683343e40176dfd0e13f22b3b7bc84aaa0f66f23ad06f8816711df2135
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: 26cff1a4aeb5d8c39015f2dd7ea49fc6963d65b7e0a01cd8b32255195f770d85
+- openapi-export.json: 15affc2d0274607df6f98b54fc475b34be03bbca22b261034611cca33a9b7206
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 1027
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: 16c0734c34cfbb7fbd8642e3e3cfbca63198633daa58fa902e7fd33f060097a1
+- llm_txt_sha256: c0ebf61f3ec23707f0d35121f45f0a04cad9025868ac64b735b84d36665cab11

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.17",
+    "version": "0.99.18",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -2470,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.17",
+  "x-version": "0.99.18",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.17",
+    "version": "0.99.18",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -91604,5 +91604,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.17"
+  "x-version": "0.99.18"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.17",
-  "sourceOpenApiHash": "26cff1a4aeb5d8c39015f2dd7ea49fc6963d65b7e0a01cd8b32255195f770d85",
+  "packageVersion": "0.99.18",
+  "sourceOpenApiHash": "15affc2d0274607df6f98b54fc475b34be03bbca22b261034611cca33a9b7206",
   "coverage": {
     "rawOperationCount": 1139,
     "operationCount": 883,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.17",
+  "version": "0.99.18",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {

--- a/services/osm-geo.service.js
+++ b/services/osm-geo.service.js
@@ -36,10 +36,19 @@ function _mcpTimeoutMs() {
  *   OVERPASS_TIMEOUT     — Overpass upstream timed out
  *   AREA_TOO_BROAD       — query deliberately refused (area too large)
  *   RESPONSE_SIZE_LIMIT  — result truncated / withheld due to geometry/size limits
+ *   SESSION_ERROR        — MCP session expired/recycled mid-request (JSON-RPC -32001),
+ *                           all retries with a fresh session exhausted — transient,
+ *                           not evidence of "no data" in the queried area
  *   SERVICE_ABORT        — generic Cernion service error or unexpected exception
  */
 function _classifyDegradedReason(errCodeOrMessage) {
   const s = String(errCodeOrMessage || '').toUpperCase();
+  if (
+    s.includes('SESSION_ERROR_EXHAUSTED') ||
+    s.includes('SESSION NOT FOUND') ||
+    s.includes('-32001')
+  )
+    return 'SESSION_ERROR';
   if (
     s.includes('GEOCOD') ||
     s.includes('BBOX') ||

--- a/src/mcp-client.js
+++ b/src/mcp-client.js
@@ -45,6 +45,35 @@ class CernionMCPClient {
   }
 
   /**
+   * Returns true when the error message indicates the server-side MCP
+   * session expired or was recycled mid-request (JSON-RPC -32001 "Session
+   * not found"). Distinct from a fresh connection failure: the transport
+   * successfully connected, but the session it was issued became invalid
+   * before (or during) the actual tool-call POST — a transient condition a
+   * brand-new session (i.e. a retry via callWithNewSession, which always
+   * builds a fresh CernionMCPClient/session per attempt) is expected to
+   * resolve, not something a caller should have to distinguish from "no
+   * data" itself.
+   * @param {string} msg
+   * @private
+   */
+  static _isSessionError(msg) {
+    const s = (msg || '').toLowerCase();
+    return s.includes('session not found') || s.includes('-32001');
+  }
+
+  /**
+   * Returns true when a failed attempt should be retried with a fresh
+   * session by callWithNewSession's outer loop, rather than surfaced
+   * immediately to the caller.
+   * @param {string} msg
+   * @private
+   */
+  static _isRetryableError(msg) {
+    return CernionMCPClient._isQuotaError(msg) || CernionMCPClient._isSessionError(msg);
+  }
+
+  /**
    * Redact sensitive token-like values from propagated error messages.
    * @param {string} message
    * @returns {string}
@@ -124,9 +153,9 @@ class CernionMCPClient {
           return true;
         } catch (error) {
           lastError = error;
-          // Quota/rate-limit errors are handled by callWithNewSession's outer retry loop.
+          // Quota/rate-limit/session errors are handled by callWithNewSession's outer retry loop.
           // Break immediately so we don't waste 3×exponential-backoff here.
-          if (CernionMCPClient._isQuotaError(error.message)) break;
+          if (CernionMCPClient._isRetryableError(error.message)) break;
           retries--;
           if (retries > 0) {
             // Wait before retry (exponential backoff)
@@ -524,7 +553,7 @@ class CernionMCPClient {
           }
           try {
             const result = await CernionMCPClient._executeCall(toolName, params, token);
-            if (CernionMCPClient._isQuotaError(result?.error?.message)) {
+            if (CernionMCPClient._isRetryableError(result?.error?.message)) {
               lastError = new Error(result.error.message);
               continue;
             }
@@ -555,7 +584,7 @@ class CernionMCPClient {
             return result;
           } catch (err) {
             lastError = err;
-            if (!CernionMCPClient._isQuotaError(err.message)) {
+            if (!CernionMCPClient._isRetryableError(err.message)) {
               const elapsedMs = Date.now() - startedAt;
 
               // Log MCP call error if jobId provided
@@ -612,10 +641,13 @@ class CernionMCPClient {
           status: 'quota_exhausted',
           durationMs: elapsedMs,
         });
+        const exhaustedBySessionErrorOnly =
+          CernionMCPClient._isSessionError(lastError?.message) &&
+          !CernionMCPClient._isQuotaError(lastError?.message);
         return {
           success: false,
           error: {
-            code: 'QUOTA_EXHAUSTED',
+            code: exhaustedBySessionErrorOnly ? 'SESSION_ERROR_EXHAUSTED' : 'QUOTA_EXHAUSTED',
             message: CernionMCPClient._sanitizeErrorMessage(
               lastError?.message || 'Quota exhausted after all retry attempts'
             ),

--- a/tests/mcp-client.test.js
+++ b/tests/mcp-client.test.js
@@ -374,4 +374,90 @@ describe('CernionMCPClient', () => {
       );
     });
   });
+
+  describe('MCP session-error retry (-32001 "Session not found")', () => {
+    // Reproduces the reported failure mode: connect() succeeds (a session was
+    // issued), but the actual tool-call POST later fails because that
+    // session expired/was recycled server-side. callTool()'s own catch block
+    // turns this into a returned {success:false, error:{...}} rather than a
+    // thrown exception, so the retry decision happens on the *returned*
+    // object, not via a caught exception like the quota-error tests above.
+
+    it('retries with a fresh session on a -32001 "Session not found" result and succeeds', async () => {
+      let attempts = 0;
+      jest.spyOn(CernionMCPClient.prototype, 'connect').mockResolvedValue(true);
+      jest.spyOn(CernionMCPClient.prototype, 'callTool').mockImplementation(async () => {
+        attempts++;
+        if (attempts < 2) {
+          return {
+            success: false,
+            error: {
+              code: 404,
+              message:
+                'Streamable HTTP error: Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"},"id":null}',
+              toolName: 'test_tool',
+            },
+          };
+        }
+        return { success: true, data: { ok: true } };
+      });
+      jest.spyOn(CernionMCPClient.prototype, 'disconnect').mockResolvedValue();
+
+      const origBase = CernionMCPClient.QUOTA_RETRY_BASE_MS;
+      CernionMCPClient.QUOTA_RETRY_BASE_MS = 0;
+
+      const result = await CernionMCPClient.callWithNewSession('test_tool', {}, 'tok');
+
+      CernionMCPClient.QUOTA_RETRY_BASE_MS = origBase;
+      expect(result.success).toBe(true);
+      expect(attempts).toBe(2); // failed once with a session error, succeeded on retry
+    });
+
+    it('returns SESSION_ERROR_EXHAUSTED (not QUOTA_EXHAUSTED) after all session-error retries fail', async () => {
+      jest.spyOn(CernionMCPClient.prototype, 'connect').mockResolvedValue(true);
+      jest.spyOn(CernionMCPClient.prototype, 'callTool').mockResolvedValue({
+        success: false,
+        error: { code: 404, message: 'Session not found', toolName: 'test_tool' },
+      });
+      jest.spyOn(CernionMCPClient.prototype, 'disconnect').mockResolvedValue();
+
+      const origBase = CernionMCPClient.QUOTA_RETRY_BASE_MS;
+      const origMax = CernionMCPClient.MAX_QUOTA_RETRIES;
+      CernionMCPClient.QUOTA_RETRY_BASE_MS = 0;
+      CernionMCPClient.MAX_QUOTA_RETRIES = 2;
+
+      const result = await CernionMCPClient.callWithNewSession('test_tool', {}, 'tok');
+
+      CernionMCPClient.QUOTA_RETRY_BASE_MS = origBase;
+      CernionMCPClient.MAX_QUOTA_RETRIES = origMax;
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('SESSION_ERROR_EXHAUSTED');
+      expect(result.error.toolName).toBe('test_tool');
+    });
+
+    it('also retries when the session error surfaces as a thrown connect() exception', async () => {
+      let attempts = 0;
+      jest.spyOn(CernionMCPClient.prototype, 'connect').mockImplementation(async () => {
+        attempts++;
+        if (attempts < 2) {
+          throw new Error('Failed to connect to Cernion MCP: -32001 Session not found');
+        }
+        return true;
+      });
+      jest
+        .spyOn(CernionMCPClient.prototype, 'callTool')
+        .mockResolvedValue({ success: true, data: { ok: true } });
+      jest.spyOn(CernionMCPClient.prototype, 'disconnect').mockResolvedValue();
+
+      const origBase = CernionMCPClient.QUOTA_RETRY_BASE_MS;
+      CernionMCPClient.QUOTA_RETRY_BASE_MS = 0;
+
+      const result = await CernionMCPClient.callWithNewSession('test_tool', {}, 'tok');
+
+      CernionMCPClient.QUOTA_RETRY_BASE_MS = origBase;
+      expect(result.success).toBe(true);
+      expect(attempts).toBe(2);
+    });
+  });
 });

--- a/tests/osm-geo.service.test.js
+++ b/tests/osm-geo.service.test.js
@@ -701,6 +701,23 @@ describe('OSM Geo Service', () => {
       expect(result.degradedReason).toBe('GEOCODING_FAILED');
     });
 
+    it('substationFinder: exhausted MCP session error classified as SESSION_ERROR, not generic SERVICE_ABORT', async () => {
+      callWithNewSession.mockResolvedValueOnce({
+        success: false,
+        error: {
+          code: 'SESSION_ERROR_EXHAUSTED',
+          message:
+            'Streamable HTTP error: Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"},"id":null}',
+          toolName: 'osm_substation_finder',
+        },
+      });
+      const result = await broker.call('osm-geo.substationFinder', {
+        boundingBox: { north: 47.97, south: 47.88, east: 10.2968, west: 10.1538 },
+      });
+      expect(result.success).toBe(false);
+      expect(result.degradedReason).toBe('SESSION_ERROR');
+    });
+
     it('gridTopology: postalCode + location combined into the geocoded location string', async () => {
       axios.get.mockResolvedValueOnce({ data: NOMINATIM_SEARCH_FIXTURE });
       axios.post.mockResolvedValueOnce({ data: GRID_TOPOLOGY_OVERPASS_FIXTURE });


### PR DESCRIPTION
## Summary
- `osm-geo/substation-finder` (and other MCP-proxied endpoints) intermittently returned `success:false` with a JSON-RPC `-32001 "Session not found"` error at HTTP 200 — not geodata-dependent, purely a transient server-side session condition. Reported alongside a separately-documented sustained multi-minute `assets/all` outage sharing the same underlying client code path (`src/async-job-poller.js` also calls `CernionMCPClient.callWithNewSession`).
- Root cause: `callTool()`'s catch block converts a thrown transport error into a returned `{success:false, error:{...}}` object, so `callWithNewSession`'s retry-decision check (`_isQuotaError`, matching only quota/rate-limit text) never treated a `-32001`/"Session not found" message as retryable — it returned on the first attempt, even though the retry loop already builds a brand-new session on every attempt.
- Added `_isSessionError()`/`_isRetryableError()`, used at all three retry-decision sites in `callWithNewSession`. Exhausted session-only retries now return `error.code: 'SESSION_ERROR_EXHAUSTED'` (was an ad-hoc SDK transport code, `404` in the reported case).
- `services/osm-geo.service.js`'s shared `_classifyDegradedReason()` gained a `SESSION_ERROR` category, distinguishing this from a real "no data" response and from generic `SERVICE_ABORT`.

## Risk note
`callWithNewSession` is a heavily fanned-in shared facade (~25 services) — GitNexus impact analysis flagged this HIGH risk. Verified the change is purely an additive widening of the retry-classification predicate (no change to existing quota-error or success-path behavior); confirmed via grep no code/tests elsewhere depend on the old incidental `error.code: 404` shape.

## Test plan
- [x] New tests in `tests/mcp-client.test.js` (3): retry+succeed on a `-32001` result from `callTool()` (the actual reported code path), `SESSION_ERROR_EXHAUSTED` after retries fail, retry when the error surfaces via a thrown `connect()` exception
- [x] New test in `tests/osm-geo.service.test.js` (1): exhausted session error classified as `SESSION_ERROR`, not `SERVICE_ABORT`
- [x] Full suite across every known consumer of the changed retry path: `mcp-client.test.js` + `osm-geo.service.test.js` + `async-job-poller.test.js` + `assets.service.test.js` + `grid-operations.service.test.js` — 5 suites / 208 tests pass
- [x] `check:tdd-matrix-coverage`, `check:quality-gate`, `audit:openapi` (warning count unchanged, 381), `check:llm`, `audit:security` all pass
- [x] Lint: no new violations in changed files (verified against pre-existing baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)