### PR TITLE
fix: bound VNBdigital MCP calls to stop municipal-energy-value-analysis hangs (v0.99.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Cernion Energy Tools project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.19] — 2026-08-14
+
+### Fixed
+- **`dashboard-api/municipal-energy-value-analysis` hung completely (30-60s, `HTTP:000` — no response at all, not even headers) for some municipalities, reported live for Berlin and Hamburg, and correlating with 2,708 failed municipality lookups in a nationwide sweep.** Live investigation (timing the actual underlying `vnbdigital_search`/`vnbdigital_lookup` MCP calls directly) found the slowness is **not** deterministically tied to any specific municipality — a repeat test hung on München instead, one of the cities originally reported as reliably fast, while Berlin/Hamburg resolved quickly. The real, local, fixable defect: `dashboard-api`'s shared `safeCall()` helper had no timeout at all — a slow/hanging upstream `grid-operations.vnbdigitalSearch`/`vnbdigitalLookup` call (itself a thin proxy to an external MCP tool) blocked the entire endpoint for as long as the underlying MCP SDK transport allowed (120s per attempt, more with retries), while the calling client's own proxy/timeout gave up first with a bare connection-level `HTTP:000`.
+- Added an optional `timeoutMs` parameter to `safeCall()` (`services/dashboard-api/methods-part-01-of-14.js`) — unset by default, so every other one of its many existing call sites is unaffected. `resolveMunicipalVnbdigitalOperator()` (`services/dashboard-api/methods-part-13-of-14.js`) now bounds both its `vnbdigitalSearch` and `vnbdigitalLookup` calls to 12s each. On timeout, the existing `missing-evidence` degraded-response shape (already used for every other VNBdigital failure mode on this endpoint) is returned instead of hanging — matching this endpoint's own documented philosophy ("missing data is surfaced in missingEvidence and sourceRows, not as errors").
+- `osm-geo.service.js` already solved this exact problem for its own MCP calls (`_callMcpWithTimeout`) but the pattern had never been extended to `dashboard-api`; `safeCall`'s new parameter makes the same bounded-call capability available to its many other call sites without requiring each to hand-roll its own `Promise.race` wrapper.
+
+### Testing
+- New test in `tests/dashboard-api.test.js`: a mocked `vnbdigitalLookup` that resolves after 60s (well past the new 12s bound) — asserts the endpoint still responds in well under 20s with the correct `missing-evidence` degraded shape, not a hang.
+- Caught during test development: the initial `safeCall` timeout implementation never cleared its `setTimeout` on the fast/normal path, leaking a dangling timer on every timeout-bounded call (harmless in production, but surfaced immediately as a Jest "did not exit" warning once run across the full 456-test suite, each exercising `resolveMunicipalVnbdigitalOperator`'s two now-bounded calls). Fixed with `clearTimeout` in a `finally` block.
+- Full suite: `tests/dashboard-api.test.js` — 1 suite / 456 tests pass, clean exit (no dangling handles).
+
 ## [0.99.18] — 2026-08-13
 
 ### Fixed

--- a/llm.txt
+++ b/llm.txt
@@ -2,8 +2,8 @@
 
 ## Metadata
 - project: cernion-energy-tools
-- version: 0.99.18
-- changelog_latest_release: 0.99.18
+- version: 0.99.19
+- changelog_latest_release: 0.99.19
 
 ## Purpose
 This file is a navigation manifest for LLM/agent consumers. It lists cluster
@@ -246,12 +246,12 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - `tests/query.service.test.js`: `query.searchCopilot` body-based wrapper returns expected `query`, `domain`, and `results` shape.
 
 ## Source File Hashes
-- CHANGELOG.md: 678f62683343e40176dfd0e13f22b3b7bc84aaa0f66f23ad06f8816711df2135
+- CHANGELOG.md: 23edb3d1a69ab60592857cdd32f319084471f2e9f53c54463d23328e01f24917
 - README.md: e5c8aa36d7cd7195c83e00138361bd22d8cbe1860ff829bb026687d462d860ff
 - docs/BACKEND_CONTEXT.md: 3e9bf1425ed08e0741b0832e8fa4df8469975642712b79c8078a3f4c66893ac8
 - src/cookbook-recipes.js: 9e48573ca263ef129bc3944a83b013cff25157e25afc703be0ada62d5af8163d
 - src/capability-catalog.js: f62636a7c749d6a2502c8d1199c03d2f0d04d7be6d4ec9170b7cb81f79c6f2a4
-- openapi-export.json: 15affc2d0274607df6f98b54fc475b34be03bbca22b261034611cca33a9b7206
+- openapi-export.json: 13fa54ecadbfc5629e279a1ad5fbb424583f5a28ecc85bd97579cedd9686bf21
 
 ## OpenAPI Surface (full contract, not embedded)
 - path_count: 1027
@@ -259,4 +259,4 @@ Agents resolving capabilities/recipes/operations do not need to read past this p
 - full_spec: openapi-export.json (repo root) or GET /api/openapi.json
 
 ## Integrity
-- llm_txt_sha256: c0ebf61f3ec23707f0d35121f45f0a04cad9025868ac64b735b84d36665cab11
+- llm_txt_sha256: 27c9f41bbfd3923d068762debd0e78e8f3ad584842de9dcda215c81481531487

--- a/openapi-copilot.json
+++ b/openapi-copilot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.18",
+    "version": "0.99.19",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -2470,7 +2470,7 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.18",
+  "x-version": "0.99.19",
   "x-copilot-subset": true,
   "x-copilot-operations-version": 26
 }

--- a/openapi-export.json
+++ b/openapi-export.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Cernion Energy Tools API",
-    "version": "0.99.18",
+    "version": "0.99.19",
     "description": "MicroService Agent System for Energy Markets - REST API with AI integration.\n\nCERNION_TOKEN: request at https://cernion.de/ or by email: dev@stromdao.com.\n\nFor the public instance at https://api.cernion.de/, create your token at https://cernion.de/cet-token/."
   },
   "servers": [
@@ -91604,5 +91604,5 @@
     }
   },
   "x-generator": "scripts/export-openapi.js",
-  "x-version": "0.99.18"
+  "x-version": "0.99.19"
 }

--- a/operation-capability-index.json
+++ b/operation-capability-index.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "cernion.operationCapabilityIndex.v1",
   "generator": "scripts/generate-operation-capability-index.js",
-  "packageVersion": "0.99.18",
-  "sourceOpenApiHash": "15affc2d0274607df6f98b54fc475b34be03bbca22b261034611cca33a9b7206",
+  "packageVersion": "0.99.19",
+  "sourceOpenApiHash": "13fa54ecadbfc5629e279a1ad5fbb424583f5a28ecc85bd97579cedd9686bf21",
   "coverage": {
     "rawOperationCount": 1139,
     "operationCount": 883,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cernion-energy-tools",
-  "version": "0.99.18",
+  "version": "0.99.19",
   "description": "MicroService Agent System for Energy Markets",
   "main": "index.js",
   "engines": {

--- a/services/dashboard-api/methods-part-01-of-14.js
+++ b/services/dashboard-api/methods-part-01-of-14.js
@@ -134,14 +134,33 @@ module.exports = {
     return promise;
   },
 
-  async safeCall(ctx, action, params, fallback = null, errors = [], label = null) {
+  async safeCall(
+    ctx,
+    action,
+    params,
+    fallback = null,
+    errors = [],
+    label = null,
+    timeoutMs = null
+  ) {
+    let timer;
     try {
-      return await ctx.call(action, params);
+      const callPromise = ctx.call(action, params);
+      if (!timeoutMs) return await callPromise;
+      const timeoutPromise = new Promise((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label || action} timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        );
+      });
+      return await Promise.race([callPromise, timeoutPromise]);
     } catch (err) {
       const name = label || action;
       this.logger.warn(`dashboard-api: ${name} failed — ${err.message}`);
       if (errors) errors.push(name);
       return fallback;
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   },
 

--- a/services/dashboard-api/methods-part-13-of-14.js
+++ b/services/dashboard-api/methods-part-13-of-14.js
@@ -11,6 +11,17 @@ const {
   buildIntermunicipalComparison,
 } = require('./shared');
 
+// resolveMunicipalVnbdigitalOperator chains two sequential external
+// vnbdigital MCP calls with no local processing between them, so a slow or
+// hanging upstream response previously blocked the whole
+// municipal-energy-value-analysis endpoint for as long as the underlying MCP
+// SDK transport allowed (up to 120s per attempt, more with retries) —
+// reported live as a full 30-60s HTTP:000 (no response at all, not even
+// headers) once the caller's own client/proxy gave up first. Each call is
+// bounded so the endpoint degrades gracefully (existing 'missing-evidence'
+// shape below) instead of hanging.
+const VNBDIGITAL_CALL_TIMEOUT_MS = 12000;
+
 module.exports = {
   async resolveMunicipalVnbdigitalOperator(ctx, analysis = {}) {
     if (
@@ -34,7 +45,8 @@ module.exports = {
       { searchTerm },
       null,
       errors,
-      'grid-operations.vnbdigitalSearch'
+      'grid-operations.vnbdigitalSearch',
+      VNBDIGITAL_CALL_TIMEOUT_MS
     );
     const searchResult = this.pickMunicipalVnbdigitalSearchResult(
       this.unwrapVnbdigitalSearchResults(search)
@@ -55,7 +67,8 @@ module.exports = {
       lookupParams,
       null,
       errors,
-      'grid-operations.vnbdigitalLookup'
+      'grid-operations.vnbdigitalLookup',
+      VNBDIGITAL_CALL_TIMEOUT_MS
     );
     const vnb = this.pickMunicipalVnb(this.unwrapVnbdigitalLookupVnbs(lookup));
     if (!vnb?.name) {

--- a/tests/dashboard-api.test.js
+++ b/tests/dashboard-api.test.js
@@ -13378,6 +13378,32 @@ describe('dashboard-api.service', () => {
       expect(source.sourceLabel).toContain('Netze BW GmbH');
     });
 
+    // Reported live: municipality-energy-value-analysis?municipality=Berlin/Hamburg
+    // hung 30-60s with no response at all (HTTP:000) — safeCall() had no
+    // timeout, so a slow/hanging grid-operations.vnbdigitalLookup call blocked
+    // the whole endpoint for as long as the underlying MCP transport allowed.
+    it('degrades gracefully instead of hanging when vnbdigitalLookup is slow', async () => {
+      handlers['vnbdigitalLookup'] = () =>
+        new Promise((resolve) => {
+          const t = setTimeout(() => resolve(MOCK_VNBDIGITAL_LOOKUP), 60000);
+          if (t.unref) t.unref(); // don't keep the Jest process alive past this test
+        });
+
+      const startedAt = Date.now();
+      const result = await broker.call('dashboard-api.municipalEnergyValueAnalysisStatus', {
+        municipality: 'Wiesloch',
+        year: 2025,
+        scenario: 'baseline',
+      });
+      const elapsedMs = Date.now() - startedAt;
+
+      expect(elapsedMs).toBeLessThan(20000); // bounded well under the 60s mock delay
+      expect(result.gridOperatorName).toBeNull();
+      expect(result.gridOperatorEvidenceStatus).toBe('missing-evidence');
+      const source = result.sourceRows.find((r) => r.sourceKey === 'vnbdigital_operator_identity');
+      expect(source.evidenceStatus).toBe('missing-evidence');
+    }, 25000);
+
     it('returns scalar/display-safe budgetImpactRows with Konzessionsabgabe for Mauer', async () => {
       const result = await broker.call('dashboard-api.municipalEnergyValueAnalysisStatus', {
         municipality: 'Mauer',


### PR DESCRIPTION
## Summary
- `dashboard-api/municipal-energy-value-analysis` reproducibly hung 30-60s with no response at all (`HTTP:000` — not even headers) for some municipalities, reported live for Berlin/Hamburg and correlating with 2,708 failed lookups in a nationwide sweep.
- Live investigation (timing the actual `vnbdigital_search`/`vnbdigital_lookup` MCP calls directly) found the slowness is **not** deterministically tied to any specific municipality — a repeat test hung on München instead, one of the cities originally reported as reliably fast.
- Root cause: `dashboard-api`'s shared `safeCall()` helper had no timeout at all — a slow/hanging upstream call blocked the whole endpoint for as long as the MCP SDK transport allowed (120s per attempt, more with retries), while the caller's own client/proxy gave up first.
- Added an optional `timeoutMs` parameter to `safeCall()` (unset by default — every other existing call site unaffected) and bounded both VNBdigital calls in `resolveMunicipalVnbdigitalOperator()` to 12s each. On timeout, the endpoint's existing `missing-evidence` degraded-response shape is returned instead of hanging.
- Caught during test development: the timeout's `setTimeout` was never cleared on the fast path, leaking a dangling timer per bounded call across the whole 456-test suite — fixed with `clearTimeout` in a `finally` block.

## Test plan
- [x] New test: mocked `vnbdigitalLookup` resolving after 60s (past the 12s bound) — endpoint responds in well under 20s with the correct `missing-evidence` shape
- [x] Full suite: `tests/dashboard-api.test.js` — 456 tests pass, clean process exit (no dangling handles)
- [x] `check:tdd-matrix-coverage`, `check:quality-gate`, `audit:openapi` (warning count unchanged, 381), `check:llm`, `audit:security` all pass
- [x] Lint: no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)